### PR TITLE
[PR #265] fix(mfe): css loading

### DIFF
--- a/.ai/targets/SCREENSETS.md
+++ b/.ai/targets/SCREENSETS.md
@@ -179,7 +179,9 @@
 ## MFE BUILD CONFIGURATION
 - REQUIRED: `build.modulePreload: false` in every MFE vite.config.ts. Vite's modulePreload injects a `__vitePreload` helper that resolves chunk URLs against the page origin (host), not the MFE server origin, causing 404s in cross-origin MFE loading.
 - REQUIRED: `build.target: 'esnext'` for top-level await support (federation runtime uses it).
-- REQUIRED: `build.cssCodeSplit: false` for single CSS output in MFE bundles.
+- NOTE: `build.cssCodeSplit` may remain enabled; `MfeHandlerMF` reads the remote's CSS metadata and injects emitted styles into the mount target before lifecycle mount.
+- REQUIRED: Register `@originjs/vite-plugin-federation` (`federation()`) and `hai3MfeExternalize({ shared })` from `src/mfe_packages/shared/vite-plugin-frontx-externalize.ts` with the **same** `shared` dependency list. Federation only rewrites expose entries; the externalize plugin rewrites imports in code-split chunks so shared packages load via `importShared()`.
+- NOTE: In `packages/screensets`, `npm run test:integration` builds `_blank-mfe` in production mode and asserts `MfeHandlerMF` can load the bundle (minify + `cssCodeSplit: true` compatible).
 - REFERENCE: See `src/mfe_packages/_blank-mfe/vite.config.ts` for canonical MFE vite configuration.
 
 ## MFE LIFECYCLE ARCHITECTURE
@@ -209,3 +211,4 @@
 - [ ] MFE API services are local (not imported from host).
 - [ ] MFE events use mfe/ prefix convention.
 - [ ] MFE init.ts creates app, registers slices, registers API services.
+- [ ] MFE vite.config matches canonical setup: `modulePreload: false`, `target: 'esnext'`, `federation()` + `hai3MfeExternalize` with identical `shared` arrays.

--- a/architecture/features/feature-mfe-isolation/FEATURE.md
+++ b/architecture/features/feature-mfe-isolation/FEATURE.md
@@ -19,7 +19,14 @@
   - [Recursive Blob URL Chain](#recursive-blob-url-chain)
   - [Parse Static Import Filenames](#parse-static-import-filenames)
   - [Rewrite Module Imports](#rewrite-module-imports)
-  - [Parse Expose Chunk Filename](#parse-expose-chunk-filename)
+  - [Find Expose Module Body](#find-expose-module-body)
+  - [Parse Expose Metadata](#parse-expose-metadata)
+  - [Parse Expose Chunk Filename (callback body)](#parse-expose-chunk-filename-callback-body)
+  - [Parse Expose Stylesheets](#parse-expose-stylesheets)
+  - [Wrap Lifecycle With Remote Stylesheets](#wrap-lifecycle-with-remote-stylesheets)
+  - [Inject Remote Stylesheets](#inject-remote-stylesheets)
+  - [Remove Injected Stylesheets](#remove-injected-stylesheets)
+  - [Upsert Mount Style Element](#upsert-mount-style-element)
   - [Write Share Scope to Global](#write-share-scope-to-global)
   - [hai3-mfe-externalize: Rename Shared Chunks](#hai3-mfe-externalize-rename-shared-chunks)
   - [hai3-mfe-externalize: Map Bundled Sub-Chunks to Packages](#hai3-mfe-externalize-map-bundled-sub-chunks-to-packages)
@@ -104,14 +111,15 @@ Enable multiple independently deployed MFE bundles to coexist in the same browse
 6. [x] - `p1` - Algorithm: build share scope via `cpt-frontx-algo-mfe-isolation-build-share-scope` — `inst-build-share-scope`
 7. [x] - `p1` - `writeShareScope()` writes the constructed entries to `globalThis.__federation_shared__['default']` — `inst-write-share-scope`
 8. [x] - `p1` - Algorithm: fetch `remoteEntry.js` source text via `cpt-frontx-algo-mfe-isolation-fetch-source` — `inst-fetch-remote-entry`
-9. [x] - `p1` - Algorithm: parse expose chunk filename via `cpt-frontx-algo-mfe-isolation-parse-expose-chunk` — `inst-parse-expose-chunk`
-10. [x] - `p1` - **IF** expose chunk filename is null **RETURN** `MfeLoadError` — `inst-check-expose-chunk`
+9. [x] - `p1` - Algorithm: parse expose metadata (moduleMap callback body, chunk filename, stylesheet paths) via `cpt-frontx-algo-mfe-isolation-parse-expose-metadata` — `inst-parse-expose-metadata`
+10. [x] - `p1` - **IF** expose metadata is null **RETURN** `MfeLoadError` — `inst-check-expose-metadata`
 11. [x] - `p1` - Algorithm: build blob URL chain for expose chunk via `cpt-frontx-algo-mfe-isolation-blob-url-chain` — `inst-blob-url-chain`
 12. [x] - `p1` - **IF** expose blob URL is absent from `blobUrlMap` **RETURN** `MfeLoadError` — `inst-check-expose-blob`
 13. [x] - `p1` - Dynamic `import()` of the expose blob URL produces the expose module — `inst-import-expose-blob`
 14. [x] - `p1` - Module factory extracted from expose module; result validated as `MfeEntryLifecycle` (must have `mount` and `unmount`) — `inst-validate-lifecycle`
 15. [x] - `p1` - **IF** lifecycle interface not satisfied **RETURN** `MfeLoadError` — `inst-check-lifecycle`
-16. [x] - `p1` - **RETURN** `MfeEntryLifecycle<ChildMfeBridge>` to caller — `inst-return-lifecycle`
+16. [x] - `p1` - Algorithm: when stylesheet paths are non-empty, wrap lifecycle so `mount` injects remote CSS (`cpt-frontx-algo-mfe-isolation-wrap-lifecycle-stylesheets`) and `unmount` removes injected `<link>` / `<style>` nodes — `inst-wrap-stylesheets`
+17. [x] - `p1` - **RETURN** `MfeEntryLifecycle<ChildMfeBridge>` to caller — `inst-return-lifecycle`
 
 ### MFE Build with Externalize Plugin
 
@@ -224,16 +232,84 @@ Replaces relative specifiers in a chunk's source text with either a blob URL (if
 3. [x] - `p1` - Non-relative specifiers (bare package names, absolute URLs) are not modified — `inst-skip-non-relative`
 4. [x] - `p1` - **RETURN** the fully rewritten source text — `inst-return-rewritten`
 
-### Parse Expose Chunk Filename
+### Find Expose Module Body
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-find-expose-module-body`
+
+Locates the `moduleMap` factory callback body for the requested `exposedModule` key in `remoteEntry.js` (supports `()=>{...}` and minified `()=>(...)`).
+
+1. [x] - `p1` - Match `"<exposedModule>":()=>` with opening `{` or `(` — `inst-match-module-key`
+2. [x] - `p1` - Scan forward with delimiter balancing (respecting strings) until the matching `}` or `)` — `inst-scan-balanced-body`
+3. [x] - `p1` - **RETURN** the inner source slice or null if not found — `inst-return-body-slice`
+
+### Parse Expose Metadata
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-parse-expose-metadata`
+
+Orchestrates expose load metadata from `remoteEntry.js`: finds the moduleMap callback body, resolves the expose JS chunk filename, and collects emitted CSS paths for mount-time injection.
+
+1. [x] - `p1` - Call `cpt-frontx-algo-mfe-isolation-find-expose-module-body` — `inst-find-body`
+2. [x] - `p1` - **IF** body is null **RETURN** null — `inst-no-body`
+3. [x] - `p1` - Resolve chunk filename via `cpt-frontx-algo-mfe-isolation-parse-expose-chunk` — `inst-resolve-chunk`
+4. [x] - `p1` - **IF** chunk filename is null **RETURN** null — `inst-no-chunk`
+5. [x] - `p1` - Resolve stylesheet paths via `cpt-frontx-algo-mfe-isolation-parse-expose-stylesheets` — `inst-resolve-css`
+6. [x] - `p1` - **RETURN** `{ chunkFilename, stylesheetPaths }` — `inst-return-metadata`
+
+### Parse Expose Chunk Filename (callback body)
 
 - [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-parse-expose-chunk`
 
-Extracts the filename of the expose entry chunk from the remoteEntry source.
+Extracts the expose entry chunk filename from the **moduleMap callback body** (not the full remoteEntry).
 
-1. [x] - `p1` - Escape the `exposedModule` string for regex use — `inst-escape-module`
-2. [x] - `p1` - Apply the pattern: `"<exposedModule>"[^}]*__federation_import\(['"]\.\/([^'"]+)['"]\)` against the remoteEntry source text — `inst-apply-regex`
-3. [x] - `p1` - **IF** pattern matches **RETURN** the captured filename (group 1) — `inst-return-filename`
-4. [x] - `p1` - **IF** no match **RETURN** null — `inst-return-null`
+1. [x] - `p1` - Prefer match `['"]\.\/(__federation_expose_[^'"]+\.js)['"]` — `inst-expose-stable-name`
+2. [x] - `p1` - Else match `__federation_import(\s*['"]\.\/([^'"]+)['"]\s*)` — `inst-expose-import-fallback`
+3. [x] - `p1` - **RETURN** captured filename or null — `inst-return-chunk-or-null`
+
+### Parse Expose Stylesheets
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-parse-expose-stylesheets`
+
+Extracts `.css` asset paths from the expose callback (pretty `dynamicLoadingCss([...],` or minified `([...], …, "<exposeKey>")`).
+
+1. [x] - `p1` - **IF** legacy `dynamicLoadingCss` shape matches, parse string literals inside the bracket list — `inst-parse-legacy-css`
+2. [x] - `p1` - **ELSE** match minified bracket list followed by expose key; parse string literals — `inst-parse-minified-css`
+3. [x] - `p1` - **RETURN** deduplicated path list (may be empty) — `inst-return-css-paths`
+
+### Wrap Lifecycle With Remote Stylesheets
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-wrap-lifecycle-stylesheets`
+
+When the remote emitted CSS paths, returns a lifecycle proxy that injects styles before `mount` and removes them on `unmount`.
+
+1. [x] - `p1` - **IF** `stylesheetPaths` is empty **RETURN** the original lifecycle — `inst-no-css-proxy`
+2. [x] - `p1` - **ELSE** **RETURN** object whose `mount` awaits `cpt-frontx-algo-mfe-isolation-inject-remote-stylesheets` then delegates — `inst-proxy-mount`
+3. [x] - `p1` - `unmount` calls `cpt-frontx-algo-mfe-isolation-remove-injected-stylesheets` then delegates — `inst-proxy-unmount`
+
+### Inject Remote Stylesheets
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-inject-remote-stylesheets`
+
+For each path, resolves absolute URL with `baseUrl` and upserts a `<link rel="stylesheet">` under the mount container with a deterministic id prefix.
+
+1. [x] - `p1` - **FOR EACH** path: `cpt-frontx-algo-mfe-isolation-upsert-mount-style-element` with `href` — `inst-inject-each-link`
+
+### Remove Injected Stylesheets
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-remove-injected-stylesheets`
+
+Queries `link[id^=prefix], style[id^=prefix]` within the mount container and removes each node.
+
+1. [x] - `p1` - **RETURN** after removal (idempotent) — `inst-cleanup-styles`
+
+### Upsert Mount Style Element
+
+- [x] `p1` - **ID**: `cpt-frontx-algo-mfe-isolation-upsert-mount-style-element`
+
+Creates or updates a `<link rel="stylesheet">` (href) or `<style>` (inline css) under `Element` or `ShadowRoot`, keyed by id.
+
+1. [x] - `p1` - Locate existing node by id (`getElementById` or `querySelector`) — `inst-find-existing`
+2. [x] - `p1` - **IF** href: ensure `LINK` element; set `href` — `inst-upsert-link`
+3. [x] - `p1` - **ELSE** ensure `STYLE` element; set `textContent` — `inst-upsert-inline`
 
 ### Write Share Scope to Global
 
@@ -341,7 +417,14 @@ Tracks the fetch state of each chunk URL across all loads for the lifetime of th
 - `cpt-frontx-algo-mfe-isolation-blob-url-chain`
 - `cpt-frontx-algo-mfe-isolation-parse-imports`
 - `cpt-frontx-algo-mfe-isolation-rewrite-module-imports`
+- `cpt-frontx-algo-mfe-isolation-find-expose-module-body`
+- `cpt-frontx-algo-mfe-isolation-parse-expose-metadata`
 - `cpt-frontx-algo-mfe-isolation-parse-expose-chunk`
+- `cpt-frontx-algo-mfe-isolation-parse-expose-stylesheets`
+- `cpt-frontx-algo-mfe-isolation-wrap-lifecycle-stylesheets`
+- `cpt-frontx-algo-mfe-isolation-inject-remote-stylesheets`
+- `cpt-frontx-algo-mfe-isolation-remove-injected-stylesheets`
+- `cpt-frontx-algo-mfe-isolation-upsert-mount-style-element`
 - `cpt-frontx-algo-mfe-isolation-write-share-scope`
 - `cpt-frontx-state-mfe-isolation-load-blob-state`
 - `cpt-frontx-state-mfe-isolation-source-cache`

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "clsx": "^2.1.1",
         "date-fns": "4.1.0",
         "input-otp": "1.4.2",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "lucide-react": "0.563.0",
         "react": "19.2.4",
         "react-day-picker": "9.12.0",
@@ -48,7 +48,7 @@
         "@vitejs/plugin-react": "4.3.4",
         "autoprefixer": "10.4.23",
         "concurrently": "^9.2.1",
-        "dependency-cruiser": "17.3.2",
+        "dependency-cruiser": "17.3.10",
         "eslint": "9.27.0",
         "eslint-plugin-react-hooks": "5.0.0",
         "eslint-plugin-unused-imports": "4.1.4",
@@ -355,7 +355,6 @@
       "integrity": "sha512-Jc360x4yqb3eEg4OY4KEIdGePBxZogivKI+OGIU8aLXgAYPTECvzeOBc90312yHA1hr3AeRlAFl0rIc8lQaIrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.50.0",
         "@algolia/requester-browser-xhr": "5.50.0",
@@ -1936,7 +1935,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -2006,7 +2004,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -2295,7 +2292,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2736,7 +2732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2785,7 +2780,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2903,61 +2897,6 @@
         }
       }
     },
-    "node_modules/@docsearch/js/node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@docsearch/js/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -2978,7 +2917,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2990,6 +2928,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3581,7 +3520,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
       "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3830,22 +3768,6 @@
       "bin": {
         "gts": "dist/cli/index.js",
         "gts-server": "dist/server/index.js"
-      }
-    },
-    "node_modules/@globaltypesystem/gts-ts/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@globaltypesystem/gts-ts/node_modules/ajv-formats": {
@@ -6463,7 +6385,6 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8397,7 +8318,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -9846,7 +9766,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -10209,7 +10128,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -10367,8 +10287,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
@@ -10436,7 +10355,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -10449,21 +10367,12 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -10474,7 +10383,6 @@
       "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -10580,7 +10488,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
       "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.32.1",
@@ -10610,7 +10517,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
       "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.1",
         "@typescript-eslint/types": "8.32.1",
@@ -11373,11 +11279,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11491,9 +11396,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -11529,7 +11434,6 @@
       "integrity": "sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.16.0",
         "@algolia/client-abtesting": "5.50.0",
@@ -11657,6 +11561,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -11830,7 +11735,6 @@
       "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -11904,7 +11808,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -12096,7 +11999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12404,7 +12306,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -12900,9 +12801,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13165,7 +13066,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -13488,32 +13388,30 @@
       }
     },
     "node_modules/dependency-cruiser": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.3.2.tgz",
-      "integrity": "sha512-1xx1Q1i7WuW85W1x1cLFcl4L5bjW5bT+qBm6kwnAdIHDA87x/gU7NWKknpBWMilX2lQphxtB1VeU3GVOj3wYqw==",
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.3.10.tgz",
+      "integrity": "sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "8.15.0",
+        "acorn": "8.16.0",
         "acorn-jsx": "5.3.2",
         "acorn-jsx-walk": "2.0.0",
         "acorn-loose": "8.5.2",
-        "acorn-walk": "8.3.4",
-        "ajv": "8.17.1",
-        "commander": "14.0.2",
-        "enhanced-resolve": "5.18.3",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.20.1",
         "ignore": "7.0.5",
         "interpret": "3.1.1",
         "is-installed-globally": "1.0.0",
         "json5": "2.2.3",
-        "memoize": "10.2.0",
-        "picomatch": "4.0.3",
+        "picomatch": "4.0.4",
         "prompts": "2.4.2",
         "rechoir": "0.8.0",
         "safe-regex": "2.1.1",
-        "semver": "7.7.3",
+        "semver": "7.7.4",
         "tsconfig-paths-webpack-plugin": "4.2.0",
-        "watskeburt": "5.0.0"
+        "watskeburt": "5.0.3"
       },
       "bin": {
         "depcruise": "bin/dependency-cruise.mjs",
@@ -13527,10 +13425,23 @@
         "node": "^20.12||^22||>=24"
       }
     },
+    "node_modules/dependency-cruiser/node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dependency-cruiser/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13614,7 +13525,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -13910,14 +13822,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -14041,7 +13953,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -14140,7 +14051,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14205,7 +14115,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
       "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14218,7 +14127,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
       "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -14499,7 +14407,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -15062,7 +14969,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -15575,7 +15481,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
       "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -15810,7 +15715,6 @@
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -16911,7 +16815,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -16983,7 +16886,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -17479,16 +17381,6 @@
         "url": "https://opencollective.com/lint-staged"
       }
     },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/listr2": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
@@ -17554,9 +17446,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -17723,20 +17615,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -17762,6 +17640,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17942,22 +17821,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/memoize": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
-      "integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
       }
     },
     "node_modules/memory-pager": {
@@ -18282,19 +18145,6 @@
         "ufo": "^1.6.3"
       }
     },
-    "node_modules/mlly/node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/mongodb-connection-string-url": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
@@ -18371,23 +18221,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -19569,7 +19402,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19811,7 +19643,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -19865,7 +19696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -20122,6 +19952,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -20137,6 +19968,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20147,6 +19979,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20159,7 +19992,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -20344,23 +20178,6 @@
         "sharp": "^0.34.5"
       }
     },
-    "node_modules/promptfoo/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/promptfoo/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -20388,16 +20205,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/promptfoo/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/promptfoo/node_modules/drizzle-orm": {
@@ -20992,7 +20799,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21023,7 +20829,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -21036,7 +20841,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -21270,8 +21074,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -22836,7 +22639,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -23537,7 +23339,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -23623,7 +23424,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
       "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23637,7 +23437,6 @@
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
       "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
@@ -24031,7 +23830,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -24359,7 +24157,6 @@
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",
@@ -24400,9 +24197,9 @@
       }
     },
     "node_modules/watskeburt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.0.tgz",
-      "integrity": "sha512-fEMhfIzu9WOuAJdDcTT+aPjn0JHI2+UeJ+zWSEs/tgMvc+MFDZVmhlZ8C1uJWXax1ETYc4trUnHFHyx2DrG0jQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -24734,7 +24531,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -24881,7 +24677,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -24911,7 +24706,6 @@
       "name": "@cyberfabric/api",
       "version": "0.2.0-alpha.0",
       "license": "Apache-2.0",
-      "peer": true,
       "devDependencies": {
         "axios": "^1.6.0",
         "tsup": "^8.0.0",
@@ -24931,7 +24725,7 @@
         "fs-extra": "^11.2.0",
         "inquirer": "^12.3.0",
         "js-yaml": "^4.1.1",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "ts-morph": "^27.0.2"
       },
       "bin": {
@@ -25019,7 +24813,6 @@
       "name": "@cyberfabric/framework",
       "version": "0.2.0-alpha.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "path-to-regexp": "^8.2.0"
       },
@@ -25052,7 +24845,6 @@
       "name": "@cyberfabric/i18n",
       "version": "0.2.0-alpha.0",
       "license": "Apache-2.0",
-      "peer": true,
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.4.2"
@@ -25184,7 +24976,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -25206,7 +24997,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -25379,9 +25169,8 @@
     },
     "packages/screensets": {
       "name": "@cyberfabric/screensets",
-      "version": "0.2.0-alpha.0",
+      "version": "0.2.0-alpha.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@globaltypesystem/gts-ts": "^0.3.0"
       },
@@ -25396,7 +25185,6 @@
       "name": "@cyberfabric/state",
       "version": "0.2.0-alpha.0",
       "license": "Apache-2.0",
-      "peer": true,
       "devDependencies": {
         "@reduxjs/toolkit": "^2.2.1",
         "tsup": "^8.0.0",
@@ -25416,7 +25204,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "clsx": "^2.1.1",
     "date-fns": "4.1.0",
     "input-otp": "1.4.2",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "lucide-react": "0.563.0",
     "react": "19.2.4",
     "react-day-picker": "9.12.0",
@@ -93,6 +93,16 @@
     "zod": "^4.0.0"
   },
   "overrides": {
+    "lodash": "4.18.1",
+    "@fastify/ajv-compiler": {
+      "ajv": "8.18.0"
+    },
+    "fast-json-stringify": {
+      "ajv": "8.18.0"
+    },
+    "@modelcontextprotocol/sdk": {
+      "ajv": "8.18.0"
+    },
     "pg-cloudflare": "1.2.7",
     "pg-connection-string": "2.9.1",
     "pg-pool": "3.10.1",
@@ -120,7 +130,7 @@
     "@vitejs/plugin-react": "4.3.4",
     "autoprefixer": "10.4.23",
     "concurrently": "^9.2.1",
-    "dependency-cruiser": "17.3.2",
+    "dependency-cruiser": "17.3.10",
     "eslint": "9.27.0",
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-unused-imports": "4.1.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "^11.2.0",
     "inquirer": "^12.3.0",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "ts-morph": "^27.0.2"
   },
   "devDependencies": {

--- a/packages/i18n/src/languages.ts
+++ b/packages/i18n/src/languages.ts
@@ -9,11 +9,11 @@
 import { Language, TextDirection } from './types';
 import type { LanguageMetadata } from './types';
 
-// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-1
 /**
  * All supported languages with metadata.
  * This list defines what languages the application can use.
  */
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-western
 export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
   // Western European
   {
@@ -58,8 +58,10 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     englishName: 'Dutch',
     direction: TextDirection.LeftToRight,
   },
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-western
 
   // Eastern European
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-eastern
   {
     code: Language.Russian,
     name: 'Русский',
@@ -84,8 +86,10 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     englishName: 'Czech',
     direction: TextDirection.LeftToRight,
   },
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-eastern
 
   // Middle East & North Africa (RTL)
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-mena
   {
     code: Language.Arabic,
     name: 'العربية',
@@ -116,8 +120,10 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     englishName: 'Turkish',
     direction: TextDirection.LeftToRight,
   },
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-mena
 
   // Asian
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-asian
   {
     code: Language.ChineseSimplified,
     name: '简体中文',
@@ -173,8 +179,10 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     englishName: 'Bengali',
     direction: TextDirection.LeftToRight,
   },
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-asian
 
   // Nordic
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-nordic
   {
     code: Language.Swedish,
     name: 'Svenska',
@@ -199,8 +207,10 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     englishName: 'Finnish',
     direction: TextDirection.LeftToRight,
   },
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-nordic
 
   // Other
+// @cpt-begin:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-remaining
   {
     code: Language.Greek,
     name: 'Ελληνικά',
@@ -246,7 +256,7 @@ export const SUPPORTED_LANGUAGES: LanguageMetadata[] = [
     direction: TextDirection.LeftToRight,
   },
 ];
-// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-1
+// @cpt-end:cpt-frontx-dod-i18n-infrastructure-language-support:p1:inst-array-remaining
 
 /**
  * Get language metadata by code.

--- a/packages/screensets/__tests__/integration/mfe-prod-build.integration.test.ts
+++ b/packages/screensets/__tests__/integration/mfe-prod-build.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Production MFE integration: build _blank-mfe with explicit minify + cssCodeSplit,
+ * then verify emitted remoteEntry.js and expose chunk match what MfeHandlerMF parses.
+ *
+ * Full load()+mount() is not run here: Node's default ESM loader cannot evaluate the
+ * handler's blob/data dynamic imports the way a browser can (see federation runtime
+ * `new URL(specifier, import.meta.url)` vs data: bases). Browser E2E can extend this.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MfeHandlerMF } from '../../src/mfe/handler/mf-handler';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+const BLANK_MFE_ROOT = join(REPO_ROOT, 'src', 'mfe_packages', '_blank-mfe');
+const ASSETS_DIR = join(BLANK_MFE_ROOT, 'dist', 'assets');
+
+type ParseExpose = (
+  this: MfeHandlerMF,
+  remoteEntrySource: string,
+  exposedModule: string
+) => { chunkFilename: string; stylesheetPaths: string[] } | null;
+
+describe('MfeHandlerMF + production _blank-mfe build', () => {
+  beforeAll(() => {
+    const result = spawnSync('npm', ['run', 'build'], {
+      cwd: BLANK_MFE_ROOT,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `blank-mfe production build failed:\n${result.stderr || result.stdout}`
+      );
+    }
+    if (!statSync(join(ASSETS_DIR, 'remoteEntry.js')).isFile()) {
+      throw new Error(`Expected ${ASSETS_DIR}/remoteEntry.js after build`);
+    }
+  });
+
+  it('parses minified remoteEntry and resolves expose chunk on disk', () => {
+    const remoteSource = readFileSync(join(ASSETS_DIR, 'remoteEntry.js'), 'utf8');
+    const handler = new MfeHandlerMF(
+      'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~',
+      { timeout: 30_000, retries: 0 }
+    );
+    const parseExposeMetadata = (
+      MfeHandlerMF.prototype as unknown as { parseExposeMetadata: ParseExpose }
+    ).parseExposeMetadata;
+
+    const meta = parseExposeMetadata.call(handler, remoteSource, './lifecycle');
+    expect(meta).not.toBeNull();
+    expect(meta?.chunkFilename).toMatch(/^__federation_expose_.+\.js$/);
+    const chunkPath = join(ASSETS_DIR, meta!.chunkFilename);
+    expect(statSync(chunkPath).isFile()).toBe(true);
+  });
+
+  it('expose chunk uses minified import syntax the blob rewriter recognizes', () => {
+    const remoteSource = readFileSync(join(ASSETS_DIR, 'remoteEntry.js'), 'utf8');
+    const handler = new MfeHandlerMF(
+      'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~',
+      { timeout: 30_000, retries: 0 }
+    );
+    const parseExposeMetadata = (
+      MfeHandlerMF.prototype as unknown as { parseExposeMetadata: ParseExpose }
+    ).parseExposeMetadata;
+    const parseStaticImportFilenames = (
+      MfeHandlerMF.prototype as unknown as {
+        parseStaticImportFilenames: (
+          this: MfeHandlerMF,
+          source: string,
+          chunkFilename: string
+        ) => string[];
+      }
+    ).parseStaticImportFilenames;
+
+    const meta = parseExposeMetadata.call(handler, remoteSource, './lifecycle');
+    expect(meta).not.toBeNull();
+    const exposeSrc = readFileSync(join(ASSETS_DIR, meta!.chunkFilename), 'utf8');
+    const deps = parseStaticImportFilenames.call(
+      handler,
+      exposeSrc,
+      meta!.chunkFilename
+    );
+    expect(deps.length).toBeGreaterThan(0);
+    for (const dep of deps) {
+      expect(statSync(join(ASSETS_DIR, dep)).isFile()).toBe(true);
+    }
+  });
+
+  it('emits deterministic __federation_shared_* chunks declared in manifest', () => {
+    const sharedOnDisk = new Set(
+      readdirSync(ASSETS_DIR).filter(
+        (n) => n.startsWith('__federation_shared_') && n.endsWith('.js')
+      )
+    );
+    expect(sharedOnDisk.size).toBeGreaterThan(0);
+    for (const name of sharedOnDisk) {
+      expect(statSync(join(ASSETS_DIR, name)).isFile()).toBe(true);
+    }
+  });
+});

--- a/packages/screensets/__tests__/integration/mfe-prod-build.integration.test.ts
+++ b/packages/screensets/__tests__/integration/mfe-prod-build.integration.test.ts
@@ -8,8 +8,8 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MfeHandlerMF } from '../../src/mfe/handler/mf-handler';
 
@@ -17,6 +17,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
 const BLANK_MFE_ROOT = join(REPO_ROOT, 'src', 'mfe_packages', '_blank-mfe');
 const ASSETS_DIR = join(BLANK_MFE_ROOT, 'dist', 'assets');
+const POSIX_NPM_PATHS = ['/usr/bin/npm', '/usr/local/bin/npm'] as const;
 
 type ParseExpose = (
   this: MfeHandlerMF,
@@ -24,12 +25,80 @@ type ParseExpose = (
   exposedModule: string
 ) => { chunkFilename: string; stylesheetPaths: string[] } | null;
 
+type CommandSpec = {
+  command: string;
+  args: string[];
+};
+
+function resolveNpmBuildCommand(): CommandSpec {
+  const nodeBinDir = dirname(process.execPath);
+  const npmExecPath = process.env.npm_execpath;
+
+  if (
+    typeof npmExecPath === 'string' &&
+    npmExecPath.length > 0 &&
+    isAbsolute(npmExecPath) &&
+    existsSync(npmExecPath)
+  ) {
+    return npmExecPath.endsWith('.js')
+      ? {
+          command: process.execPath,
+          args: [npmExecPath, 'run', 'build'],
+        }
+      : {
+          command: npmExecPath,
+          args: ['run', 'build'],
+        };
+  }
+
+  const npmCliPath = join(
+    nodeBinDir,
+    '..',
+    'lib',
+    'node_modules',
+    'npm',
+    'bin',
+    'npm-cli.js'
+  );
+
+  if (existsSync(npmCliPath)) {
+    return {
+      command: process.execPath,
+      args: [npmCliPath, 'run', 'build'],
+    };
+  }
+
+  if (process.platform === 'win32') {
+    const npmCmdPath = join(nodeBinDir, 'npm.cmd');
+    if (existsSync(npmCmdPath)) {
+      return {
+        command: npmCmdPath,
+        args: ['run', 'build'],
+      };
+    }
+  } else {
+    for (const npmPath of POSIX_NPM_PATHS) {
+      if (existsSync(npmPath)) {
+        return {
+          command: npmPath,
+          args: ['run', 'build'],
+        };
+      }
+    }
+  }
+
+  throw new Error(
+    'Unable to resolve an absolute npm executable path for the integration build.'
+  );
+}
+
 describe('MfeHandlerMF + production _blank-mfe build', () => {
   beforeAll(() => {
-    const result = spawnSync('npm', ['run', 'build'], {
+    const npmBuild = resolveNpmBuildCommand();
+    const result = spawnSync(npmBuild.command, npmBuild.args, {
       cwd: BLANK_MFE_ROOT,
       encoding: 'utf8',
-      shell: process.platform === 'win32',
+      shell: false,
     });
     if (result.status !== 0) {
       throw new Error(
@@ -89,6 +158,34 @@ describe('MfeHandlerMF + production _blank-mfe build', () => {
     for (const dep of deps) {
       expect(statSync(join(ASSETS_DIR, dep)).isFile()).toBe(true);
     }
+  });
+
+  it('parses bare side-effect imports from minified and multiline sources', () => {
+    const handler = new MfeHandlerMF(
+      'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~',
+      { timeout: 30_000, retries: 0 }
+    );
+    const parseStaticImportFilenames = (
+      MfeHandlerMF.prototype as unknown as {
+        parseStaticImportFilenames: (
+          this: MfeHandlerMF,
+          source: string,
+          chunkFilename: string
+        ) => string[];
+      }
+    ).parseStaticImportFilenames;
+
+    const deps = parseStaticImportFilenames.call(
+      handler,
+      'const setup=1;import"./dep.js";\n  import "../other.js";\nimport { helper } from "./named.js";import("./dynamic.js");',
+      'chunks/widget.js'
+    );
+
+    expect(deps).toEqual([
+      'chunks/named.js',
+      'chunks/dep.js',
+      'other.js',
+    ]);
   });
 
   it('emits deterministic __federation_shared_* chunks declared in manifest', () => {

--- a/packages/screensets/__tests__/mfe/handler/mf-handler.test.ts
+++ b/packages/screensets/__tests__/mfe/handler/mf-handler.test.ts
@@ -624,7 +624,7 @@ describe('MfeHandlerMF - Caching and Manifest Resolution', () => {
       expect(typeof result.mount).toBe('function');
     });
 
-    it('injects remote stylesheets into the shadow root before mount', async () => {
+    it('injects remote stylesheet links into the shadow root before mount', async () => {
       const { manifest, registerSources } = createTestManifest(
         'styledRemote',
         ['./Widget'],
@@ -635,10 +635,6 @@ describe('MfeHandlerMF - Caching and Manifest Resolution', () => {
         }
       );
       registerSources(mocks.registerSource);
-      mocks.registerSource(
-        `${TEST_BASE_URL}/styledRemote/widget.css`,
-        '.widget { color: red; }'
-      );
 
       const entry: MfeEntryMF = {
         id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.styled.v1',
@@ -658,9 +654,98 @@ describe('MfeHandlerMF - Caching and Manifest Resolution', () => {
       });
 
       const styleElement = shadowRoot.getElementById('__hai3-mfe-runtime-style-0');
-      expect(styleElement).toBeTruthy();
-      expect(styleElement?.textContent).toContain('.widget');
-      expect(styleElement?.textContent).toContain('color: red');
+      expect(styleElement).toBeInstanceOf(HTMLLinkElement);
+      expect((styleElement as HTMLLinkElement | null)?.rel).toBe('stylesheet');
+      expect((styleElement as HTMLLinkElement | null)?.href).toBe(
+        `${TEST_BASE_URL}/styledRemote/widget.css`
+      );
+      expect(shadowRoot.querySelectorAll('link[id^="__hai3-mfe-runtime-style-"]')).toHaveLength(1);
+      expect(shadowRoot.querySelector('style[id^="__hai3-mfe-runtime-style-"]')).toBeNull();
+    });
+
+    it('reuses stylesheet link ids instead of duplicating them on repeated mount', async () => {
+      const { manifest, registerSources } = createTestManifest(
+        'styledRepeatRemote',
+        ['./Widget'],
+        {
+          cssByExpose: {
+            './Widget': ['widget.css'],
+          },
+        }
+      );
+      registerSources(mocks.registerSource);
+
+      const entry: MfeEntryMF = {
+        id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.styled-repeat.v1',
+        manifest,
+        exposedModule: './Widget',
+      };
+
+      const lifecycle = await handler.load(entry);
+      const host = document.createElement('div');
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const bridge = {
+        domainId: 'domain',
+        instanceId: 'instance',
+        executeActionsChain: async () => undefined,
+        subscribeToProperty: () => () => undefined,
+        getProperty: () => undefined,
+      };
+
+      await lifecycle.mount(shadowRoot, bridge);
+      await lifecycle.mount(shadowRoot, bridge);
+
+      expect(shadowRoot.querySelectorAll('link[id="__hai3-mfe-runtime-style-0"]')).toHaveLength(1);
+    });
+
+    it('removes injected remote stylesheets before unmount', async () => {
+      const { manifest, registerSources } = createTestManifest(
+        'styledUnmountRemote',
+        ['./Widget'],
+        {
+          cssByExpose: {
+            './Widget': ['widget.css'],
+          },
+          chunkSources: {
+            './Widget': `export default {
+              mount: () => {},
+              unmount: (container) => {
+                if (container.querySelector('link[id^="__hai3-mfe-runtime-style-"], style[id^="__hai3-mfe-runtime-style-"]')) {
+                  throw new Error('runtime stylesheet cleanup should happen before unmount');
+                }
+              }
+            };`,
+          },
+        }
+      );
+      registerSources(mocks.registerSource);
+
+      const entry: MfeEntryMF = {
+        id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.styled-unmount.v1',
+        manifest,
+        exposedModule: './Widget',
+      };
+
+      const lifecycle = await handler.load(entry);
+      const host = document.createElement('div');
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+
+      await lifecycle.mount(shadowRoot, {
+        domainId: 'domain',
+        instanceId: 'instance',
+        executeActionsChain: async () => undefined,
+        subscribeToProperty: () => () => undefined,
+        getProperty: () => undefined,
+      });
+
+      expect(
+        shadowRoot.getElementById('__hai3-mfe-runtime-style-0')
+      ).toBeTruthy();
+
+      await expect(lifecycle.unmount(shadowRoot)).resolves.toBeUndefined();
+      expect(
+        shadowRoot.getElementById('__hai3-mfe-runtime-style-0')
+      ).toBeNull();
     });
   });
 });

--- a/packages/screensets/__tests__/mfe/handler/mf-handler.test.ts
+++ b/packages/screensets/__tests__/mfe/handler/mf-handler.test.ts
@@ -28,7 +28,11 @@ import {
 function createTestManifest(
   remoteName: string,
   exposedModules: string[],
-  options?: { sharedDependencies?: MfManifest['sharedDependencies'] }
+  options?: {
+    sharedDependencies?: MfManifest['sharedDependencies'];
+    cssByExpose?: Record<string, string[]>;
+    chunkSources?: Record<string, string>;
+  }
 ): {
   manifest: MfManifest;
   registerSources: (reg: (url: string, src: string) => void) => void;
@@ -50,9 +54,12 @@ function createTestManifest(
   };
 
   const registerSources = (reg: (url: string, src: string) => void) => {
-    reg(remoteEntryUrl, createRemoteEntrySource(exposeMap));
-    for (const chunk of Object.values(exposeMap)) {
-      reg(`${baseUrl}${chunk}`, createExposeChunkSource());
+    reg(remoteEntryUrl, createRemoteEntrySource(exposeMap, options?.cssByExpose));
+    for (const [moduleName, chunk] of Object.entries(exposeMap)) {
+      reg(
+        `${baseUrl}${chunk}`,
+        options?.chunkSources?.[moduleName] ?? createExposeChunkSource()
+      );
     }
   };
 
@@ -561,6 +568,99 @@ describe('MfeHandlerMF - Caching and Manifest Resolution', () => {
 
       const fetchedUrls = mocks.mockFetch.mock.calls.map((c: unknown[]) => c[0]);
       expect(fetchedUrls).toContain(`${baseUrl}root-dep.js`);
+    });
+
+    it('parses minified remoteEntry with ()=> expression body (production shape)', async () => {
+      const remoteName = 'prodRemoteEntryShape';
+      const remoteEntryUrl = `${TEST_BASE_URL}/${remoteName}/remoteEntry.js`;
+      const baseUrl = `${TEST_BASE_URL}/${remoteName}/`;
+      const exposeChunk = '__federation_expose_Widget-prod.js';
+      const minifiedRemote = `const moduleMap={"./Widget":()=>(E([],!1,"./Widget"),w("./${exposeChunk}").then(e=>e))};`;
+
+      mocks.registerSource(remoteEntryUrl, minifiedRemote);
+      mocks.registerSource(`${baseUrl}${exposeChunk}`, createExposeChunkSource());
+
+      const manifest: MfManifest = {
+        id: `gts.hai3.mfes.mfe.mf_manifest.v1~test.${remoteName}.manifest.v1`,
+        remoteEntry: remoteEntryUrl,
+        remoteName,
+      };
+
+      const entry: MfeEntryMF = {
+        id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.prodRemoteEntry.v1',
+        manifest,
+        exposedModule: './Widget',
+      };
+
+      const result = await handler.load(entry);
+      expect(result).toBeDefined();
+      expect(typeof result.mount).toBe('function');
+    });
+
+    it('supports minified static imports during blob rewriting', async () => {
+      const { manifest, registerSources } = createTestManifest(
+        'minifiedRemote',
+        ['./Widget'],
+        {
+          chunkSources: {
+            './Widget': 'import{helper as h}from"./dep.js";export default{mount:()=>h(),unmount:()=>{}};',
+          },
+        }
+      );
+      registerSources(mocks.registerSource);
+      mocks.registerSource(
+        `${TEST_BASE_URL}/minifiedRemote/dep.js`,
+        'export const helper = () => {};'
+      );
+
+      const entry: MfeEntryMF = {
+        id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.minified.v1',
+        manifest,
+        exposedModule: './Widget',
+      };
+
+      const result = await handler.load(entry);
+      expect(result).toBeDefined();
+      expect(typeof result.mount).toBe('function');
+    });
+
+    it('injects remote stylesheets into the shadow root before mount', async () => {
+      const { manifest, registerSources } = createTestManifest(
+        'styledRemote',
+        ['./Widget'],
+        {
+          cssByExpose: {
+            './Widget': ['widget.css'],
+          },
+        }
+      );
+      registerSources(mocks.registerSource);
+      mocks.registerSource(
+        `${TEST_BASE_URL}/styledRemote/widget.css`,
+        '.widget { color: red; }'
+      );
+
+      const entry: MfeEntryMF = {
+        id: 'gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~test.styled.v1',
+        manifest,
+        exposedModule: './Widget',
+      };
+
+      const lifecycle = await handler.load(entry);
+      const host = document.createElement('div');
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      await lifecycle.mount(shadowRoot, {
+        domainId: 'domain',
+        instanceId: 'instance',
+        executeActionsChain: async () => undefined,
+        subscribeToProperty: () => () => undefined,
+        getProperty: () => undefined,
+      });
+
+      const styleElement = shadowRoot.getElementById('__hai3-mfe-runtime-style-0');
+      expect(styleElement).toBeTruthy();
+      expect(styleElement?.textContent).toContain('.widget');
+      expect(styleElement?.textContent).toContain('color: red');
     });
   });
 });

--- a/packages/screensets/__tests__/mfe/handler/share-scope.test.ts
+++ b/packages/screensets/__tests__/mfe/handler/share-scope.test.ts
@@ -394,7 +394,7 @@ describe('MfeHandlerMF - share scope construction and blob URL isolation', () =>
       await expect(blobGet()).rejects.toBeInstanceOf(MfeLoadError);
     });
 
-    it('throws MfeLoadError when expose chunk cannot be found in remoteEntry', async () => {
+    it('throws MfeLoadError when expose metadata cannot be resolved from remoteEntry', async () => {
       const remoteName = 'missingExposeRemote';
       const remoteEntryUrl = `${TEST_BASE_URL}/${remoteName}/remoteEntry.js`;
 
@@ -418,7 +418,7 @@ describe('MfeHandlerMF - share scope construction and blob URL isolation', () =>
 
       await expect(handler.load(entry)).rejects.toThrow(MfeLoadError);
       await expect(handler.load(entry)).rejects.toThrow(
-        'Cannot find expose chunk'
+        'Cannot resolve expose metadata'
       );
     });
   });

--- a/packages/screensets/__tests__/mfe/test-utils/mock-blob-url-loader.ts
+++ b/packages/screensets/__tests__/mfe/test-utils/mock-blob-url-loader.ts
@@ -139,7 +139,7 @@ export function createRemoteEntrySource(
     .map(
       ([key, chunk]) => {
         const cssPaths = cssByExpose[key] ?? [];
-        const cssArg = `[${cssPaths.map((path) => `'${path}'`).join(',')}]`;
+        const cssArg = `[${cssPaths.map((path) => "'" + path + "'").join(',')}]`;
         return `"${key}":()=>{dynamicLoadingCss(${cssArg},false,'${key}');return __federation_import('./${chunk}')}`;
       }
     )

--- a/packages/screensets/__tests__/mfe/test-utils/mock-blob-url-loader.ts
+++ b/packages/screensets/__tests__/mfe/test-utils/mock-blob-url-loader.ts
@@ -132,12 +132,16 @@ export function setupBlobUrlLoaderMocks() {
  *   e.g. { './Widget1': 'expose-Widget1.js' }
  */
 export function createRemoteEntrySource(
-  exposedModules: Record<string, string>
+  exposedModules: Record<string, string>,
+  cssByExpose: Record<string, string[]> = {}
 ): string {
   const entries = Object.entries(exposedModules)
     .map(
-      ([key, chunk]) =>
-        `"${key}":()=>{return __federation_import('./${chunk}')}`
+      ([key, chunk]) => {
+        const cssPaths = cssByExpose[key] ?? [];
+        const cssArg = `[${cssPaths.map((path) => `'${path}'`).join(',')}]`;
+        return `"${key}":()=>{dynamicLoadingCss(${cssArg},false,'${key}');return __federation_import('./${chunk}')}`;
+      }
     )
     .join(',');
   return `const moduleMap = {${entries}};`;

--- a/packages/screensets/package.json
+++ b/packages/screensets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyberfabric/screensets",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.1",
   "description": "Pure TypeScript contracts and registry for FrontX screenset management",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -37,7 +37,8 @@
     "build": "tsup",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.18",

--- a/packages/screensets/src/mfe/handler/mf-handler.ts
+++ b/packages/screensets/src/mfe/handler/mf-handler.ts
@@ -23,6 +23,11 @@ import type {
   FederationPackageVersions,
 } from './federation-types';
 
+interface ExposedModuleMetadata {
+  readonly chunkFilename: string;
+  readonly stylesheetPaths: string[];
+}
+
 /**
  * A shareScope object written to globalThis.__federation_shared__.
  * Format: { [packageName]: { [version]: { get, loaded?, scope? } } }
@@ -122,7 +127,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     const manifest = await this.resolveManifest(entry.manifest);
     this.manifestCache.cacheManifest(manifest);
 
-    const moduleFactory = await this.loadExposedModuleIsolated(
+    const { moduleFactory, stylesheetPaths, baseUrl } = await this.loadExposedModuleIsolated(
       manifest,
       entry.exposedModule,
       entry.id
@@ -137,7 +142,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       );
     }
 
-    return loadedModule;
+    return this.wrapLifecycleWithStylesheets(
+      loadedModule,
+      stylesheetPaths,
+      baseUrl
+    );
   }
 
   /**
@@ -157,7 +166,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     manifest: MfManifest,
     exposedModule: string,
     entryId: string
-  ): Promise<() => unknown> {
+  ): Promise<{
+    moduleFactory: () => unknown;
+    stylesheetPaths: string[];
+    baseUrl: string;
+  }> {
     const remoteEntryUrl = manifest.remoteEntry;
     const baseUrl = remoteEntryUrl.substring(
       0,
@@ -177,11 +190,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
 
     // Parse remoteEntry to find the expose chunk filename
     const remoteEntrySource = await this.fetchSourceText(remoteEntryUrl);
-    const exposeFilename = this.parseExposeChunkFilename(
+    const exposeMetadata = this.parseExposeMetadata(
       remoteEntrySource,
       exposedModule
     );
-    if (!exposeFilename) {
+    if (!exposeMetadata) {
       throw new MfeLoadError(
         `Cannot find expose chunk for '${exposedModule}' in remoteEntry`,
         entryId
@@ -189,12 +202,12 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     }
 
     // Build blob URL chain for the expose chunk and all its static deps
-    await this.createBlobUrlChain(loadState, exposeFilename);
+    await this.createBlobUrlChain(loadState, exposeMetadata.chunkFilename);
 
-    const exposeBlobUrl = loadState.blobUrlMap.get(exposeFilename);
+    const exposeBlobUrl = loadState.blobUrlMap.get(exposeMetadata.chunkFilename);
     if (!exposeBlobUrl) {
       throw new MfeLoadError(
-        `Failed to create blob URL for expose chunk '${exposeFilename}'`,
+        `Failed to create blob URL for expose chunk '${exposeMetadata.chunkFilename}'`,
         entryId
       );
     }
@@ -206,9 +219,13 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       'Module', '__esModule', 'default', '_export_sfc',
     ]);
     const keys = Object.keys(exposeModule as object);
-    return keys.every((k) => exportSet.has(k))
-      ? () => (exposeModule as Record<string, unknown>).default
-      : () => exposeModule;
+    return {
+      moduleFactory: keys.every((k) => exportSet.has(k))
+        ? () => (exposeModule as Record<string, unknown>).default
+        : () => exposeModule,
+      stylesheetPaths: exposeMetadata.stylesheetPaths,
+      baseUrl,
+    };
   }
 
   private isValidLifecycleModule(
@@ -222,6 +239,60 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       typeof candidate.mount === 'function' &&
       typeof candidate.unmount === 'function'
     );
+  }
+
+  private wrapLifecycleWithStylesheets(
+    lifecycle: MfeEntryLifecycle<ChildMfeBridge>,
+    stylesheetPaths: string[],
+    baseUrl: string
+  ): MfeEntryLifecycle<ChildMfeBridge> {
+    if (stylesheetPaths.length === 0) {
+      return lifecycle;
+    }
+
+    return {
+      mount: async (container, bridge) => {
+        await this.injectRemoteStylesheets(container, stylesheetPaths, baseUrl);
+        await lifecycle.mount(container, bridge);
+      },
+      unmount: async (container) => lifecycle.unmount(container),
+    };
+  }
+
+  private async injectRemoteStylesheets(
+    container: Element | ShadowRoot,
+    stylesheetPaths: string[],
+    baseUrl: string
+  ): Promise<void> {
+    const stylesheetTexts = await Promise.all(
+      stylesheetPaths.map((path) => this.fetchSourceText(baseUrl + path))
+    );
+
+    stylesheetTexts.forEach((css, index) => {
+      const targetId = `__hai3-mfe-runtime-style-${index}`;
+      this.upsertStyleElement(container, css, targetId);
+    });
+  }
+
+  private upsertStyleElement(
+    container: Element | ShadowRoot,
+    css: string,
+    id: string
+  ): void {
+    let styleElement: HTMLStyleElement | null = null;
+    if ('getElementById' in container && typeof container.getElementById === 'function') {
+      styleElement = container.getElementById(id) as HTMLStyleElement | null;
+    } else if (container instanceof Element) {
+      styleElement = container.querySelector(`style#${id}`);
+    }
+
+    if (!styleElement) {
+      styleElement = document.createElement('style');
+      styleElement.id = id;
+      container.appendChild(styleElement);
+    }
+
+    styleElement.textContent = css;
   }
 
   /**
@@ -453,23 +524,158 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
   /**
    * Parse the remoteEntry source to find the expose chunk filename.
    *
-   * Matches the moduleMap entry pattern:
+   * Matches the moduleMap entry pattern (dev / pretty-print):
    *   "./lifecycle-helloworld":()=>{
    *     ...
    *     return __federation_import('./__federation_expose_Lifecycle-helloworld-CeX0Lwd2.js')...
    *   }
+   *
+   * Production builds minify the entry to an arrow expression body and rename helpers, e.g.:
+   *   "./lifecycle":()=>(E([],!1,"./lifecycle"),w("./__federation_expose_Lifecycle-….js").then(...))
    */
   // @cpt-algo:cpt-frontx-algo-mfe-isolation-parse-expose-chunk:p1
-  private parseExposeChunkFilename(
+  private parseExposeMetadata(
+    remoteEntrySource: string,
+    exposedModule: string
+  ): ExposedModuleMetadata | null {
+    const body = this.findExposeModuleBody(remoteEntrySource, exposedModule);
+    if (body === null) {
+      return null;
+    }
+
+    const chunkFilename = this.parseExposeChunkFilename(body);
+    if (!chunkFilename) {
+      return null;
+    }
+
+    const stylesheetPaths = this.parseStylesheetPaths(body, exposedModule);
+    return {
+      chunkFilename,
+      stylesheetPaths,
+    };
+  }
+
+  /**
+   * Resolve the expose chunk file inside the moduleMap callback body.
+   * Prefers stable `__federation_expose_*` paths; falls back to __federation_import().
+   */
+  private parseExposeChunkFilename(exposeBody: string): string | null {
+    const exposeRef = /['"]\.\/(__federation_expose_[^'"]+\.js)['"]/.exec(exposeBody);
+    if (exposeRef) {
+      return exposeRef[1];
+    }
+    const importMatch = /__federation_import\(\s*['"]\.\/([^'"]+)['"]\s*\)/.exec(
+      exposeBody
+    );
+    return importMatch ? importMatch[1] : null;
+  }
+
+  private findExposeModuleBody(
     remoteEntrySource: string,
     exposedModule: string
   ): string | null {
     const escaped = exposedModule.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(
-      `"${escaped}"[^}]*__federation_import\\(['"]\\.\\/([^'"]+)['"]\\)`
+    const startRegex = new RegExp(
+      `["']${escaped}["']\\s*:\\s*\\(\\)\\s*=>\\s*(\\{|\\()`,
+      'g'
     );
-    const match = regex.exec(remoteEntrySource);
-    return match ? match[1] : null;
+    const match = startRegex.exec(remoteEntrySource);
+    if (!match) {
+      return null;
+    }
+
+    const delimiter = match[1] as '{' | '(';
+    const bodyStart = match.index + match[0].length;
+    if (delimiter === '{') {
+      return this.scanBalancedDelimiter(remoteEntrySource, bodyStart, '{', '}');
+    }
+    return this.scanBalancedDelimiter(remoteEntrySource, bodyStart, '(', ')');
+  }
+
+  /**
+   * Slice `source` from `startIndex` up to (but not including) the closing delimiter
+   * that balances the opening `{` or `(` at startIndex-1 context (caller positions
+   * startIndex immediately after the opening delimiter).
+   */
+  private scanBalancedDelimiter(
+    source: string,
+    startIndex: number,
+    openChar: string,
+    closeChar: string
+  ): string | null {
+    let depth = 1;
+    let quote: '"' | "'" | '`' | null = null;
+    let escapedChar = false;
+
+    for (let index = startIndex; index < source.length; index++) {
+      const char = source[index];
+
+      if (quote !== null) {
+        if (escapedChar) {
+          escapedChar = false;
+          continue;
+        }
+        if (char === '\\') {
+          escapedChar = true;
+          continue;
+        }
+        if (char === quote) {
+          quote = null;
+        }
+        continue;
+      }
+
+      if (char === '"' || char === '\'' || char === '`') {
+        quote = char;
+        continue;
+      }
+      if (char === openChar) {
+        depth += 1;
+        continue;
+      }
+      if (char === closeChar) {
+        depth -= 1;
+        if (depth === 0) {
+          return source.slice(startIndex, index);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract CSS asset paths from the expose callback. Pretty builds call
+   * `dynamicLoadingCss([...], …)`; minified output uses a short alias with the same
+   * argument shape: `([...], <bool>, "<exposeKey>")`.
+   */
+  private parseStylesheetPaths(
+    exposeBody: string,
+    exposedModule: string
+  ): string[] {
+    const legacy = /dynamicLoadingCss\(\s*\[([\s\S]*?)\]\s*,/.exec(exposeBody);
+    if (legacy) {
+      return this.extractCssStringPaths(legacy[1]);
+    }
+
+    const escaped = exposedModule.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const minified = new RegExp(
+      `\\[([\\s\\S]*?)\\]\\s*,\\s*[^,]+\\s*,\\s*["']${escaped}["']`
+    ).exec(exposeBody);
+    if (!minified) {
+      return [];
+    }
+    return this.extractCssStringPaths(minified[1]);
+  }
+
+  private extractCssStringPaths(bracketInner: string): string[] {
+    const paths: string[] = [];
+    const stringRegex = /['"]([^'"]+\.css[^'"]*)['"]/g;
+    let match: RegExpExecArray | null;
+    while ((match = stringRegex.exec(bracketInner)) !== null) {
+      paths.push(match[1]);
+    }
+    return paths;
   }
 
   /**
@@ -488,14 +694,14 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     const filenames: string[] = [];
 
     // Named imports: import { x } from './dep.js'  /  export { x } from './dep.js'
-    const namedRegex = /from\s+['"](\.\.?\/[^'"]+)['"]/g;
+    const namedRegex = /from\s*['"](\.\.?\/[^'"]+)['"]/g;
     let match;
     while ((match = namedRegex.exec(source)) !== null) {
       filenames.push(this.resolveRelativePath(chunkFilename, match[1]));
     }
 
     // Bare side-effect imports: import './dep.js'
-    const bareRegex = /(?:^|;|\n)\s*import\s+['"](\.\.?\/[^'"]+)['"]\s*;/g;
+    const bareRegex = /(?:^|;|\n)\s*import\s*['"](\.\.?\/[^'"]+)['"]\s*;?/g;
     while ((match = bareRegex.exec(source)) !== null) {
       filenames.push(this.resolveRelativePath(chunkFilename, match[1]));
     }
@@ -525,11 +731,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
 
     // Static imports: from './...' or from '../...'
     let result = source.replace(
-      /from\s+'(\.\.?\/[^']+)'/g,
+      /from\s*'(\.\.?\/[^']+)'/g,
       (_match, relPath: string) => `from '${resolve(relPath)}'`
     );
     result = result.replace(
-      /from\s+"(\.\.?\/[^"]+)"/g,
+      /from\s*"(\.\.?\/[^"]+)"/g,
       (_match, relPath: string) => `from "${resolve(relPath)}"`
     );
 
@@ -545,11 +751,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
 
     // Bare side-effect imports: import './dep.js'
     result = result.replace(
-      /import\s+'(\.\.?\/[^']+)'\s*;/g,
+      /import\s*'(\.\.?\/[^']+)'\s*;?/g,
       (_match, relPath: string) => `import '${resolve(relPath)}';`
     );
     result = result.replace(
-      /import\s+"(\.\.?\/[^"]+)"\s*;/g,
+      /import\s*"(\.\.?\/[^"]+)"\s*;?/g,
       (_match, relPath: string) => `import "${resolve(relPath)}";`
     );
 

--- a/packages/screensets/src/mfe/handler/mf-handler.ts
+++ b/packages/screensets/src/mfe/handler/mf-handler.ts
@@ -23,6 +23,8 @@ import type {
   FederationPackageVersions,
 } from './federation-types';
 
+const RUNTIME_STYLE_ID_PREFIX = '__hai3-mfe-runtime-style-';
+
 interface ExposedModuleMetadata {
   readonly chunkFilename: string;
   readonly stylesheetPaths: string[];
@@ -255,7 +257,10 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
         await this.injectRemoteStylesheets(container, stylesheetPaths, baseUrl);
         await lifecycle.mount(container, bridge);
       },
-      unmount: async (container) => lifecycle.unmount(container),
+      unmount: async (container) => {
+        this.removeInjectedStylesheets(container);
+        await lifecycle.unmount(container);
+      },
     };
   }
 
@@ -264,35 +269,59 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     stylesheetPaths: string[],
     baseUrl: string
   ): Promise<void> {
-    const stylesheetTexts = await Promise.all(
-      stylesheetPaths.map((path) => this.fetchSourceText(baseUrl + path))
-    );
-
-    stylesheetTexts.forEach((css, index) => {
-      const targetId = `__hai3-mfe-runtime-style-${index}`;
-      this.upsertStyleElement(container, css, targetId);
+    stylesheetPaths.forEach((path, index) => {
+      const targetId = `${RUNTIME_STYLE_ID_PREFIX}${index}`;
+      this.upsertStyleElement(
+        container,
+        { href: new URL(path, baseUrl).href },
+        targetId
+      );
     });
+  }
+
+  private removeInjectedStylesheets(container: Element | ShadowRoot): void {
+    const injectedStyles = container.querySelectorAll<HTMLLinkElement | HTMLStyleElement>(
+      `link[id^="${RUNTIME_STYLE_ID_PREFIX}"], style[id^="${RUNTIME_STYLE_ID_PREFIX}"]`
+    );
+    injectedStyles.forEach((styleElement) => styleElement.remove());
   }
 
   private upsertStyleElement(
     container: Element | ShadowRoot,
-    css: string,
+    stylesheet: { css?: string; href?: string },
     id: string
   ): void {
-    let styleElement: HTMLStyleElement | null = null;
+    let styleElement: HTMLLinkElement | HTMLStyleElement | null = null;
     if ('getElementById' in container && typeof container.getElementById === 'function') {
-      styleElement = container.getElementById(id) as HTMLStyleElement | null;
+      styleElement = container.getElementById(id) as HTMLLinkElement | HTMLStyleElement | null;
     } else if (container instanceof Element) {
-      styleElement = container.querySelector(`style#${id}`);
+      styleElement = container.querySelector(`[id="${id}"]`);
     }
 
-    if (!styleElement) {
-      styleElement = document.createElement('style');
-      styleElement.id = id;
-      container.appendChild(styleElement);
+    if (stylesheet.href) {
+      if (!styleElement || styleElement.tagName !== 'LINK') {
+        styleElement?.remove();
+        const linkElement = document.createElement('link');
+        linkElement.id = id;
+        linkElement.rel = 'stylesheet';
+        container.appendChild(linkElement);
+        styleElement = linkElement;
+      }
+
+      const linkElement = styleElement as HTMLLinkElement;
+      linkElement.href = stylesheet.href;
+      return;
     }
 
-    styleElement.textContent = css;
+    if (!styleElement || styleElement.tagName !== 'STYLE') {
+      styleElement?.remove();
+      const inlineStyleElement = document.createElement('style');
+      inlineStyleElement.id = id;
+      container.appendChild(inlineStyleElement);
+      styleElement = inlineStyleElement;
+    }
+
+    styleElement.textContent = stylesheet.css ?? '';
   }
 
   /**
@@ -576,7 +605,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
   ): string | null {
     const escaped = exposedModule.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const startRegex = new RegExp(
-      `["']${escaped}["']\\s*:\\s*\\(\\)\\s*=>\\s*(\\{|\\()`,
+      String.raw`["']${escaped}["']\s*:\s*\(\)\s*=>\s*(\{|\()`,
       'g'
     );
     const match = startRegex.exec(remoteEntrySource);
@@ -611,22 +640,17 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       const char = source[index];
 
       if (quote !== null) {
-        if (escapedChar) {
-          escapedChar = false;
-          continue;
-        }
-        if (char === '\\') {
-          escapedChar = true;
-          continue;
-        }
-        if (char === quote) {
+        const next = this.advanceQuotedString(char, quote, escapedChar);
+        escapedChar = next.escapedChar;
+        if (next.exitQuote) {
           quote = null;
         }
         continue;
       }
 
-      if (char === '"' || char === '\'' || char === '`') {
-        quote = char;
+      const startedQuote = this.parseQuoteStart(char);
+      if (startedQuote !== null) {
+        quote = startedQuote;
         continue;
       }
       if (char === openChar) {
@@ -641,6 +665,30 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       }
     }
 
+    return null;
+  }
+
+  private advanceQuotedString(
+    char: string,
+    quote: '"' | "'" | '`',
+    escapedChar: boolean
+  ): { escapedChar: boolean; exitQuote: boolean } {
+    if (escapedChar) {
+      return { escapedChar: false, exitQuote: false };
+    }
+    if (char === '\\') {
+      return { escapedChar: true, exitQuote: false };
+    }
+    if (char === quote) {
+      return { escapedChar: false, exitQuote: true };
+    }
+    return { escapedChar: false, exitQuote: false };
+  }
+
+  private parseQuoteStart(char: string): '"' | "'" | '`' | null {
+    if (char === '"' || char === '\'' || char === '`') {
+      return char as '"' | "'" | '`';
+    }
     return null;
   }
 
@@ -700,13 +748,114 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
       filenames.push(this.resolveRelativePath(chunkFilename, match[1]));
     }
 
-    // Bare side-effect imports: import './dep.js'
-    const bareRegex = /(?:^|;|\n)\s*import\s*['"](\.\.?\/[^'"]+)['"]\s*;?/g;
-    while ((match = bareRegex.exec(source)) !== null) {
-      filenames.push(this.resolveRelativePath(chunkFilename, match[1]));
-    }
+    filenames.push(
+      ...this.parseBareSideEffectImportFilenames(source, chunkFilename)
+    );
 
     return [...new Set(filenames)];
+  }
+
+  private parseBareSideEffectImportFilenames(
+    source: string,
+    chunkFilename: string
+  ): string[] {
+    const filenames: string[] = [];
+    let cursor = 0;
+
+    while (cursor < source.length) {
+      const importIndex = source.indexOf('import', cursor);
+      if (importIndex === -1) {
+        break;
+      }
+
+      if (!this.hasBareImportBoundary(source, importIndex)) {
+        cursor = importIndex + 'import'.length;
+        continue;
+      }
+
+      let specifierIndex = this.skipImportWhitespace(
+        source,
+        importIndex + 'import'.length
+      );
+      const quote = source[specifierIndex];
+      if (quote !== '"' && quote !== '\'') {
+        cursor = importIndex + 'import'.length;
+        continue;
+      }
+
+      specifierIndex += 1;
+      if (!this.isRelativeImportSpecifier(source, specifierIndex)) {
+        cursor = specifierIndex;
+        continue;
+      }
+
+      let specifierEnd = specifierIndex;
+      while (
+        specifierEnd < source.length &&
+        source[specifierEnd] !== quote
+      ) {
+        specifierEnd += 1;
+      }
+
+      if (specifierEnd >= source.length) {
+        break;
+      }
+
+      filenames.push(
+        this.resolveRelativePath(
+          chunkFilename,
+          source.slice(specifierIndex, specifierEnd)
+        )
+      );
+      cursor = specifierEnd + 1;
+    }
+
+    return filenames;
+  }
+
+  private hasBareImportBoundary(source: string, importIndex: number): boolean {
+    let boundaryIndex = importIndex - 1;
+    while (
+      boundaryIndex >= 0 &&
+      this.isBareImportWhitespace(source[boundaryIndex])
+    ) {
+      boundaryIndex -= 1;
+    }
+
+    return (
+      boundaryIndex < 0 ||
+      source[boundaryIndex] === ';' ||
+      source[boundaryIndex] === '\n'
+    );
+  }
+
+  private skipImportWhitespace(source: string, index: number): number {
+    let cursor = index;
+    while (
+      cursor < source.length &&
+      this.isImportWhitespace(source[cursor])
+    ) {
+      cursor += 1;
+    }
+    return cursor;
+  }
+
+  private isRelativeImportSpecifier(source: string, index: number): boolean {
+    return (
+      source[index] === '.' &&
+      (
+        source[index + 1] === '/' ||
+        (source[index + 1] === '.' && source[index + 2] === '/')
+      )
+    );
+  }
+
+  private isBareImportWhitespace(char: string): boolean {
+    return char === ' ' || char === '\t' || char === '\r';
+  }
+
+  private isImportWhitespace(char: string): boolean {
+    return this.isBareImportWhitespace(char) || char === '\n';
   }
 
   /**

--- a/packages/screensets/src/mfe/handler/mf-handler.ts
+++ b/packages/screensets/src/mfe/handler/mf-handler.ts
@@ -79,7 +79,7 @@ interface MfeLoaderConfig {
  * Module Federation handler for loading MFE bundles.
  *
  * For each load() call:
- *  1. Parses remoteEntry.js (fetched as text) to find the expose chunk
+ *  1. Parses remoteEntry.js (fetched as text) for expose chunk filename and CSS paths
  *  2. Builds a shareScope with per-load blob URL get() functions
  *  3. Creates a blob URL chain for the expose chunk and all its static deps
  *     (fresh __federation_fn_import → fresh moduleCache)
@@ -190,7 +190,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     const shareScope = this.buildShareScope(manifest, loadState);
     this.writeShareScope(shareScope);
 
-    // Parse remoteEntry to find the expose chunk filename
+    // Parse remoteEntry moduleMap callback: expose chunk filename + emitted CSS paths
     const remoteEntrySource = await this.fetchSourceText(remoteEntryUrl);
     const exposeMetadata = this.parseExposeMetadata(
       remoteEntrySource,
@@ -198,7 +198,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     );
     if (!exposeMetadata) {
       throw new MfeLoadError(
-        `Cannot find expose chunk for '${exposedModule}' in remoteEntry`,
+        `Cannot resolve expose metadata for '${exposedModule}' in remoteEntry`,
         entryId
       );
     }
@@ -243,6 +243,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     );
   }
 
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-wrap-lifecycle-stylesheets:p1
   private wrapLifecycleWithStylesheets(
     lifecycle: MfeEntryLifecycle<ChildMfeBridge>,
     stylesheetPaths: string[],
@@ -264,6 +265,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     };
   }
 
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-inject-remote-stylesheets:p1
   private async injectRemoteStylesheets(
     container: Element | ShadowRoot,
     stylesheetPaths: string[],
@@ -279,6 +281,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     });
   }
 
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-remove-injected-stylesheets:p1
   private removeInjectedStylesheets(container: Element | ShadowRoot): void {
     const injectedStyles = container.querySelectorAll<HTMLLinkElement | HTMLStyleElement>(
       `link[id^="${RUNTIME_STYLE_ID_PREFIX}"], style[id^="${RUNTIME_STYLE_ID_PREFIX}"]`
@@ -286,6 +289,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     injectedStyles.forEach((styleElement) => styleElement.remove());
   }
 
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-upsert-mount-style-element:p1
   private upsertStyleElement(
     container: Element | ShadowRoot,
     stylesheet: { css?: string; href?: string },
@@ -551,18 +555,13 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
   }
 
   /**
-   * Parse the remoteEntry source to find the expose chunk filename.
+   * Parse remoteEntry to locate the expose moduleMap callback and derive load metadata.
    *
-   * Matches the moduleMap entry pattern (dev / pretty-print):
-   *   "./lifecycle-helloworld":()=>{
-   *     ...
-   *     return __federation_import('./__federation_expose_Lifecycle-helloworld-CeX0Lwd2.js')...
-   *   }
-   *
-   * Production builds minify the entry to an arrow expression body and rename helpers, e.g.:
-   *   "./lifecycle":()=>(E([],!1,"./lifecycle"),w("./__federation_expose_Lifecycle-….js").then(...))
+   * Returns the expose JS chunk filename (for blob URL chain) and any CSS asset paths
+   * emitted by the federation runtime (`dynamicLoadingCss` / minified equivalent) so
+   * styles can be injected at mount time.
    */
-  // @cpt-algo:cpt-frontx-algo-mfe-isolation-parse-expose-chunk:p1
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-parse-expose-metadata:p1
   private parseExposeMetadata(
     remoteEntrySource: string,
     exposedModule: string
@@ -587,7 +586,12 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
   /**
    * Resolve the expose chunk file inside the moduleMap callback body.
    * Prefers stable `__federation_expose_*` paths; falls back to __federation_import().
+   *
+   * Matches patterns inside the callback (dev / pretty-print and minified), e.g.:
+   *   return __federation_import('./__federation_expose_Lifecycle-….js')...
+   *   "./lifecycle":()=>(E([],!1,"./lifecycle"),w("./__federation_expose_….js").then(...))
    */
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-parse-expose-chunk:p1
   private parseExposeChunkFilename(exposeBody: string): string | null {
     const exposeRef = /['"]\.\/(__federation_expose_[^'"]+\.js)['"]/.exec(exposeBody);
     if (exposeRef) {
@@ -599,6 +603,11 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
     return importMatch ? importMatch[1] : null;
   }
 
+  /**
+   * Find the moduleMap factory body for `exposedModule` in remoteEntry source.
+   * Supports `()=>{...}` and minified `()=>(...)` arrow forms.
+   */
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-find-expose-module-body:p1
   private findExposeModuleBody(
     remoteEntrySource: string,
     exposedModule: string
@@ -697,6 +706,7 @@ class MfeHandlerMF extends MfeHandler<MfeEntryMF, ChildMfeBridge> {
    * `dynamicLoadingCss([...], …)`; minified output uses a short alias with the same
    * argument shape: `([...], <bool>, "<exposeKey>")`.
    */
+  // @cpt-algo:cpt-frontx-algo-mfe-isolation-parse-expose-stylesheets:p1
   private parseStylesheetPaths(
     exposeBody: string,
     exposedModule: string

--- a/packages/screensets/vitest.integration.config.ts
+++ b/packages/screensets/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Isolated config for MFE production-build integration tests (slow: runs vite build).
+ * Run: npm run test:integration
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['__tests__/integration/**/*.integration.test.ts'],
+    testTimeout: 180_000,
+    hookTimeout: 180_000,
+  },
+});

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -55,7 +55,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "tailwind-merge": "^2.6.0"
   },
   "peerDependencies": {

--- a/src/mfe_packages/_blank-mfe/vite.config.ts
+++ b/src/mfe_packages/_blank-mfe/vite.config.ts
@@ -31,8 +31,9 @@ export default defineConfig({
   ],
   build: {
     target: 'esnext',
-    minify: false,
-    cssCodeSplit: false,
     modulePreload: false,
+    /** Default Vite prod behavior; MfeHandlerMF integration test asserts compatibility. */
+    minify: true,
+    cssCodeSplit: true,
   },
 });

--- a/src/mfe_packages/demo-mfe/package.json
+++ b/src/mfe_packages/demo-mfe/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-tooltip": "^1.1.5",
     "@tanstack/react-table": "^8.21.3",
     "date-fns": "^4.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "lucide-react": "^0.563.0",
     "react-day-picker": "^9.12.0",
     "recharts": "^2.15.0",

--- a/src/mfe_packages/demo-mfe/vite.config.ts
+++ b/src/mfe_packages/demo-mfe/vite.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
   ],
   build: {
     target: 'esnext',
-    minify: false,
-    cssCodeSplit: false,
     modulePreload: false,
+    minify: true,
+    cssCodeSplit: true,
   },
 });

--- a/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
+++ b/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
@@ -314,7 +314,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           //   const requireReact = () => __importShared_react;
           code = code.replace(
             new RegExp(
-              `import\\s+\\{([^}]+)\\}\\s+from\\s+['"]\\./${escapedChunk}['"];?`,
+              `import\\s*\\{([^}]+)\\}\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, namedClause: string) => {
@@ -338,7 +338,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           // Default imports: import Foo from './chunk.js'
           code = code.replace(
             new RegExp(
-              `import\\s+(\\w+)\\s+from\\s+['"]\\./${escapedChunk}['"];?`,
+              `import\\s*(\\w+)\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, defaultName: string) => {
@@ -351,7 +351,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           // Namespace imports: import * as Foo from './chunk.js'
           code = code.replace(
             new RegExp(
-              `import\\s+\\*\\s+as\\s+(\\w+)\\s+from\\s+['"]\\./${escapedChunk}['"];?`,
+              `import\\s*\\*\\s*as\\s*(\\w+)\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, nsName: string) => {

--- a/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
+++ b/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
@@ -314,7 +314,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           //   const requireReact = () => __importShared_react;
           code = code.replace(
             new RegExp(
-              `import\\s*\\{([^}]+)\\}\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
+              String.raw`import\s*\{([^}]+)\}\s*from\s*['"]\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, namedClause: string) => {
@@ -338,7 +338,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           // Default imports: import Foo from './chunk.js'
           code = code.replace(
             new RegExp(
-              `import\\s*(\\w+)\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
+              String.raw`import\s*(\w+)\s*from\s*['"]\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, defaultName: string) => {
@@ -351,7 +351,7 @@ export function hai3MfeExternalize(options: Hai3MfeExternalizeOptions): Plugin {
           // Namespace imports: import * as Foo from './chunk.js'
           code = code.replace(
             new RegExp(
-              `import\\s*\\*\\s*as\\s*(\\w+)\\s*from\\s*['"]\\./${escapedChunk}['"];?`,
+              String.raw`import\s*\*\s*as\s*(\w+)\s*from\s*['"]\./${escapedChunk}['"];?`,
               'g'
             ),
             (_match, nsName: string) => {


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#265](https://github.com/cyberfabric/cyberware-frontx/pull/265) | **Author:** tscbmstubp | **Opened:** 2026-04-03T16:40:13Z | **Status:** merged on 2026-04-07T04:28:24Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Fixes #367 and #368 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime stylesheet injection for remote micro‑frontend modules into mount targets (including ShadowRoot), with deterministic upsert/cleanup.

* **Bug Fixes**
  * Support for CSS code‑split micro‑frontend builds and improved parsing of federated expose metadata and static imports.

* **Documentation**
  * Updated MFE build guidance and canonical build requirements; expanded architecture notes and pre‑diff checklist.

* **Tests**
  * New integration and unit tests validating production MFE builds, federation exposes, stylesheet injection, and parsing logic.

* **Chores**
  * Dependency/version bumps (including lodash) and package version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#265 -->