### PR TITLE
[PR #285] fix(mfe): blob revocation specs

### DIFF
--- a/architecture/ADR/0004-blob-url-mfe-isolation.md
+++ b/architecture/ADR/0004-blob-url-mfe-isolation.md
@@ -104,6 +104,7 @@ This decision should be revisited when:
 - Operational impact (OPS): Not applicable — client-side build output and in-browser runtime behavior.
 - The never-revoke rule: `URL.createObjectURL` returns a URL that persists until explicitly revoked. Because `import()` with top-level await may parse (and cache the URL reference) before the module body executes, revoking the blob URL before all dependent modules finish loading causes `ERR_FAILED` on subsequent imports of the same specifier
 - Related: ADR 0019 (`cpt-frontx-adr-mf2-manifest-discovery`) — governs the build plugin and metadata discovery mechanism that feeds chunk URLs into the blob URL isolation pipeline
+- Related: ADR 0020 (`cpt-frontx-adr-mfe-state-lifecycle-boundary`) — extends this decision with the host/author state-lifecycle contract; narrows the "blob URLs accumulate" consequence to per-load (catalog-bounded) by ruling out per-mount fresh-load mechanisms
 - Related: ADR 0001 (Four-Layer SDK Architecture) — blob loader lives in `packages/screensets` (L1) and must not import other `@cyberfabric/*` packages
 - Related: ADR 0002 (Event-Driven Flux Data Flow) — EventBus isolation is the primary motivation for per-MFE module scope
 - Learning curve: blob URL isolation with import specifier rewriting is a non-standard pattern; developers debugging MFE loading issues should understand that blob URLs produce opaque identifiers in browser DevTools and that source text is fetched separately from module evaluation

--- a/architecture/ADR/0020-mfe-state-lifecycle-boundary.md
+++ b/architecture/ADR/0020-mfe-state-lifecycle-boundary.md
@@ -1,0 +1,157 @@
+---
+status: accepted
+date: 2026-05-06
+decision-makers: FrontX core team
+---
+
+# MFE State Lifecycle Boundary
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Host owns module-scope, author owns instance-scope (no host-side reset hook)](#host-owns-module-scope-author-owns-instance-scope-no-host-side-reset-hook)
+  - [`persistAcrossMounts: false` flag with blob URL revocation on unmount](#persistacrossmounts-false-flag-with-blob-url-revocation-on-unmount)
+  - [Per-mount fresh `load()` (force-reload, fresh URL minting)](#per-mount-fresh-load-force-reload-fresh-url-minting)
+  - [Iframe-per-instance](#iframe-per-instance)
+  - [`new Function`-based runtime instantiation](#new-function-based-runtime-instantiation)
+  - [Build-time whitelist enforcement on expose chains](#build-time-whitelist-enforcement-on-expose-chains)
+- [Review Triggers](#review-triggers)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-frontx-adr-mfe-state-lifecycle-boundary`
+
+## Context and Problem Statement
+
+ADR-0004 (`cpt-frontx-adr-blob-url-mfe-isolation`) establishes per-MFE isolation by minting a fresh blob URL per `load()`. That decision is silent on what happens *after* load: the same loaded lifecycle is cached on `extensionState` and reused across `mount() / unmount() / mount()` cycles, so module-scope state (the `HAI3App` instance, plugin registrations, store singletons, registered effects) survives every remount within a session. `MountExtSwapHandler`'s A→B→A path makes this concrete and reproducible — the second mount of A reuses the same module graph and only gets a fresh React tree in a new Shadow DOM container.
+
+Two product-shaped expectations land on this single mechanism:
+
+1. *Persist across mounts* — screens whose navigation/edit state should survive a tab swap (most dashboard widgets, list-detail flows).
+2. *Fresh state per mount* — wizards, one-off flows, ephemeral modals that should not preserve form data or scroll position across opens.
+
+CodeRabbit raised this on PR #276 (MF 2.0 migration) as a memory-lifecycle concern. The original spinout proposed a per-extension `persistAcrossMounts` flag whose `false` setting would revoke blob URLs on unmount and force a fresh `load()` on the next mount. After working through MF 2.0 runtime semantics, the HTML module-table behaviour, and the dashboard-domain blast radius, the proposal collapses into two distinguishable findings: (i) URL revocation does not produce module-state freshness, and (ii) per-mount fresh evaluation grows unboundedly because the HTML module table has no JS-accessible eviction. Both findings push the decision away from a host-managed per-mount mechanism and toward a written contract owned by the MFE author.
+
+## Decision Drivers
+
+* **(P0)** No correctness regression of `cpt-frontx-fr-blob-no-revoke` — the never-revoke rule must continue to hold for every load that reaches `import()`.
+* **(P0)** Bounded host memory growth across long-lived sessions — the dashboard-domain pattern (each widget = an MFE instance, mounted and remounted as the user navigates) puts mount-driven growth in the hot path.
+* **(P1)** Per-mount module-state freshness must be expressible by an MFE author who needs it (wizards, one-off flows), without requiring host changes.
+* **(P1)** No introduction of `eval()` / `new Function()` / CSP `unsafe-eval` to the host's CSP profile (`cpt-frontx-nfr-sec-csp-blob`).
+
+## Considered Options
+
+* Host owns module-scope, author owns instance-scope — written contract on the MFE entry; no host-side reset hook.
+* `persistAcrossMounts: false` flag with blob URL revocation on unmount — original spinout proposal.
+* Per-mount fresh `load()` (force-reload, fresh URL minting, fresh evaluation) — same flag, but with the revocation step replaced by a correctly-implemented fresh-load mechanism.
+* Iframe-per-instance — render every mount in its own `<iframe>`.
+* `new Function`-based runtime instantiation — build-time ESM-to-factory transform, host invokes `new Function(source)()` per mount.
+* Build-time whitelist enforcement on expose chains — build plugin errors on module-level mutable state in MFE source.
+
+## Decision Outcome
+
+Chosen option: **"Host owns module-scope, author owns instance-scope"**, expressed as a written contract on the MFE entry (`cpt-frontx-fr-mfe-author-state-lifecycle`).
+
+The host commits to: one fresh `load()` per MFE per session (today's behaviour), per-load isolation via blob URL minting + source-text LRU caches, and no `URL.revokeObjectURL()` ever (`cpt-frontx-fr-blob-no-revoke`, narrowed to TLA + lazy-import correctness).
+
+The MFE author commits to: constructing per-instance state inside `mount(container, bridge, mountContext?)`, disposing of it inside `unmount(container)`, and not relying on `unmount()` to reset module-level singletons or to drop blob URLs. Authors who want fresh module state per use case keep that state at instance scope, not at module scope.
+
+This boundary is recorded in `architecture/features/feature-mfe-isolation/FEATURE.md` §7 ("State Lifecycle") and as DoD `cpt-frontx-dod-mfe-isolation-author-state-lifecycle`.
+
+### Consequences
+
+* Good, because per-mount state freshness is fully expressible by authors at the source level — the boundary is enforceable without a host-side flag and without breaking `cpt-frontx-fr-blob-no-revoke`.
+* Good, because host memory growth stays catalog-bounded (one load per MFE per session, modulo retries) — the dashboard-domain pattern remains tolerable.
+* Good, because no new public API surface on `MfeHandlerMF` or `DefaultMountManager`; no GTS schema change for `Extension`/`MfeEntry`.
+* Bad, because authors who put state at module scope expecting `unmount()` to reset it will be surprised. Mitigation: contract is documented in FEATURE §7 and called out in FR rationale; failure mode is silent-stale-state, the same failure mode that any flag-based approach would also have for shared-dep singletons.
+* Bad, because "cycle the MFE" becomes an MFE-author operation (unregister + re-register with a fresh ID), not a host primitive — inconvenient if a host-driven reset turns out to be needed.
+* Neutral, because this decision strictly extends ADR-0004; it adds no new mechanism, only a written contract on top of an existing one.
+
+### Confirmation
+
+* `MfeHandlerMF` and `DefaultMountManager` remain unchanged — no new API for cache clear / blob URL release / fresh-load-on-unmount.
+* MFE entries pair every resource constructed in `mount()` with a teardown in `unmount()`, including: React root, `bridge.subscribeToProperty` returns, `bridge.registerActionHandler` registrations, timers, observers, DOM nodes attached to `container`. Verified by AC-8 (Mount/unmount instance hygiene) in feature-mfe-isolation.
+* No `unmount()` mutates module-level singletons (the `HAI3App` instance, plugin registrations, blob URLs, module-scope caches) — verified by structural acceptance criterion in feature-mfe-isolation.
+
+## Pros and Cons of the Options
+
+### Host owns module-scope, author owns instance-scope (no host-side reset hook)
+
+* Good, because it preserves `cpt-frontx-fr-blob-no-revoke` correctness exactly and adds no new failure mode.
+* Good, because it requires zero handler / mount manager / type changes.
+* Good, because per-load growth is finite and catalog-bounded, fitting long-lived dashboard-domain sessions.
+* Bad, because authors keeping state at module scope must learn the contract; default behaviour can surprise on first encounter.
+* Bad, because there is no host-driven "cycle this MFE" primitive — the only way to force a fresh module evaluation is to re-register with a new ID.
+
+### `persistAcrossMounts: false` flag with blob URL revocation on unmount
+
+* Good, because it offers a per-extension knob aligned with author intent on paper.
+* Bad, because **revocation does not produce freshness**: `URL.createObjectURL()` is what mints a unique URL and forces a fresh module evaluation; `URL.revokeObjectURL()` only releases the URL→Blob bytes mapping. The parsed module record stays pinned in the HTML module table by URL string, with no JS-accessible eviction API. The flag as written would silently fail to deliver the semantics it advertises — module-scope state would persist regardless.
+* Bad, because revoking before all queued sub-module fetches complete reintroduces the `ERR_FILE_NOT_FOUND` failure mode that `cpt-frontx-fr-blob-no-revoke` exists to prevent. There is no observable safe moment to revoke (TLA, lazy `import()`, deferred MF runtime fetches all defer past `unmount()`).
+
+### Per-mount fresh `load()` (force-reload, fresh URL minting)
+
+* Good, because it would deliver true fresh module evaluation for the MFE's own expose graph (same mechanism as the initial load).
+* Bad, because **per-mount growth is unbounded**: every fresh evaluation creates a permanent HTML module-table entry keyed by URL string, with no JS-accessible eviction. Per-mount growth scales with mount count × (shared deps + expose chunks); rough estimate ~2–5 MB per mount, no in-realm recovery. Per-load growth is finite and catalog-bounded; per-mount growth is not.
+* Bad, because the dashboard-domain pattern (each widget is an MFE instance, mounted and remounted as the user navigates) makes this load-bearing rather than tolerable.
+* Bad, because the cost is paid at every mount (full re-fetch + re-parse), not just on cold load.
+
+### Iframe-per-instance
+
+* Good, because it gives an OS-level fresh Realm per mount, with no contract burden on the MFE author.
+* Bad, because the dashboard-domain pattern makes per-instance Realm isolation overhead unacceptable.
+* Bad, because the cross-document boundary breaks the existing direct-call `ChildMfeBridge` contract — would have to be re-plumbed over `postMessage`.
+
+### `new Function`-based runtime instantiation
+
+* Good, because `new Function(source)()` always produces a fresh evaluation closure.
+* Bad, because `new Function` does not accept ES module syntax — every expose chunk would need a build-time ESM-to-factory transform, requiring a complete handler rewrite.
+* Bad, because it requires CSP `script-src 'unsafe-eval'`, incompatible with the host's CSP profile (`cpt-frontx-nfr-sec-csp-blob` builds on `blob:` precisely to avoid `unsafe-eval`).
+
+### Build-time whitelist enforcement on expose chains
+
+* Good, because a build-time check would catch problems before runtime if it could be made reliable.
+* Bad, because the host has no analogous guarantee for third-party shared deps reached through the expose chain — the rule reduces to author convention for everything outside the MFE's own source, defeating the value of a build-time check.
+* Bad, because the boundary is more honestly expressed as a written contract (`cpt-frontx-fr-mfe-author-state-lifecycle`) than as a partial compile-time gate.
+
+## Review Triggers
+
+This decision should be revisited when:
+
+* Browsers add a JS-accessible eviction API for HTML module-table entries — would change the per-mount growth bound.
+* MF 2.0 (or whatever shared-deps mechanism FrontX uses at the time) introduces native per-load isolation that subsumes the blob URL chain — in which case the "host owns module-scope" half of the boundary may shift.
+* The deferred heap-snapshot study (open follow-up in feature-mfe-isolation) measures per-load retained set materially diverging from the static prediction — would invalidate the catalog-bounded claim and force a different bound argument.
+* Authors report that the silent-stale-state surprise is a recurring source of bugs in production despite the contract being documented — would prompt a revisit of cheaper partial-reset options (the `lifecycle.reset()` hook from the original CodeRabbit §1 Option B).
+* Calendar review: when any of the above triggers fires, or alongside ADR-0004's next review (currently 2027-Q1), whichever comes first.
+
+**Invalidation condition**: this decision becomes invalid if FrontX abandons the never-revoke invariant, or if browsers expose a JS-accessible eviction primitive that lets per-mount fresh load become a bounded operation.
+
+## More Information
+
+- Operational impact (OPS): Not applicable — purely an in-browser host/author contract.
+- Origin: CodeRabbit comment on PR #276 (MF 2.0 migration); the resolution thread captures the full analysis including the §1a / §1b / §1c argument from the original CodeRabbit response and the per-mount-growth counter from the resolution.
+- Heap-snapshot study (deferred follow-up): a single DevTools heap-snapshot run on a representative session, intended as a sanity check on the per-load bound rather than as sizing input for an opt-in flag. Lower priority than the artifact updates; runs whenever a mount-heavy regression is suspected.
+- FrontX shared-deps note: FrontX does not use MF 2.0's `singleton: true` shared-scope sharing — the standard MF runtime caveat that "shared singletons survive a force-reload" does not apply here; FrontX shared deps are externalized at build time and re-minted as fresh blob URLs per load (`cpt-frontx-fr-blob-fresh-eval`).
+- Related: ADR-0004 (`cpt-frontx-adr-blob-url-mfe-isolation`) — establishes the per-load blob URL mechanism that this decision builds on. The "Bad, because blob URLs accumulate" consequence in ADR-0004 is narrowed by this decision: per-load growth is the only growth dimension, and it is catalog-bounded.
+- Related: ADR-0019 (`cpt-frontx-adr-mf2-manifest-discovery`) — feeds chunk URLs into the blob URL pipeline that this decision constrains.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **FEATURE**: [features/feature-mfe-isolation/FEATURE.md](../features/feature-mfe-isolation/FEATURE.md) — §7 State Lifecycle, DoD `cpt-frontx-dod-mfe-isolation-author-state-lifecycle`, AC-8
+- **ADR-0004**: [0004-blob-url-mfe-isolation.md](0004-blob-url-mfe-isolation.md) — establishes the blob URL isolation mechanism this decision constrains
+
+This decision directly addresses:
+* `cpt-frontx-fr-mfe-author-state-lifecycle` — written contract on per-mount state lifecycle
+* `cpt-frontx-fr-blob-no-revoke` — preserved unchanged; rationale narrowed to TLA + lazy-import correctness
+* `cpt-frontx-principle-mfe-isolation` — instance-scope cleanup boundary

--- a/architecture/DECOMPOSITION.md
+++ b/architecture/DECOMPOSITION.md
@@ -204,6 +204,7 @@ The DESIGN is decomposed into 13 features aligned with package/module boundaries
   - [x] `p1` - `cpt-frontx-fr-blob-import-rewriting`
   - [x] `p1` - `cpt-frontx-fr-blob-recursive-chain`
   - [x] `p2` - `cpt-frontx-fr-blob-per-load-map`
+  - [x] `p1` - `cpt-frontx-fr-mfe-author-state-lifecycle`
   - [x] `p1` - `cpt-frontx-fr-externalize-transform`
   - [x] `p1` - `cpt-frontx-fr-externalize-filenames`
   - [x] `p2` - `cpt-frontx-fr-externalize-build-only`

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -65,7 +65,8 @@ Requirements that significantly influence architecture decisions.
 `cpt-frontx-adr-channel-aware-version-locking`,
 `cpt-frontx-adr-per-action-type-handler-routing`,
 `cpt-frontx-adr-tanstack-query-data-management`,
-`cpt-frontx-adr-mf2-manifest-discovery`
+`cpt-frontx-adr-mf2-manifest-discovery`,
+`cpt-frontx-adr-mfe-state-lifecycle-boundary`
 
 #### Functional Drivers
 
@@ -107,7 +108,8 @@ Requirements that significantly influence architecture decisions.
 | `cpt-frontx-fr-mfe-action-types` | `Action` and `ActionsChain` types enable chain-based MFE action execution with fallback support; action `type` values are GTS schema type IDs (trailing `~`); extension references in payloads use `subject` field |
 | `cpt-frontx-fr-mfe-theme-propagation` | `themes()` plugin propagates theme changes to all MFE extensions via `mfeRegistry.updateSharedProperty()` |
 | `cpt-frontx-fr-mfe-i18n-propagation` | `i18n()` plugin propagates language changes to all MFE extensions via `mfeRegistry.updateSharedProperty()` |
-| `cpt-frontx-fr-blob-no-revoke` | Blob URLs kept alive for page lifetime; `URL.revokeObjectURL()` never called after `import()` resolves |
+| `cpt-frontx-fr-blob-no-revoke` | Blob URLs kept alive for page lifetime; `URL.revokeObjectURL()` never called after `import()` resolves — top-level-await correctness invariant of the loader |
+| `cpt-frontx-fr-mfe-author-state-lifecycle` | MFE entry constructs per-mount state in `mount()` and disposes it in `unmount()`; module-scope state survives across mount cycles within a single load (host owns module-scope lifetime, author owns instance-scope lifetime) |
 | `cpt-frontx-fr-blob-source-cache` | In-memory cache of fetched source text keyed by chunk URL; at most one network fetch per chunk across all loads |
 | `cpt-frontx-fr-blob-recursive-chain` | MFE handler recursively creates blob URLs for chunk and all static dependencies |
 | `cpt-frontx-fr-blob-per-load-map` | Blob URL mapping scoped per MFE load; different loads have independent instances preventing cross-load reuse |

--- a/architecture/PRD.md
+++ b/architecture/PRD.md
@@ -568,7 +568,23 @@ The `i18n()` plugin MUST call `mfeRegistry?.updateSharedProperty(HAI3_SHARED_PRO
 
 The handler MUST NOT call `URL.revokeObjectURL()` after `import()` resolves; blob URLs MUST remain valid for the page lifetime.
 
-**Rationale**: Modules with top-level `await` continue evaluating after `import()` resolves.
+**Rationale**: ES module evaluation is not finished when `import()` resolves. A module that contains top-level `await`, dynamic `import()`, or any deferred sub-module load continues to fetch and parse against the blob URL after the outer promise has settled. Revoking the URL — at any point — turns those queued fetches into `ERR_FILE_NOT_FOUND` and breaks the load nondeterministically. Never-revoke is a correctness invariant of the loader, not a memory-hygiene policy; per-mount state hygiene is the MFE author's responsibility, not the loader's (see `cpt-frontx-fr-mfe-author-state-lifecycle`).
+**Actors**: `cpt-frontx-actor-microfrontend`
+
+#### MFE Author Owns Per-Mount State Lifecycle
+
+- [x] `p1` - **ID**: `cpt-frontx-fr-mfe-author-state-lifecycle`
+
+The MFE entry is responsible for constructing per-mount state inside its `mount()` and for disposing of that state inside its `unmount()`. Module-scope state established when the MFE bundle first evaluates (the React module instance, the MFE-local store singleton, registered effects, plugin registrations) survives across mount/unmount cycles within a single load — the loader does not, and will not, force fresh module evaluation at every mount.
+
+Concretely, the MFE entry MUST:
+
+1. Create per-instance state (component trees, subscriptions, timers, observers, action handlers registered through the bridge) inside `mount(container, bridge, mountContext?)` so that each mount produces an independent set of resources.
+2. Tear those resources down inside `unmount(container)` (unsubscribe, cancel timers, remove DOM nodes, dispose observers, release any references to the bridge).
+3. NOT rely on `unmount()` to reset module-level singletons or to drop blob URLs; `unmount()` is purely an instance-lifecycle hook.
+4. MUST assume any module-scope cache it keeps is shared across all mounts of that MFE within the page, and key/manage that cache accordingly (e.g., key entries by mount-context, do not rely on per-mount eviction).
+
+**Rationale**: The loader cannot safely revoke blob URLs (`cpt-frontx-fr-blob-no-revoke`), so module-scope state must be assumed to persist for the lifetime of the load. Pushing per-mount lifecycle to the MFE author keeps a clean correctness boundary: the host guarantees module-scope persistence, the MFE guarantees instance-scope cleanup. Authors who want fresh module state per use case can elect not to keep state at module scope at all.
 **Actors**: `cpt-frontx-actor-microfrontend`
 
 #### Source Text Cache

--- a/architecture/features/feature-mfe-isolation/FEATURE.md
+++ b/architecture/features/feature-mfe-isolation/FEATURE.md
@@ -1,6 +1,6 @@
 # Feature: MFE Blob URL Isolation
 
-<!-- version: 1.9 -->
+<!-- version: 1.12 -->
 
 
 <!-- toc -->
@@ -38,9 +38,11 @@
   - [MFE-Internal Dataflow](#mfe-internal-dataflow)
   - [MfManifest Type and GTS Schema Update](#mfmanifest-type-and-gts-schema-update)
   - [ChildMfeBridge Abstract Class Contract](#childmfebridge-abstract-class-contract)
+  - [MFE Author State Lifecycle Boundary](#mfe-author-state-lifecycle-boundary)
 - [6. Acceptance Criteria](#6-acceptance-criteria)
   - [Behavioral (verified in browser)](#behavioral-verified-in-browser)
   - [Structural (verified by code/tests)](#structural-verified-by-codetests)
+- [7. State Lifecycle](#7-state-lifecycle)
 - [Additional Context](#additional-context)
 
 <!-- /toc -->
@@ -90,6 +92,7 @@ Enable multiple independently deployed MFE bundles to coexist in the same browse
 - PRD: [PRD.md](../../PRD.md) — sections 5.6 (MFE Blob URL Isolation), 5.7 (MFE Build Plugin), 5.8 (MFE Internal Dataflow)
 - ADR: `cpt-frontx-adr-blob-url-mfe-isolation`
 - ADR: `cpt-frontx-adr-mf2-manifest-discovery`
+- ADR: `cpt-frontx-adr-mfe-state-lifecycle-boundary`
 - Depends on feature: `cpt-frontx-feature-mfe-registry`
 
 #### Non-Applicable Domains
@@ -549,6 +552,26 @@ Action target contract enforcement is two-layered: (1) **GTS schema validation**
 
 ---
 
+### MFE Author State Lifecycle Boundary
+
+- [x] `p1` - **ID**: `cpt-frontx-dod-mfe-isolation-author-state-lifecycle`
+
+The MFE entry's `mount(container, bridge, mountContext?)` is the only place per-instance state is constructed; the matching `unmount(container)` is the only place that state is torn down. Module-scope state established when the bundle first evaluates (the `HAI3App` instance built in `init.ts`, plugin registrations, module-level singletons and caches) persists for the lifetime of the load — the host neither resets it nor offers an API to reset it, because never-revoke (`cpt-frontx-fr-blob-no-revoke`) makes any such reset unsafe.
+
+**Implementation details**:
+- Each `mount()` call creates an independent set of resources: React root via `createRoot(container)`, `bridge.subscribeToProperty()` subscriptions, `bridge.registerActionHandler()` registrations, timers, `MutationObserver` / `IntersectionObserver` instances, DOM nodes attached to `container`.
+- The matching `unmount()` call MUST tear those resources down: unsubscribe property subscriptions, cancel timers, call `root.unmount()` on the React root, disconnect observers, remove DOM nodes from `container`, drop references to the bridge.
+- `unmount()` MUST NOT touch module-level singletons (the `HAI3App` instance, plugin registrations, blob URLs, module-scope caches).
+- An MFE that needs fresh module-scope state per use case keeps that state at instance scope inside `mount()`, not at module scope in `init.ts`. "Cycle the MFE" is therefore an MFE-author operation realised by unregistering and re-registering with a fresh ID — this triggers a new load and a new module evaluation — not a host-side reset hook.
+
+**Covers (PRD)**:
+- `cpt-frontx-fr-mfe-author-state-lifecycle`
+
+**Covers (DESIGN)**:
+- `cpt-frontx-principle-mfe-isolation` (instance-scope cleanup boundary)
+
+---
+
 ## 6. Acceptance Criteria
 
 ### Behavioral (verified in browser)
@@ -560,6 +583,7 @@ Action target contract enforcement is two-layered: (1) **GTS schema validation**
 - [x] **AC-5: Version separation** — different versions of the same shared package produce separate downloads and separate isolated instances; `react@18` and `react@19` from different MFEs are NOT shared
 - [x] **AC-6: Shared properties** — shared properties (theme, language) reach child runtimes via the bridge; child MFE components display the host-set theme and language values
 - [x] **AC-7: Actions chain routing** — `mount_ext` actions chain works across package switches in any order (MFE A → MFE B → MFE A), including programmatic navigation via `executeActionsChain`; zero `OperationTimeout` errors during cross-package mount/unmount cycles
+- [x] **AC-8: Mount/unmount instance hygiene** — repeatedly mounting and unmounting the same MFE entry on the same container leaves no leaked instance-scope resources: after `unmount()` returns, prior-mount property subscriptions emit no further callbacks, prior-mount action handlers no longer receive routed actions, and the React root attached by the prior mount is gone from the DOM
 
 ### Structural (verified by code/tests)
 
@@ -574,12 +598,43 @@ Action target contract enforcement is two-layered: (1) **GTS schema validation**
 - [x] The `frontx-mf-gts` plugin enriches `mfe.json` in-place: `manifest.shared[].chunkPath` set to MFE-relative paths (`shared/{name}.js`); the handler resolves against `publicPath` and deduplicates via `sharedDepTextCache` keyed by `name@version`; no intermediate `mfe.gts-manifest.json` artifact
 - [x] MFE `vite.config.ts` uses `shared: {}` (empty) and `build.rollupOptions.external` for shared deps; expose chunks contain bare specifiers for shared deps
 - [x] MFE `init.ts` files contain no direct imports from `react-redux`, `redux`, or `@reduxjs/toolkit`
+- [x] Each MFE entry's `mount()` and `unmount()` are paired: every resource created in `mount()` (React root, `bridge.subscribeToProperty` returns, `bridge.registerActionHandler` registrations, timers, observers, DOM nodes) is disposed in the matching `unmount()`; no `unmount()` mutates module-level singletons (`HAI3App`, plugin registrations, module-scope caches)
+
+---
+
+## 7. State Lifecycle
+
+The loader and the MFE entry sit on opposite sides of a single, sharp responsibility boundary. The host owns module-scope lifetime (load → page unload, no revocation); the MFE author owns instance-scope lifetime (mount → unmount).
+
+**Host loader (`MfeHandlerMF`) owns module-scope lifetime.**
+
+- The host fetches source text, builds blob URLs, evaluates the bundle, and returns the lifecycle. From the moment a load completes, every blob URL produced for that load is live for the page lifetime — including transitive shared dep blob URLs, the expose chunk blob URL, and any chunks reached through the recursive chain.
+- The host does NOT call `URL.revokeObjectURL()`. Ever. This is a correctness invariant of the loader: ES module evaluation is deferred and asynchronous, and the only safe lower bound for "this URL is no longer needed" is page unload, which the browser handles automatically. See FR `cpt-frontx-fr-blob-no-revoke`.
+- Module-scope state established during evaluation (the React module instance, store singletons declared at module scope, plugin registrations performed in `init.ts`, registered effects, entries pushed into module-level caches) therefore persists for the lifetime of the load. The host treats this state as immutable from its perspective — it neither resets it nor offers an API to reset it.
+- The `sharedDepTextCache` keyed by `name@version` is host-managed and shared across all runtimes; the `sourceTextCache` keyed by absolute URL is host-managed and bounded via LRU. Neither is touched on unmount.
+
+**MFE author owns instance-scope lifetime.**
+
+- The lifecycle's `mount(container, bridge, mountContext?)` is called once per mount and is the only place per-instance state may be created: React roots, subscriptions, timers, MutationObservers, IntersectionObservers, action handlers registered through `bridge.registerActionHandler()`, listeners registered with `bridge.subscribeToProperty()`, DOM nodes attached to the mount container.
+- The lifecycle's `unmount(container)` is called once per mount and MUST tear those resources down. The MFE author MUST NOT rely on `unmount()` to reset module-level singletons or to drop blob URLs — it is purely an instance-lifecycle hook. See FR `cpt-frontx-fr-mfe-author-state-lifecycle`.
+- An MFE that wants fresh module state per use case (a wizard that should reset on every open, a modal that should not preserve form data across opens) MUST keep that state at instance scope, not at module scope. The boundary is enforceable by the author at the source level — no host-side flag can simulate it without breaking the never-revoke invariant.
+- Any module-scope cache the MFE chooses to keep is the MFE's contract with itself — the host treats it as opaque and durable.
+
+**What this rules out.**
+
+- The loader does NOT expose a "clear cached lifecycle" or "revoke this extension's blob URLs" hook. Any such hook would have to either violate `cpt-frontx-fr-blob-no-revoke` or pretend to clean up while leaking — neither is acceptable.
+- The host does NOT trigger a fresh `handler.load()` on remount. Remount reuses the existing lifecycle reference returned by the original load, calling its `mount()` again. The MFE author sees mount/unmount cycles, not load/load cycles.
+- "Cycle the MFE" is therefore an MFE-author operation, not a host operation. An MFE that needs to be reset MUST be unregistered and re-registered with a fresh ID; this triggers a new load and a new evaluation.
 
 ---
 
 ## Additional Context
 
-**Never-revoke policy rationale**: The `import()` function resolves when a module is parsed and its top-level synchronous code has run. Modules with top-level `await` or dynamic `import()` internally continue evaluating asynchronously after the outer `import()` promise resolves. If the blob URL is revoked at this point, the async continuation cannot fetch the already-queued sub-module evaluation and fails with `ERR_FILE_NOT_FOUND`. Blob URLs are cleaned up automatically by the browser on page unload; no manual revocation is needed.
+**Never-revoke is a top-level-await correctness invariant**: The `import()` function resolves when a module is parsed and its top-level synchronous code has run. Modules with top-level `await` or dynamic `import()` internally continue evaluating asynchronously after the outer `import()` promise resolves. If the blob URL is revoked at this point, the async continuation cannot fetch the already-queued sub-module evaluation and fails with `ERR_FILE_NOT_FOUND` — nondeterministically, depending on scheduler timing. Never-revoke is therefore a correctness rule for the loader, not a memory-hygiene policy. Blob URLs are cleaned up automatically by the browser on page unload.
+
+**Decision rationale and rejected alternatives**: The host/author state-lifecycle boundary documented in §7 is recorded as ADR-0020 (`cpt-frontx-adr-mfe-state-lifecycle-boundary`), which captures the full pros/cons analysis of the alternatives evaluated and rejected (`persistAcrossMounts: false` flag with revocation on unmount, per-mount fresh `load()` with force-reload, iframe-per-instance, `new Function`-based runtime instantiation, build-time whitelist enforcement on expose chains). Future revisits should start there rather than re-deriving the analysis.
+
+**Open follow-up — heap snapshot validation**: A single DevTools heap-snapshot run on a representative session remains useful as a sanity check on the per-load bound — does the retained set per load match the static prediction? Lower priority than the artifact updates, runs whenever a mount-heavy regression is suspected.
 
 **Per-load isolation mechanism**: Each load creates fresh blob URLs for ALL shared deps from the handler-level `sharedDepTextCache` (keyed by `name@version`). Even though the source text is identical (same `name@version`), each `URL.createObjectURL()` call produces a unique blob URL that the browser evaluates as a fresh module — independent state, independent closures. The `sharedDepBlobUrls` map and `blobUrlMap` are scoped to a single load; the `sharedDepTextCache` is handler-level (keyed by `name@version`) to avoid redundant fetches across runtimes.
 

--- a/packages/react/src/mfe/ThemeAwareReactLifecycle.tsx
+++ b/packages/react/src/mfe/ThemeAwareReactLifecycle.tsx
@@ -87,6 +87,7 @@ function MountRuntimeAwareProvider({
  * Concrete subclasses must provide:
  * - `renderContent(bridge)` - screen component rendering
  */
+// @cpt-dod:cpt-frontx-dod-mfe-isolation-author-state-lifecycle:p1
 export abstract class ThemeAwareReactLifecycle implements MfeEntryLifecycle<ChildMfeBridge> {
   private root: Root | null = null;
 


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#285](https://github.com/cyberfabric/cyberware-frontx/pull/285) | **Author:** tscbmstubp | **Opened:** 2026-05-06T14:13:42Z | **Status:** merged on 2026-05-12T06:03:52Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Updated SDLC artifacts according to #377 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new architectural decision record defining module federation state lifecycle boundaries between host and extension authors.
  * Expanded design specifications clarifying blob URL handling semantics and state lifecycle ownership responsibilities.
  * Updated feature acceptance criteria for improved lifecycle boundary management and resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#285 -->