### PR TITLE
[PR #279] fix(theme): use stylesheet rule instead of inline style for CSS varia…

### DIFF
--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -46,7 +46,8 @@ export function createThemeRegistry(): ThemeRegistry {
       document.head.appendChild(styleEl);
     }
 
-    const sheet = styleEl.sheet!;
+    const sheet = styleEl.sheet;
+    if (!sheet) return;
     while (sheet.cssRules.length > 0) sheet.deleteRule(0);
 
     const parts: string[] = [];

--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -35,24 +35,25 @@ export function createThemeRegistry(): ThemeRegistry {
   function applyCSSVariables(variables: Record<string, string>): void {
     if (typeof document === 'undefined') return;
 
-    let styleEl = document.getElementById('hai3-theme-vars') as HTMLStyleElement | null;
-    if (!styleEl) {
+    const existing = document.getElementById('hai3-theme-vars');
+    let styleEl: HTMLStyleElement;
+    if (existing instanceof HTMLStyleElement) {
+      styleEl = existing;
+    } else {
+      existing?.remove();
       styleEl = document.createElement('style');
       styleEl.id = 'hai3-theme-vars';
       document.head.appendChild(styleEl);
     }
 
-    const entries = Object.entries(variables);
-    if (entries.length === 0) {
-      styleEl.replaceChildren();
-      return;
-    }
+    const sheet = styleEl.sheet!;
+    while (sheet.cssRules.length > 0) sheet.deleteRule(0);
 
-    // Inline replace strips </style> sequences to prevent CSS injection from external theme sources.
-    const varLines = entries
-      .map(([key, value]) => `  ${key.replace(/<\/style/gi, '')}: ${value.replace(/<\/style/gi, '')};`)
-      .join('\n');
-    styleEl.replaceChildren(document.createTextNode(`:root {\n${varLines}\n}`));
+    const entries = Object.entries(variables);
+    if (entries.length === 0) return;
+
+    const decls = entries.map(([key, value]) => `${key}: ${value}`).join('; ');
+    sheet.insertRule(`:root { ${decls} }`, 0);
   }
 
   return {

--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -49,11 +49,12 @@ export function createThemeRegistry(): ThemeRegistry {
     const sheet = styleEl.sheet!;
     while (sheet.cssRules.length > 0) sheet.deleteRule(0);
 
-    const entries = Object.entries(variables);
-    if (entries.length === 0) return;
-
-    const decls = entries.map(([key, value]) => `${key}: ${value}`).join('; ');
-    sheet.insertRule(`:root { ${decls} }`, 0);
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(variables)) {
+      parts.push(`${key}: ${value}`);
+    }
+    if (parts.length === 0) return;
+    sheet.insertRule(`:root { ${parts.join('; ')} }`, 0);
   }
 
   return {

--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -44,14 +44,15 @@ export function createThemeRegistry(): ThemeRegistry {
 
     const entries = Object.entries(variables);
     if (entries.length === 0) {
-      styleEl.textContent = '';
+      styleEl.replaceChildren();
       return;
     }
 
-    // Strip </style> sequences to prevent CSS injection if values ever come from external sources.
-    const safe = (s: string) => s.replace(/<\/style/gi, '');
-    const varLines = entries.map(([key, value]) => `  ${safe(key)}: ${safe(value)};`).join('\n');
-    styleEl.textContent = `:root {\n${varLines}\n}`;
+    // Inline replace strips </style> sequences to prevent CSS injection from external theme sources.
+    const varLines = entries
+      .map(([key, value]) => `  ${key.replace(/<\/style/gi, '')}: ${value.replace(/<\/style/gi, '')};`)
+      .join('\n');
+    styleEl.replaceChildren(document.createTextNode(`:root {\n${varLines}\n}`));
   }
 
   return {

--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -15,8 +15,6 @@ import type { ThemeRegistry, ThemeConfig } from '../types';
 export function createThemeRegistry(): ThemeRegistry {
   const themes = new Map<string, ThemeConfig>();
   let currentThemeId: string | null = null;
-  /** Track CSS property names set by the previous theme so they can be cleared on switch */
-  let previousVarKeys: string[] = [];
 
   // Subscription support for React
   const subscribers = new Set<() => void>();
@@ -30,27 +28,28 @@ export function createThemeRegistry(): ThemeRegistry {
   }
 
   /**
-   * Clear previous theme vars and apply new CSS custom properties to :root
+   * Write theme CSS custom properties into a managed <style> element in <head>.
+   * Using a stylesheet rule instead of inline styles allows Shadow DOM :host rules
+   * and user CSS to override theme variables, which inline style.setProperty() blocks.
    */
   function applyCSSVariables(variables: Record<string, string>): void {
     if (typeof document === 'undefined') return;
 
-    const root = document.documentElement;
-
-    // Clear previous theme vars that are not in the new set
-    const newKeys = Object.keys(variables);
-    for (const key of previousVarKeys) {
-      if (!(key in variables)) {
-        root.style.removeProperty(key);
-      }
+    let styleEl = document.getElementById('hai3-theme-vars') as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'hai3-theme-vars';
+      document.head.appendChild(styleEl);
     }
 
-    // Apply each CSS variable
-    for (const [key, value] of Object.entries(variables)) {
-      root.style.setProperty(key, value);
+    const entries = Object.entries(variables);
+    if (entries.length === 0) {
+      styleEl.textContent = '';
+      return;
     }
 
-    previousVarKeys = newKeys;
+    const varLines = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+    styleEl.textContent = `:root {\n${varLines}\n}`;
   }
 
   return {

--- a/packages/framework/src/registries/themeRegistry.ts
+++ b/packages/framework/src/registries/themeRegistry.ts
@@ -48,7 +48,9 @@ export function createThemeRegistry(): ThemeRegistry {
       return;
     }
 
-    const varLines = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n');
+    // Strip </style> sequences to prevent CSS injection if values ever come from external sources.
+    const safe = (s: string) => s.replace(/<\/style/gi, '');
+    const varLines = entries.map(([key, value]) => `  ${safe(key)}: ${safe(value)};`).join('\n');
     styleEl.textContent = `:root {\n${varLines}\n}`;
   }
 


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#279](https://github.com/cyberfabric/cyberware-frontx/pull/279) | **Author:** billpliske | **Opened:** 2026-04-29T15:45:16Z | **Status:** merged on 2026-05-02T06:51:18Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

…bles

  Inline style.setProperty() on document.documentElement has the highest CSS
  specificity and cannot be overridden by any rule, including Shadow DOM :host
  rules. This prevented MFE screensets from applying per-screenset theme overrides.

  Replace with a managed <style id="hai3-theme-vars"> element injected into
  <head>. Un-layered stylesheet rules beat &#219;layer base fallbacks in globals.css
  and can be overridden by Shadow DOM :host rules, unblocking issue #315.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized theme variable handling by writing all theme CSS variables into a single persistent stylesheet for smoother, more consistent theme switching and improved performance.

* **Bug Fix**
  * Avoids applying themes when there are no variables, preventing unnecessary updates and potential stale styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#279 -->