### PR TITLE
[PR #248] Actions types expressed as GTS instances fix

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# .coderabbit.yaml
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - main
+      - develop

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ packages/cli/src/generated/
 
 # Local CLI e2e artifacts
 .artifacts/
+
+# Cypilot execution plans
+.cypilot/.plans/

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -1,5 +1,6 @@
 # Technical Design — FrontX Dev Kit
 
+<!-- artifact-version: 1.1 -->
 
 <!-- toc -->
 
@@ -93,7 +94,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-frontx-fr-mfe-entry-types` | `MfeEntry`, `MfeEntryMF`, `Extension`, `ScreenExtension` types define MFE communication contracts |
 | `cpt-frontx-fr-mfe-ext-domain` | `ExtensionDomain` type defines id, sharedProperties, actions, lifecycleStages, and timeout contract |
 | `cpt-frontx-fr-mfe-shared-property` | `SharedProperty` type with `id: string` and `value: unknown`; constants are GTS type IDs |
-| `cpt-frontx-fr-mfe-action-types` | `Action` and `ActionsChain` types enable chain-based MFE action execution with fallback support |
+| `cpt-frontx-fr-mfe-action-types-v2` | `Action` and `ActionsChain` types enable chain-based MFE action execution with fallback support; action `type` values are GTS schema type IDs (trailing `~`); extension references in payloads use `subject` field |
 | `cpt-frontx-fr-mfe-theme-propagation` | `themes()` plugin propagates theme changes to all MFE extensions via `screensetsRegistry.updateSharedProperty()` |
 | `cpt-frontx-fr-mfe-i18n-propagation` | `i18n()` plugin propagates language changes to all MFE extensions via `screensetsRegistry.updateSharedProperty()` |
 | `cpt-frontx-fr-blob-no-revoke` | Blob URLs kept alive for page lifetime; `URL.revokeObjectURL()` never called after `import()` resolves |
@@ -141,7 +142,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-frontx-nfr-rel-serialization` | State serializable for persistence/debugging | `cpt-frontx-component-state` | Redux Toolkit enforces serializable state by default; custom middleware logs violations | Redux DevTools inspection |
 | `cpt-frontx-nfr-sec-shadow-dom` | MFE CSS isolated from host | `cpt-frontx-component-react` | Shadow DOM wrapper for MFE render containers | Visual regression tests |
 | `cpt-frontx-nfr-sec-csp-blob` | Blob URLs compatible with CSP policies | `cpt-frontx-component-screensets` | `blob:` scheme added to `script-src`; no `eval()` or `new Function()` used | CSP violation reporting in staging |
-| `cpt-frontx-nfr-sec-type-validation` | Shared properties validated at boundary | `cpt-frontx-component-framework` | GTS plugin validates shared property values against declared schemas | Unit tests with invalid payloads |
+| `cpt-frontx-nfr-sec-type-validation` | Shared properties and actions validated at boundary | `cpt-frontx-component-framework` | GTS plugin validates shared property values against declared schemas; actions validated as anonymous instances (no `id`, schema resolved from `type` field) | Unit tests with invalid payloads and malformed actions |
 | `cpt-frontx-nfr-compat-node` | Packages installable on Node ≥ 18 | All packages | `engines` field in each `package.json`; CI matrix tests Node 18/20/22 | CI build matrix |
 | `cpt-frontx-nfr-compat-typescript` | TypeScript ≥ 5.5 | All packages | `tsconfig.json` targets ES2022; strict mode enabled | CI type-check step |
 | `cpt-frontx-nfr-compat-esm` | ESM-first output | All packages | tsup configured with `format: ['esm']`; `"type": "module"` in `package.json` | Import resolution tests |
@@ -401,7 +402,7 @@ Defines the contract between the host application and microfrontend extensions. 
 ##### Responsibility scope
 
 - **Screen-set registry**: `screensetsRegistryFactory` for registering/querying screen-sets with handler injection
-- **MFE type contracts**: Entry types (component, screen, extension), domain declarations, shared property schemas, action type definitions
+- **MFE type contracts**: Entry types (component, screen, extension), domain declarations, shared property schemas, action schema type definitions (GTS schema type IDs with trailing `~`; payloads use `subject` for extension references)
 - **Blob URL isolation**: Fetches MFE bundles, rewrites import specifiers to blob URLs, caches source text, manages per-load import maps
 - **Import rewriting**: Transforms bare `@cyberfabric/*` specifiers in MFE bundles to blob URL references for runtime resolution
 - **Recursive chain loading**: Resolves transitive dependencies by recursively blob-loading imported modules

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -94,7 +94,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-frontx-fr-mfe-entry-types` | `MfeEntry`, `MfeEntryMF`, `Extension`, `ScreenExtension` types define MFE communication contracts |
 | `cpt-frontx-fr-mfe-ext-domain` | `ExtensionDomain` type defines id, sharedProperties, actions, lifecycleStages, and timeout contract |
 | `cpt-frontx-fr-mfe-shared-property` | `SharedProperty` type with `id: string` and `value: unknown`; constants are GTS type IDs |
-| `cpt-frontx-fr-mfe-action-types-v2` | `Action` and `ActionsChain` types enable chain-based MFE action execution with fallback support; action `type` values are GTS schema type IDs (trailing `~`); extension references in payloads use `subject` field |
+| `cpt-frontx-fr-mfe-action-types` | `Action` and `ActionsChain` types enable chain-based MFE action execution with fallback support; action `type` values are GTS schema type IDs (trailing `~`); extension references in payloads use `subject` field |
 | `cpt-frontx-fr-mfe-theme-propagation` | `themes()` plugin propagates theme changes to all MFE extensions via `screensetsRegistry.updateSharedProperty()` |
 | `cpt-frontx-fr-mfe-i18n-propagation` | `i18n()` plugin propagates language changes to all MFE extensions via `screensetsRegistry.updateSharedProperty()` |
 | `cpt-frontx-fr-blob-no-revoke` | Blob URLs kept alive for page lifetime; `URL.revokeObjectURL()` never called after `import()` resolves |

--- a/architecture/PRD.md
+++ b/architecture/PRD.md
@@ -499,7 +499,7 @@ The system MUST define `MfeEntry` (base with id, requiredProperties, actions, do
 
 #### Action and Actions Chain Types
 
-- [x] `p1` - **ID**: `cpt-frontx-fr-mfe-action-types-v2`
+- [x] `p1` - **ID**: `cpt-frontx-fr-mfe-action-types`
 
 `Action` MUST have type (string), target (string), optional payload and timeout. `ActionsChain` MUST contain action, optional next and fallback (recursive). Neither MUST have an id field. The `type` field value MUST be a GTS schema type ID (string ending with `~`). When an action payload references an extension, the field MUST be named `subject`; no `extensionId` field MUST appear in action payloads.
 

--- a/architecture/PRD.md
+++ b/architecture/PRD.md
@@ -1,5 +1,7 @@
 # PRD — FrontX Dev Kit
 
+<!-- artifact-version: 1.1 -->
+
 <!-- toc -->
 
 - [1. Overview](#1-overview)
@@ -497,11 +499,11 @@ The system MUST define `MfeEntry` (base with id, requiredProperties, actions, do
 
 #### Action and Actions Chain Types
 
-- [x] `p1` - **ID**: `cpt-frontx-fr-mfe-action-types`
+- [x] `p1` - **ID**: `cpt-frontx-fr-mfe-action-types-v2`
 
-`Action` MUST have type (string), target (string), optional payload and timeout. `ActionsChain` MUST contain action, optional next and fallback (recursive). Neither MUST have an id field.
+`Action` MUST have type (string), target (string), optional payload and timeout. `ActionsChain` MUST contain action, optional next and fallback (recursive). Neither MUST have an id field. The `type` field value MUST be a GTS schema type ID (string ending with `~`). When an action payload references an extension, the field MUST be named `subject`; no `extensionId` field MUST appear in action payloads.
 
-**Rationale**: Chain-based action execution with fallback support for resilient MFE communication.
+**Rationale**: Chain-based action execution with fallback support for resilient MFE communication. GTS schema type IDs (trailing `~`) distinguish type definitions from instance IDs; `subject` is the GTS-standard field name for entity references in action payloads.
 **Actors**: `cpt-frontx-actor-microfrontend`
 
 ### 5.5 MFE Core
@@ -1037,7 +1039,7 @@ A single FrontX project MUST support multiple independent production screensets 
 
 - [x] `p1` - **ID**: `cpt-frontx-nfr-perf-lazy-loading`
 
-All screen extensions MUST be lazy-loaded via dynamic `import()`. MFE bundles MUST be fetched on-demand when `HAI3_ACTION_LOAD_EXT` is executed.
+All screen extensions MUST be lazy-loaded via dynamic `import()`. MFE bundles MUST be fetched on-demand when an action whose `type` matches the `HAI3_ACTION_LOAD_EXT` GTS schema type ID is executed.
 
 **Threshold**: Screen load time < 400ms on 4G connection.
 **Rationale**: Initial bundle must not include all screens; on-demand loading reduces time-to-interactive.
@@ -1118,10 +1120,10 @@ Content Security Policy MUST include `blob:` in `script-src` directive. MFE load
 
 - [x] `p1` - **ID**: `cpt-frontx-nfr-sec-type-validation`
 
-All MFE action chains MUST pass GTS type system validation before execution.
+All MFE action chains MUST pass GTS type system validation before execution. Actions MUST be validated as anonymous instances: the action is registered without an `id` field, the schema is resolved from the `type` field, and validation is performed against that schema.
 
 **Threshold**: Invalid actions rejected with validation error details.
-**Rationale**: Prevents malformed data from reaching MFE extensions.
+**Rationale**: Prevents malformed data from reaching MFE extensions. Anonymous instance validation aligns with GTS conventions where runtime action objects are transient and carry no persistent identity.
 
 #### Node.js Compatibility
 

--- a/architecture/explorations/2026-03-31-sdlc-id-versioning-rules.md
+++ b/architecture/explorations/2026-03-31-sdlc-id-versioning-rules.md
@@ -1,0 +1,207 @@
+# Exploration: SDLC Kit Rules for Artifact ID Versioning
+
+Date: 2026-03-31
+
+## Research question
+
+When do SDLC kit rules require appending a version suffix (`-v2`, `-v3`) to a Cypilot artifact ID, and when should the ID remain unchanged? Specifically: does a bug fix to an existing requirement's description warrant ID versioning?
+
+Secondary questions:
+- What are the rules for cross-artifact ID consistency when an ID is versioned?
+- What happens to code markers when an ID is versioned?
+- What does DECOMPOSITION.md show when other artifacts have already been versioned?
+
+## Scope
+
+**In scope**: All SDLC kit rules files (`rules.md` for PRD, DESIGN, FEATURE, DECOMPOSITION, CODEBASE), the traceability spec, and the constraints.toml. The specific case of `cpt-frontx-fr-mfe-action-types` vs `cpt-frontx-fr-mfe-action-types-v2`.
+
+**Out of scope**: Whether the specific PR change is correct or incorrect -- this exploration presents the rules as written.
+
+## Findings
+
+### 1. PRD versioning rules
+
+File: `.cypilot/config/kits/sdlc/artifacts/PRD/rules.md`, lines 69-72.
+
+The PRD rules state (verbatim):
+
+```
+- [ ] When editing existing PRD: increment version in frontmatter
+- [ ] When changing capability definition: add `-v{N}` suffix to ID or increment existing version
+  - Format: `cpt-{hierarchy-prefix}-cap-{slug}-v2`, `cpt-{hierarchy-prefix}-cap-{slug}-v3`, etc.
+- [ ] Keep changelog of significant changes
+```
+
+The trigger phrase is "when changing capability definition." The rules do not define what constitutes a "change" to a capability definition versus a correction or clarification. There is no carve-out for bug fixes, typo corrections, or wording clarifications.
+
+**Confidence:** Corroborated -- exact text from the rules file.
+
+### 2. DESIGN versioning rules
+
+File: `.cypilot/config/kits/sdlc/artifacts/DESIGN/rules.md`, lines 70-73.
+
+The DESIGN rules state (verbatim):
+
+```
+- [ ] When editing existing DESIGN: increment version in frontmatter
+- [ ] When changing type/component definition: add `-v{N}` suffix to ID or increment existing version
+- [ ] Format: `cpt-{hierarchy-prefix}-type-{slug}-v2`, `cpt-{hierarchy-prefix}-comp-{slug}-v3`, etc.
+- [ ] Keep changelog of significant changes
+```
+
+The trigger phrase is "when changing type/component definition." Same observation: no distinction between substantive changes and corrections.
+
+**Confidence:** Corroborated -- exact text from the rules file.
+
+### 3. FEATURE versioning rules
+
+File: `.cypilot/config/kits/sdlc/artifacts/FEATURE/rules.md`, lines 77-80.
+
+The FEATURE rules state (verbatim):
+
+```
+- [ ] When editing existing FEATURE: increment version in frontmatter
+- [ ] When flow/algo/state/dod significantly changes: add `-v{N}` suffix to ID
+- [ ] Keep changelog of significant changes
+- [ ] Versioning code markers must match: `@cpt-{kind}:cpt-{system}-{kind}-{slug}-v2:p{N}`
+```
+
+The trigger phrase here is notably different: "when flow/algo/state/dod **significantly** changes." The word "significantly" is present in the FEATURE rules but absent from the PRD and DESIGN rules. The FEATURE rules also explicitly note that code markers must match the versioned ID.
+
+**Confidence:** Corroborated -- exact text from the rules file.
+
+### 4. DECOMPOSITION versioning rules
+
+File: `.cypilot/config/kits/sdlc/artifacts/DECOMPOSITION/rules.md`.
+
+The DECOMPOSITION rules contain **no versioning section**. There are no rules about when or how to version DECOMPOSITION IDs, and no rules about how DECOMPOSITION should handle versioned IDs from upstream artifacts (PRD, DESIGN).
+
+**Confidence:** Corroborated -- verified by reading the entire file (375 lines). No "versioning" heading or `-v{N}` mention exists.
+
+### 5. CODEBASE versioning rules
+
+File: `.cypilot/config/kits/sdlc/codebase/rules.md`, lines 124-129.
+
+The CODEBASE rules state (verbatim):
+
+```
+- [ ] When design ID versioned (`-v2`): update code markers to match
+- [ ] Marker format with version: `@cpt-flow:{cpt-id}-v2:p{N}`
+- [ ] Migration: update all markers when design version increments
+- [ ] Keep old markers commented during transition (optional)
+```
+
+This establishes that when a design ID is versioned, code markers **must** be updated to match. Old markers may optionally be kept as comments during transition.
+
+**Confidence:** Corroborated -- exact text from the rules file.
+
+### 6. Traceability spec versioning rules
+
+File: `.cypilot/.core/architecture/specs/traceability.md`, lines 316-323.
+
+The traceability spec states:
+
+```
+When design IDs are versioned:
+
+| Design ID | Code Marker |
+|-----------|-------------|
+| `cpt-app-feature-auth-flow-login` | `@cpt-flow:cpt-app-feature-auth-flow-login:p1` |
+| `cpt-app-feature-auth-flow-login-v2` | `@cpt-flow:cpt-app-feature-auth-flow-login-v2:p1` |
+
+When design version increments, update all code markers. Old markers may be kept commented during transition.
+```
+
+This confirms the CODEBASE rules: code markers must exactly match the design ID, including any version suffix. The `-v2` suffix is part of the ID itself, not a separate metadata field.
+
+**Confidence:** Corroborated -- exact text from the spec.
+
+### 7. Cross-artifact ID consistency: current state of the codebase
+
+The current state of the repository shows an inconsistency:
+
+| Artifact | ID used | Line |
+|----------|---------|------|
+| PRD.md | `cpt-frontx-fr-mfe-action-types-v2` | 502 |
+| DESIGN.md | `cpt-frontx-fr-mfe-action-types-v2` | 97 |
+| FEATURE.md | `cpt-frontx-fr-mfe-action-types-v2` | 387 |
+| DECOMPOSITION.md | `cpt-frontx-fr-mfe-action-types` (no `-v2`) | 129 |
+
+DECOMPOSITION references the old ID without the `-v2` suffix. PRD, DESIGN, and FEATURE all use the `-v2` suffix.
+
+**Confidence:** Corroborated -- verified by grepping the codebase.
+
+### 8. What the rules do NOT say
+
+The following are **absent** from all rules files:
+
+1. **No definition of "change" vs "fix"** -- No rule distinguishes between a substantive change to a capability/type definition and a correction or bug fix to the same definition. The PRD and DESIGN rules use "when changing" without qualification. Only the FEATURE rules add the qualifier "significantly."
+
+2. **No exemption for bug fixes** -- No rule states that bug fixes, corrections, or clarifications are exempt from ID versioning.
+
+3. **No exemption for wording-only changes** -- No rule states that changes to the description/definition text (without changing the semantic meaning) are exempt from versioning.
+
+4. **No DECOMPOSITION versioning guidance** -- No rule in DECOMPOSITION addresses how to handle upstream ID versioning. There is no cascade rule that says "when a PRD ID is versioned, update the DECOMPOSITION reference."
+
+5. **No definition of "significantly"** -- The FEATURE rules use "significantly changes" as a trigger, but no rule defines what qualifies as significant versus insignificant.
+
+6. **No rollback rule** -- No rule addresses what to do if an ID was incorrectly versioned (whether to revert or keep the versioned ID).
+
+**Confidence:** Corroborated -- verified by reading all five rules files in full.
+
+### 9. The `-v{N}` suffix is part of the ID, not metadata
+
+The traceability spec (lines 80-92) defines the ID format as:
+
+```
+cpt-{hierarchy-prefix}-{kind}-{slug}
+```
+
+The regex is: `` `cpt-[a-z0-9][a-z0-9-]+` ``
+
+The `-v2` suffix becomes part of the `{slug}` portion. Once an ID is versioned, `cpt-frontx-fr-mfe-action-types-v2` is a **different ID** from `cpt-frontx-fr-mfe-action-types`. They are two distinct identifiers in the system.
+
+The ID naming convention (line 104) shows an example: `api-gateway-v2` as a valid slug for "API Gateway v2". This confirms that version suffixes are part of the slug namespace.
+
+**Confidence:** Substantiated -- inferred from the ID format spec and regex pattern.
+
+## Comparison
+
+| Aspect | PRD rules | DESIGN rules | FEATURE rules | DECOMPOSITION rules | CODEBASE rules |
+|--------|-----------|--------------|---------------|---------------------|----------------|
+| Versioning trigger | "changing capability definition" | "changing type/component definition" | "**significantly** changes" | (none) | "design ID versioned" |
+| Bug fix exemption | Not mentioned | Not mentioned | Not mentioned | N/A | N/A |
+| Format specified | `-v2`, `-v3` | `-v2`, `-v3` | `-v{N}` | N/A | `-v2` |
+| Cross-artifact sync | Not mentioned | Not mentioned | Not mentioned | Not mentioned | Must match design ID |
+
+## Key takeaways
+
+- The SDLC kit rules require ID versioning when a definition "changes" (PRD, DESIGN) or "significantly changes" (FEATURE), but no rule defines what constitutes a "change" versus a "correction" or "bug fix." (Corroborated)
+
+- Only the FEATURE rules include the qualifier "significantly" before "changes." The PRD and DESIGN rules use "when changing" without qualification, which is a broader trigger. (Corroborated)
+
+- Once an ID is versioned, it becomes a distinct ID in the system. All cross-artifact references and code markers must use the exact versioned ID. (Corroborated)
+
+- The DECOMPOSITION rules contain no versioning section and no guidance on how to handle versioned upstream IDs, which creates a gap. The current codebase shows this gap: DECOMPOSITION.md references the old unversioned ID while PRD, DESIGN, and FEATURE use the `-v2` ID. (Corroborated)
+
+- No rule in any artifact's rules file provides an exemption for bug fixes, corrections, or non-semantic wording changes. The rules are silent on this distinction. (Corroborated)
+
+## Open questions
+
+1. **What qualifies as a "change" vs a "correction"?** The rules do not define this boundary. A team decision is needed on whether the `-v2` suffix was warranted for this specific case.
+
+2. **Should DECOMPOSITION be updated?** If the `-v2` ID is kept, DECOMPOSITION.md line 129 references a non-existent ID (`cpt-frontx-fr-mfe-action-types` without `-v2`). This is a cross-artifact consistency violation regardless of whether the versioning was warranted.
+
+3. **What does "significantly" mean in FEATURE rules?** The FEATURE rules use a higher bar ("significantly changes") than PRD/DESIGN rules ("changing"). No definition of "significant" is provided.
+
+4. **Is there a rollback procedure?** If the team determines the versioning was incorrect, no rule addresses how to revert a versioned ID or whether the `-v2` should simply be removed from all artifacts.
+
+## Sources
+
+1. `.cypilot/config/kits/sdlc/artifacts/PRD/rules.md` (lines 69-72) -- PRD versioning requirements
+2. `.cypilot/config/kits/sdlc/artifacts/DESIGN/rules.md` (lines 70-73) -- DESIGN versioning requirements
+3. `.cypilot/config/kits/sdlc/artifacts/FEATURE/rules.md` (lines 77-80) -- FEATURE versioning requirements with "significantly" qualifier
+4. `.cypilot/config/kits/sdlc/artifacts/DECOMPOSITION/rules.md` (full file, 375 lines) -- absence of versioning rules
+5. `.cypilot/config/kits/sdlc/codebase/rules.md` (lines 124-129) -- code marker versioning requirements
+6. `.cypilot/.core/architecture/specs/traceability.md` (lines 80-92, 316-323) -- ID format spec and code marker versioning examples
+7. `.cypilot/config/kits/sdlc/constraints.toml` -- ID kind definitions and cross-artifact reference rules (no versioning rules found)

--- a/architecture/features/feature-framework-composition/FEATURE.md
+++ b/architecture/features/feature-framework-composition/FEATURE.md
@@ -1,5 +1,7 @@
 # Feature: Framework Composition
 
+<!-- artifact-version: 1.1 -->
+
 
 <!-- toc -->
 
@@ -186,12 +188,12 @@ Enable host applications to compose a fully-wired FrontX framework instance by a
 **Actors**: `cpt-frontx-actor-host-app`, `cpt-frontx-actor-microfrontend`
 
 1. [ ] `p1` - Host calls `app.actions.loadExtension(extensionId)` - `inst-call-load-ext`
-2. [ ] `p1` - Action resolves the domain ID from the registered extension; calls `screensetsRegistry.executeActionsChain` with `HAI3_ACTION_LOAD_EXT` — fire-and-forget - `inst-execute-load-chain`
+2. [ ] `p1` - Action resolves the domain ID from the registered extension; calls `screensetsRegistry.executeActionsChain` with `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~` — fire-and-forget - `inst-execute-load-chain`
 3. [ ] `p1` - Host calls `app.actions.mountExtension(extensionId)` - `inst-call-mount-ext`
-4. [ ] `p1` - Action resolves domain ID; calls `executeActionsChain` with `HAI3_ACTION_MOUNT_EXT` - `inst-execute-mount-chain`
-5. [ ] `p1` - On successful mount completion, dispatch `setExtensionMounted({ domainId, extensionId })` to the MFE slice - `inst-dispatch-mounted`
+4. [ ] `p1` - Action resolves domain ID; calls `executeActionsChain` with `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` - `inst-execute-mount-chain`
+5. [ ] `p1` - On successful mount completion, dispatch `setExtensionMounted({ domainId, subject })` to the MFE slice - `inst-dispatch-mounted`
 6. [ ] `p2` - Host calls `app.actions.unmountExtension(extensionId)` - `inst-call-unmount-ext`
-7. [ ] `p2` - Action resolves domain ID; calls `executeActionsChain` with `HAI3_ACTION_UNMOUNT_EXT` - `inst-execute-unmount-chain`
+7. [ ] `p2` - Action resolves domain ID; calls `executeActionsChain` with `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` - `inst-execute-unmount-chain`
 8. [ ] `p2` - On successful unmount completion, dispatch `setExtensionUnmounted({ domainId })` to the MFE slice - `inst-dispatch-unmounted`
 
 ### Shared Property Broadcast
@@ -313,8 +315,8 @@ Tracked in `state.mfe.registrationStates[extensionId]`.
 
 Tracked in `state.mfe.mountedExtensions[domainId]` as an extension ID string or `undefined`.
 
-1. [ ] `p1` - **FROM** `undefined` **TO** `extensionId` **WHEN** `HAI3_ACTION_MOUNT_EXT` chain completes successfully - `inst-domain-mounted`
-2. [ ] `p2` - **FROM** `extensionId` **TO** `undefined` **WHEN** `HAI3_ACTION_UNMOUNT_EXT` chain completes successfully - `inst-domain-unmounted`
+1. [ ] `p1` - **FROM** `undefined` **TO** `subject` **WHEN** `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` chain completes successfully - `inst-domain-mounted`
+2. [ ] `p2` - **FROM** `subject` **TO** `undefined` **WHEN** `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` chain completes successfully - `inst-domain-unmounted`
 
 ### Plugin Builder State
 
@@ -570,7 +572,7 @@ The framework does NOT export `createAction` to consumers; actions are handwritt
 - [x] `screensetsRegistry.updateSharedProperty(HAI3_SHARED_PROPERTY_THEME, 'dark')` propagates to all domains declaring the property; domains not declaring it receive no update
 - [x] `app.actions.registerExtension(ext)` transitions `state.mfe.registrationStates[ext.id]` from `'unregistered'` → `'registering'` → `'registered'`
 - [x] A failing `screensetsRegistry.registerExtension()` call transitions state to `'error'` with the error message recorded
-- [x] `app.actions.mountExtension(extensionId)` after successful execution sets `state.mfe.mountedExtensions[domainId]` to `extensionId`
+- [x] `app.actions.mountExtension(extensionId)` after successful execution sets `state.mfe.mountedExtensions[domainId]` to the extension's `subject` reference
 - [x] `normalizeBase('/console/')` returns `'/console'`; `normalizeBase('')` returns `'/'`; `normalizeBase('console')` returns `'/console'`
 - [x] `stripBase('/console/dashboard', '/console')` returns `'/dashboard'`; `stripBase('/admin/x', '/console')` returns `null`; `stripBase('/console-admin', '/console')` returns `null`
 - [x] `createHAI3App()` uses the `full()` preset and returns a valid `HAI3App` without configuration

--- a/architecture/features/feature-react-bindings/FEATURE.md
+++ b/architecture/features/feature-react-bindings/FEATURE.md
@@ -1,5 +1,7 @@
 # Feature: React Bindings
 
+<!-- artifact-version: 1.1 -->
+
 
 <!-- toc -->
 
@@ -201,12 +203,12 @@ Success criteria: Developers can wrap their application with `<HAI3Provider>`, a
 
 1. [x] - `p1` - Host renders `<ExtensionDomainSlot registry={registry} domainId={...} extensionId={...}>` - `inst-render-slot`
 2. [x] - `p1` - Component renders a loading placeholder while mounting proceeds - `inst-show-loading`
-3. [x] - `p1` - Component dispatches `HAI3_ACTION_MOUNT_EXT` via `registry.executeActionsChain()` with `domainId` and `extensionId` - `inst-dispatch-mount`
+3. [x] - `p1` - Component dispatches `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` via `registry.executeActionsChain()` with `domainId` and `subject` - `inst-dispatch-mount`
 4. [x] - `p1` - IF mount succeeds THEN component queries `registry.getParentBridge(extensionId)` to obtain the parent bridge - `inst-get-bridge`
 5. [x] - `p1` - IF bridge is returned THEN component transitions to mounted state and invokes optional `onMounted(bridge)` callback - `inst-notify-mounted`
 6. [x] - `p1` - IF mount throws THEN component transitions to error state, renders error UI, invokes optional `onError(err)` callback - `inst-handle-mount-error`
-7. [x] - `p1` - On component unmount: IF bridge was obtained THEN dispatch `HAI3_ACTION_UNMOUNT_EXT` asynchronously, then invoke optional `onUnmounted()` callback - `inst-cleanup-unmount`
-8. [x] - `p2` - IF component unmounts while mount is still in progress THEN dispatch `HAI3_ACTION_UNMOUNT_EXT` immediately after the in-flight mount resolves - `inst-race-cleanup`
+7. [x] - `p1` - On component unmount: IF bridge was obtained THEN dispatch `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` asynchronously, then invoke optional `onUnmounted()` callback - `inst-cleanup-unmount`
+8. [x] - `p2` - IF component unmounts while mount is still in progress THEN dispatch `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` immediately after the in-flight mount resolves - `inst-race-cleanup`
 
 ---
 
@@ -530,7 +532,7 @@ Tracks per-language load state for `useScreenTranslations`.
 
 - [x] `p1` - **ID**: `cpt-frontx-dod-react-bindings-extension-slot`
 
-`ExtensionDomainSlot` mounts and unmounts MFE extensions within a domain. It renders a loading placeholder during mount, exposes an error UI on failure, and renders a DOM container div when mounted. It dispatches `HAI3_ACTION_MOUNT_EXT` on mount and `HAI3_ACTION_UNMOUNT_EXT` on unmount. Unmounting during an in-flight mount dispatches unmount after the mount operation settles. Optional callbacks (`onMounted`, `onUnmounted`, `onError`) are invoked at lifecycle transitions.
+`ExtensionDomainSlot` mounts and unmounts MFE extensions within a domain. It renders a loading placeholder during mount, exposes an error UI on failure, and renders a DOM container div when mounted. It dispatches `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` on mount and `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` on unmount. Unmounting during an in-flight mount dispatches unmount after the mount operation settles. Optional callbacks (`onMounted`, `onUnmounted`, `onError`) are invoked at lifecycle transitions.
 
 **Implements**:
 - `cpt-frontx-flow-react-bindings-extension-domain-slot`

--- a/architecture/features/feature-screenset-registry/FEATURE.md
+++ b/architecture/features/feature-screenset-registry/FEATURE.md
@@ -1,5 +1,7 @@
 # Feature: Screenset Registry & Contracts
 
+<!-- artifact-version: 1.1 -->
+
 
 <!-- toc -->
 
@@ -157,11 +159,12 @@ Success criteria: A host application can register a domain and extension, execut
 2. - [x] `p1` - Registry delegates to `ActionsChainsMediator.executeActionsChain(chain)` - `inst-delegate-to-mediator`
 3. - [x] `p1` - Mediator resolves the target domain from `chain.action.target` - `inst-resolve-target`
 4. - [x] `p1` - IF target domain is not registered, the chain fails with a recorded error - `inst-target-not-found`
-5. - [x] `p1` - Mediator invokes the domain's registered `ExtensionLifecycleActionHandler` - `inst-invoke-handler`
-6. - [x] `p1` - IF action completes successfully AND `chain.next` is defined, mediator executes `chain.next` recursively - `inst-execute-next`
-7. - [x] `p1` - IF action fails AND `chain.fallback` is defined, mediator executes `chain.fallback` instead - `inst-execute-fallback`
-8. - [x] `p1` - IF `result.completed` is false, registry logs the error and path to `console.error` - `inst-log-chain-failure`
-9. - [x] `p1` - Promise resolves when the chain execution concludes (success or exhausted fallback) - `inst-resolve-chain`
+5. - [x] `p1` - Mediator validates the action via anonymous instance pattern: the action object (no `id` field) is registered with `typeSystem.register(action)`; GTS resolves the schema from `action.type` via `schemaIdFields` config; `typeSystem.validateInstance('')` validates the anonymous instance — IF validation fails the chain fails with a recorded error - `inst-validate-action-anonymous`
+6. - [x] `p1` - Mediator invokes the domain's registered `ExtensionLifecycleActionHandler` - `inst-invoke-handler`
+7. - [x] `p1` - IF action completes successfully AND `chain.next` is defined, mediator executes `chain.next` recursively - `inst-execute-next`
+8. - [x] `p1` - IF action fails AND `chain.fallback` is defined, mediator executes `chain.fallback` instead - `inst-execute-fallback`
+9. - [x] `p1` - IF `result.completed` is false, registry logs the error and path to `console.error` - `inst-log-chain-failure`
+10. - [x] `p1` - Promise resolves when the chain execution concludes (success or exhausted fallback) - `inst-resolve-chain`
 
 ### Update Shared Property
 
@@ -229,7 +232,7 @@ This algorithm enforces three subset rules. All errors are collected before retu
 
 1. - [x] `p1` - **Rule 1 — Required properties**: FOR EACH `prop` in `entry.requiredProperties`: IF `prop` is not in `domain.sharedProperties` APPEND `missing_property` error - `inst-check-required-props`
 2. - [x] `p1` - **Rule 2 — Entry actions**: FOR EACH `action` in `entry.actions`: IF `action` is not in `domain.extensionsActions` APPEND `unsupported_action` error - `inst-check-entry-actions`
-3. - [x] `p1` - **Rule 3 — Domain actions (non-infrastructure)**: FOR EACH `action` in `domain.actions`: IF `action` is in the infrastructure set (`HAI3_ACTION_LOAD_EXT`, `HAI3_ACTION_MOUNT_EXT`, `HAI3_ACTION_UNMOUNT_EXT`) CONTINUE; IF `action` is not in `entry.domainActions` APPEND `unhandled_domain_action` error - `inst-check-domain-actions`
+3. - [x] `p1` - **Rule 3 — Domain actions (non-infrastructure)**: FOR EACH `action` in `domain.actions`: IF `action` is in the infrastructure set (`gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~`, `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~`, `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~`) CONTINUE; IF `action` is not in `entry.domainActions` APPEND `unhandled_domain_action` error - `inst-check-domain-actions`
 4. - [x] `p1` - IF errors array is empty RETURN valid; ELSE RETURN invalid with collected errors - `inst-return-contract-result`
 
 ### Extension Type Hierarchy Validation
@@ -290,8 +293,8 @@ All mutating operations on a given entity are queued per entity ID to prevent co
 
 Determines whether a domain uses `swap` or `toggle` mount semantics based on its declared actions.
 
-1. - [x] `p1` - IF `domain.actions` includes `HAI3_ACTION_UNMOUNT_EXT` → domain uses `toggle` semantics (sidebar, popup, overlay domains: one extension can be explicitly unmounted) - `inst-toggle-semantics`
-2. - [x] `p1` - IF `domain.actions` does NOT include `HAI3_ACTION_UNMOUNT_EXT` → domain uses `swap` semantics (screen domain: mounting a new extension automatically unmounts the current one) - `inst-swap-semantics`
+1. - [x] `p1` - IF `domain.actions` includes `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` → domain uses `toggle` semantics (sidebar, popup, overlay domains: one extension can be explicitly unmounted) - `inst-toggle-semantics`
+2. - [x] `p1` - IF `domain.actions` does NOT include `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` → domain uses `swap` semantics (screen domain: mounting a new extension automatically unmounts the current one) - `inst-swap-semantics`
 3. - [x] `p1` - The determined semantics value is passed to `ExtensionLifecycleActionHandler` at construction - `inst-pass-semantics`
 
 ---
@@ -304,7 +307,7 @@ Determines whether a domain uses `swap` or `toggle` mount semantics based on its
 
 Tracks whether an extension's bundle has been fetched and initialized.
 
-1. - [x] `p1` - **FROM** `idle` **TO** `loading` **WHEN** `HAI3_ACTION_LOAD_EXT` is dispatched for the extension - `inst-idle-to-loading`
+1. - [x] `p1` - **FROM** `idle` **TO** `loading` **WHEN** an action whose `type` is `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~` is dispatched for the extension - `inst-idle-to-loading`
 2. - [x] `p1` - **FROM** `loading` **TO** `loaded` **WHEN** the `MfeHandler.load()` promise resolves successfully - `inst-loading-to-loaded`
 3. - [x] `p1` - **FROM** `loading` **TO** `error` **WHEN** the `MfeHandler.load()` promise rejects - `inst-loading-to-error`
 4. - [ ] `p2` - **FROM** `error` **TO** `idle` **WHEN** the extension is unregistered and re-registered - `inst-error-to-idle`
@@ -315,9 +318,9 @@ Tracks whether an extension's bundle has been fetched and initialized.
 
 Tracks whether an extension's React tree is rendered into a domain container.
 
-1. - [x] `p1` - **FROM** `unmounted` **TO** `mounting` **WHEN** `HAI3_ACTION_MOUNT_EXT` is dispatched and load state is `loaded` - `inst-unmounted-to-mounting`
+1. - [x] `p1` - **FROM** `unmounted` **TO** `mounting` **WHEN** an action whose `type` is `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` is dispatched and load state is `loaded` - `inst-unmounted-to-mounting`
 2. - [x] `p1` - **FROM** `mounting` **TO** `mounted` **WHEN** `MfeEntryLifecycle.mount()` resolves successfully - `inst-mounting-to-mounted`
-3. - [x] `p1` - **FROM** `mounted` **TO** `unmounting` **WHEN** `HAI3_ACTION_UNMOUNT_EXT` is dispatched (toggle domains) or another extension is mounted (swap domains) - `inst-mounted-to-unmounting`
+3. - [x] `p1` - **FROM** `mounted` **TO** `unmounting` **WHEN** an action whose `type` is `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~` is dispatched (toggle domains) or another extension is mounted (swap domains) - `inst-mounted-to-unmounting`
 4. - [x] `p1` - **FROM** `unmounting` **TO** `unmounted` **WHEN** `MfeEntryLifecycle.unmount()` resolves - `inst-unmounting-to-unmounted`
 5. - [x] `p1` - **FROM** `mounted` **TO** `unmounted` **WHEN** the extension is unregistered while mounted (auto-unmount) - `inst-mounted-to-unmounted-on-unregister`
 
@@ -373,7 +376,7 @@ All MFE TypeScript interfaces are defined with the correct shapes as derived fro
 - `ScreenExtension` extends `Extension`: adds required `presentation` (`ExtensionPresentation`)
 - `ExtensionPresentation`: `label`, `route`, optional `icon`, optional `order`
 - `SharedProperty`: `id`, `value: unknown`
-- `Action`: `type`, `target`, optional `payload`, optional `timeout`; no `id` field
+- `Action`: `type` (GTS schema type ID with trailing `~`), `target`, optional `payload`, optional `timeout`; no `id` field; when `payload` is present and the action targets an extension, `payload.subject` carries a GTS reference to the extension instance — no `payload.extensionId` field exists
 - `ActionsChain`: `action` (Action instance), optional `next` (ActionsChain), optional `fallback` (ActionsChain); no `id` field
 - `LifecycleStage`, `LifecycleHook` with appropriate shapes
 
@@ -381,7 +384,7 @@ All MFE TypeScript interfaces are defined with the correct shapes as derived fro
 - `cpt-frontx-fr-mfe-entry-types`
 - `cpt-frontx-fr-mfe-ext-domain`
 - `cpt-frontx-fr-mfe-shared-property`
-- `cpt-frontx-fr-mfe-action-types`
+- `cpt-frontx-fr-mfe-action-types-v2`
 
 **Covers (DESIGN)**:
 - `cpt-frontx-component-screensets`
@@ -390,10 +393,11 @@ All MFE TypeScript interfaces are defined with the correct shapes as derived fro
 
 - [x] `p1` - **ID**: `cpt-frontx-dod-screenset-registry-gts-validation`
 
-All registration paths perform GTS-native validation:
+All registration and dispatch paths perform GTS-native validation:
 
 - Domain registration: `typeSystem.register(domain)` then `typeSystem.validateInstance(domain.id)`; lifecycle hook stages validated against `domain.lifecycleStages`
 - Extension registration: `typeSystem.register(extension)` then `typeSystem.validateInstance(extension.id)`; contract matching; type hierarchy check via `typeSystem.isTypeOf`; lifecycle hooks validated against `domain.extensionsLifecycleStages`
+- Action dispatch: anonymous instance pattern — the action object (no `id` field) is registered via `typeSystem.register(action)`; GTS resolves the schema from the action's `type` field using the `schemaIdFields` configuration; `typeSystem.validateInstance('')` validates the anonymous instance against the resolved schema; the `payload.subject` field is validated as required by the schema, making a separate `requireExtensionId()` helper redundant
 - Shared property update: ephemeral instance `{ id: ephemeralId, value }` registered and validated before any domain receives the value; validation failure throws and blocks all propagation
 - All validation errors produce typed exceptions: `DomainValidationError`, `ExtensionValidationError`, `ContractValidationError`, `ExtensionTypeError`, `UnsupportedLifecycleStageError`, `EntryTypeNotHandledError`
 
@@ -456,8 +460,8 @@ All registration paths perform GTS-native validation:
 - `name: string` and `version: string` (readonly)
 - `registerSchema(schema: JSONSchema): void` — for vendor/dynamic schemas; first-class schemas are built into the plugin and need not be registered
 - `getSchema(typeId: string): JSONSchema | undefined`
-- `register(entity: unknown): void` — GTS-native registration; extracts schema from chained instance ID automatically
-- `validateInstance(instanceId: string): ValidationResult` — validates a registered instance; schema extracted from chained ID (named instance pattern)
+- `register(entity: unknown): void` — GTS-native registration; for named instances the schema is extracted from the chained instance ID; for anonymous instances (no `id` field) the schema is extracted from a `schemaIdFields`-designated field such as `type`
+- `validateInstance(instanceId: string): ValidationResult` — validates a registered instance; pass the instance `id` for named instances; pass `''` (empty string) for anonymous instances registered without an `id` field
 - `isTypeOf(typeId: string, baseTypeId: string): boolean` — type hierarchy check
 - `JSONSchema`, `ValidationError`, `ValidationResult` supporting types are exported alongside the interface
 - The package treats all type IDs as opaque strings; no parsing of type IDs occurs in `@cyberfabric/screensets`
@@ -474,7 +478,7 @@ All registration paths perform GTS-native validation:
 
 - [x] `p1` - **ID**: `cpt-frontx-dod-screenset-registry-factory-cache`
 
-`ScreensetsRegistryFactory` is an abstract class with a single abstract method `build(config: ScreensetsRegistryConfig): ScreensetsRegistry`. `DefaultScreensetsRegistryFactory` is the concrete implementation — it is marked `@internal` and not exported from the public barrel. The exported singleton `screensetsRegistryFactory` is an instance of `DefaultScreensetsRegistryFactory`. After the first `build()` call the instance is cached; subsequent calls with the same `typeSystem` reference return the cached instance; calls with a different `typeSystem` reference throw. Construction verifies all eight first-class GTS schemas are present in the plugin.
+`ScreensetsRegistryFactory` is an abstract class with a single abstract method `build(config: ScreensetsRegistryConfig): ScreensetsRegistry`. `DefaultScreensetsRegistryFactory` is the concrete implementation — it is marked `@internal` and not exported from the public barrel. The exported singleton `screensetsRegistryFactory` is an instance of `DefaultScreensetsRegistryFactory`. After the first `build()` call the instance is cached; subsequent calls with the same `typeSystem` reference return the cached instance; calls with a different `typeSystem` reference throw. Construction verifies all thirteen first-class GTS schemas are present in the plugin.
 
 **Implements**:
 - `cpt-frontx-flow-screenset-registry-factory-build`

--- a/architecture/features/feature-screenset-registry/FEATURE.md
+++ b/architecture/features/feature-screenset-registry/FEATURE.md
@@ -384,7 +384,7 @@ All MFE TypeScript interfaces are defined with the correct shapes as derived fro
 - `cpt-frontx-fr-mfe-entry-types`
 - `cpt-frontx-fr-mfe-ext-domain`
 - `cpt-frontx-fr-mfe-shared-property`
-- `cpt-frontx-fr-mfe-action-types-v2`
+- `cpt-frontx-fr-mfe-action-types`
 
 **Covers (DESIGN)**:
 - `cpt-frontx-component-screensets`

--- a/architecture/features/feature-studio-devtools/FEATURE.md
+++ b/architecture/features/feature-studio-devtools/FEATURE.md
@@ -1,5 +1,7 @@
 # Feature: Studio DevTools
 
+<!-- artifact-version: 1.1 -->
+
 - [x] `p1` - **ID**: `cpt-frontx-featstatus-studio-devtools`
 
 <!-- toc -->
@@ -225,7 +227,7 @@ Success criteria: A developer can toggle theme, language, and API mock mode in u
 6. [ ] `p1` - Filter extensions to those with `domain === HAI3_SCREEN_DOMAIN` and `isScreenExtension()` — `inst-filter-screen-ext`
 7. [ ] `p1` - **IF** no screen extensions exist **RETURN** warning logged, no further action — `inst-no-screen-ext`
 8. [ ] `p1` - Sort screen extensions by `presentation.order` ascending — `inst-sort-extensions`
-9. [ ] `p1` - Call `registry.executeActionsChain()` with `HAI3_ACTION_MOUNT_EXT` targeting `HAI3_SCREEN_DOMAIN` for the first extension — `inst-mount-ext`
+9. [ ] `p1` - Call `registry.executeActionsChain()` with `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` targeting `HAI3_SCREEN_DOMAIN` for the first extension — `inst-mount-ext`
 10. [ ] `p1` - Emit `studio/activePackageChanged` with `{ activePackageId }` — `inst-emit-pkg-changed`
 11. [ ] `p1` - Persistence effect subscribes to `studio/activePackageChanged`; writes `activePackageId` to `hai3:studio:activePackageId` — `inst-persist-pkg`
 
@@ -249,7 +251,7 @@ Success criteria: A developer can toggle theme, language, and API mock mode in u
 10. [ ] `p1` - **IF** no `activePackageId` stored OR registry unavailable **RETURN** without action — `inst-no-restore-pkg`
 11. [ ] `p1` - Retrieve screen extensions for the persisted package and sort by `presentation.order` — `inst-restore-sort-ext`
 12. [ ] `p1` - **IF** no screen extensions found, skip restore silently — `inst-no-ext-skip`
-13. [ ] `p1` - Call `registry.executeActionsChain()` with `HAI3_ACTION_MOUNT_EXT` for the first extension — `inst-restore-mount`
+13. [ ] `p1` - Call `registry.executeActionsChain()` with `gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~` for the first extension — `inst-restore-mount`
 14. [ ] `p1` - **TRY** — on any error during GTS package restore, catch and skip; application remains in current state — `inst-restore-catch`
 
 ---

--- a/packages/cli/template-sources/layout-custom-uikit/Menu.tsx
+++ b/packages/cli/template-sources/layout-custom-uikit/Menu.tsx
@@ -79,7 +79,7 @@ export const Menu: React.FC<MenuProps> = ({ children }) => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: HAI3_SCREEN_DOMAIN,
-          payload: { extensionId },
+          payload: { subject: extensionId },
         },
       });
       setMountedId(extensionId);

--- a/packages/cli/template-sources/project/src/app/mfe/bootstrap.ts
+++ b/packages/cli/template-sources/project/src/app/mfe/bootstrap.ts
@@ -131,7 +131,7 @@ export async function bootstrapMFE(
     action: {
       type: HAI3_ACTION_MOUNT_EXT,
       target: screenDomain.id,
-      payload: { extensionId: targetExtId },
+      payload: { subject: targetExtId },
     },
   });
 
@@ -154,7 +154,7 @@ export async function bootstrapMFE(
       chain.action.type === HAI3_ACTION_MOUNT_EXT &&
       chain.action.target === screenDomain.id
     ) {
-      const extensionId = chain.action.payload?.extensionId as string | undefined;
+      const extensionId = chain.action.payload?.subject as string | undefined;
       const route = screenRouteMap.get(extensionId ?? '');
       if (route && window.location.pathname !== route) {
         window.history.pushState(null, '', route);
@@ -171,7 +171,7 @@ export async function bootstrapMFE(
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: screenDomain.id,
-          payload: { extensionId: ext.id },
+          payload: { subject: ext.id },
         },
       });
     }

--- a/packages/framework/CLAUDE.md
+++ b/packages/framework/CLAUDE.md
@@ -97,7 +97,7 @@ const app = createHAI3App();
 app.screensetsRegistry.registerDomain(screenDomain, containerProvider);
 await app.screensetsRegistry.registerExtension(homeExtension);
 await app.screensetsRegistry.executeActionsChain({
-  action: { type: HAI3_ACTION_MOUNT_EXT, target: 'screen', payload: { extensionId: 'home' } }
+  action: { type: HAI3_ACTION_MOUNT_EXT, target: 'screen', payload: { subject: 'home' } }
 });
 
 // Access other registries
@@ -216,9 +216,9 @@ import {
 } from '@cyberfabric/framework';
 
 // Action IDs
-HAI3_ACTION_LOAD_EXT     // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1'
-HAI3_ACTION_MOUNT_EXT    // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1'
-HAI3_ACTION_UNMOUNT_EXT  // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1'
+HAI3_ACTION_LOAD_EXT     // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~'
+HAI3_ACTION_MOUNT_EXT    // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~'
+HAI3_ACTION_UNMOUNT_EXT  // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~'
 
 // Shared property IDs
 HAI3_SHARED_PROPERTY_THEME    // 'gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.theme.v1~'

--- a/packages/framework/__tests__/plugins/microfrontends.test.ts
+++ b/packages/framework/__tests__/plugins/microfrontends.test.ts
@@ -352,17 +352,17 @@ describe('microfrontends plugin - Phase 7.9', () => {
       expect(sidebarDomain.actions.length).toBe(3);
 
       // Verify action IDs
-      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1');
-      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1');
-      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1');
+      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~');
+      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~');
+      expect(sidebarDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~');
     });
 
     it('should handle screen domain with swap semantics (load_ext + mount_ext, no unmount_ext)', () => {
       // Screen domain should have load_ext and mount_ext, but not unmount_ext (swap semantics)
       expect(screenDomain.actions.length).toBe(2);
-      expect(screenDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1');
-      expect(screenDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1');
-      expect(screenDomain.actions).not.toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1');
+      expect(screenDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~');
+      expect(screenDomain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~');
+      expect(screenDomain.actions).not.toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~');
     });
   });
 
@@ -377,9 +377,9 @@ describe('microfrontends plugin - Phase 7.9', () => {
           'gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~',
         ],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 30000,
@@ -398,9 +398,9 @@ describe('microfrontends plugin - Phase 7.9', () => {
           'gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~',
         ],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 30000,
@@ -419,8 +419,8 @@ describe('microfrontends plugin - Phase 7.9', () => {
           'gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~',
         ],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 30000,
@@ -442,9 +442,9 @@ describe('microfrontends plugin - Phase 7.9', () => {
           'gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~',
         ],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 30000,

--- a/packages/framework/__tests__/plugins/microfrontends/dynamic-registration.test.ts
+++ b/packages/framework/__tests__/plugins/microfrontends/dynamic-registration.test.ts
@@ -63,8 +63,8 @@ describe('dynamic registration - Phase 20', () => {
     id: 'gts.hai3.mfes.ext.domain.v1~test.app.test.domain.v1',
     sharedProperties: [],
     actions: [
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
     ],
     extensionsActions: [],
     defaultActionTimeout: 5000,

--- a/packages/framework/__tests__/plugins/microfrontends/plugin.test.ts
+++ b/packages/framework/__tests__/plugins/microfrontends/plugin.test.ts
@@ -98,9 +98,9 @@ describe('microfrontends plugin - Phase 13', () => {
 
       expect(spy).toHaveBeenCalledWith({
         action: {
-          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
+          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
           target: testDomainId,
-          payload: { extensionId: testExtensionId },
+          payload: { subject: testExtensionId },
         },
       });
     });

--- a/packages/framework/src/plugins/microfrontends/actions.ts
+++ b/packages/framework/src/plugins/microfrontends/actions.ts
@@ -98,7 +98,7 @@ export function loadExtension(extensionId: string): void {
     action: {
       type: HAI3_ACTION_LOAD_EXT,
       target: domainId,
-      payload: { extensionId },
+      payload: { subject: extensionId },
     },
   }).catch((error) => {
     console.error(`[MFE] Load failed for ${extensionId}:`, error);
@@ -129,7 +129,7 @@ export function mountExtension(extensionId: string): void {
     action: {
       type: HAI3_ACTION_MOUNT_EXT,
       target: domainId,
-      payload: { extensionId },
+      payload: { subject: extensionId },
     },
   }).catch((error) => {
     console.error(`[MFE] Mount failed for ${extensionId}:`, error);
@@ -158,7 +158,7 @@ export function unmountExtension(extensionId: string): void {
     action: {
       type: HAI3_ACTION_UNMOUNT_EXT,
       target: domainId,
-      payload: { extensionId },
+      payload: { subject: extensionId },
     },
   }).catch((error) => {
     console.error(`[MFE] Unmount failed for ${extensionId}:`, error);

--- a/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/overlay.v1.json
+++ b/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/overlay.v1.json
@@ -5,9 +5,9 @@
     "gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~"
   ],
   "actions": [
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1"
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~"
   ],
   "extensionsActions": [],
   "defaultActionTimeout": 30000,

--- a/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/popup.v1.json
+++ b/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/popup.v1.json
@@ -5,9 +5,9 @@
     "gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~"
   ],
   "actions": [
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1"
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~"
   ],
   "extensionsActions": [],
   "defaultActionTimeout": 30000,

--- a/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/screen.v1.json
+++ b/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/screen.v1.json
@@ -5,8 +5,8 @@
     "gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~"
   ],
   "actions": [
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1"
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~"
   ],
   "extensionsActions": [],
   "extensionsTypeId": "gts.hai3.mfes.ext.extension.v1~hai3.screensets.layout.screen.v1~",

--- a/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/sidebar.v1.json
+++ b/packages/framework/src/plugins/microfrontends/gts/hai3.screensets/instances/domains/sidebar.v1.json
@@ -5,9 +5,9 @@
     "gts.hai3.mfes.comm.shared_property.v1~hai3.mfes.comm.language.v1~"
   ],
   "actions": [
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1",
-    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1"
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~",
+    "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~"
   ],
   "extensionsActions": [],
   "defaultActionTimeout": 30000,

--- a/packages/framework/src/plugins/microfrontends/index.ts
+++ b/packages/framework/src/plugins/microfrontends/index.ts
@@ -112,7 +112,7 @@ export function microfrontends(config: MicrofrontendsConfig): HAI3Plugin {
     if (actionType === HAI3_ACTION_MOUNT_EXT) {
       const store = getStore();
       const domainId = chain.action!.target;
-      const extensionId = chain.action!.payload?.extensionId as string;
+      const extensionId = typeof chain.action?.payload?.subject === 'string' ? chain.action.payload.subject : undefined;
       if (domainId && extensionId) {
         store.dispatch(setExtensionMounted({ domainId, extensionId }));
       }

--- a/packages/react/__tests__/mfe/hooks/useActivePackage.test.tsx
+++ b/packages/react/__tests__/mfe/hooks/useActivePackage.test.tsx
@@ -51,9 +51,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
     id: HAI3_SCREEN_DOMAIN,
     sharedProperties: [],
     actions: [
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
     ],
     extensionsActions: [],
     defaultActionTimeout: 5000,
@@ -102,13 +102,13 @@ describe('useActivePackage hook - Phase 39.6', () => {
     // Mock mount/unmount to track state and dispatch
     app.screensetsRegistry.executeActionsChain = vi.fn(async (chain) => {
       const action = chain.action;
-      if (action.type === 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1') {
-        const payload = action.payload as { extensionId: string };
+      if (action.type === 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~') {
+        const payload = action.payload as { subject: string };
         if (action.target === HAI3_SCREEN_DOMAIN) {
-          mountedExtensionId = payload.extensionId;
-          app.store.dispatch({ type: 'mfe/setExtensionMounted', payload: { extensionId: payload.extensionId, domainId: HAI3_SCREEN_DOMAIN } });
+          mountedExtensionId = payload.subject;
+          app.store.dispatch({ type: 'mfe/setExtensionMounted', payload: { subject: payload.subject, domainId: HAI3_SCREEN_DOMAIN } });
         }
-      } else if (action.type === 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1') {
+      } else if (action.type === 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~') {
         if (action.target === HAI3_SCREEN_DOMAIN) {
           mountedExtensionId = undefined;
           app.store.dispatch({ type: 'mfe/setExtensionUnmounted', payload: { domainId: HAI3_SCREEN_DOMAIN } });
@@ -142,9 +142,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
       // Mount demo extension
       await app.screensetsRegistry.executeActionsChain({
         action: {
-          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
           target: HAI3_SCREEN_DOMAIN,
-          payload: { extensionId: demoExtension.id },
+          payload: { subject: demoExtension.id },
         },
       });
 
@@ -175,9 +175,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
       await act(async () => {
         await app.screensetsRegistry.executeActionsChain({
           action: {
-            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
             target: HAI3_SCREEN_DOMAIN,
-            payload: { extensionId: demoExtension.id },
+            payload: { subject: demoExtension.id },
           },
         });
       });
@@ -195,9 +195,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
       // Mount demo extension
       await app.screensetsRegistry.executeActionsChain({
         action: {
-          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
           target: HAI3_SCREEN_DOMAIN,
-          payload: { extensionId: demoExtension.id },
+          payload: { subject: demoExtension.id },
         },
       });
 
@@ -208,9 +208,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
       await act(async () => {
         await app.screensetsRegistry.executeActionsChain({
           action: {
-            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
             target: HAI3_SCREEN_DOMAIN,
-            payload: { extensionId: demoExtension.id },
+            payload: { subject: demoExtension.id },
           },
         });
       });
@@ -228,9 +228,9 @@ describe('useActivePackage hook - Phase 39.6', () => {
       // Mount demo extension
       await app.screensetsRegistry.executeActionsChain({
         action: {
-          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+          type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
           target: HAI3_SCREEN_DOMAIN,
-          payload: { extensionId: demoExtension.id },
+          payload: { subject: demoExtension.id },
         },
       });
 
@@ -242,18 +242,18 @@ describe('useActivePackage hook - Phase 39.6', () => {
         // Unmount demo
         await app.screensetsRegistry.executeActionsChain({
           action: {
-            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
             target: HAI3_SCREEN_DOMAIN,
-            payload: { extensionId: demoExtension.id },
+            payload: { subject: demoExtension.id },
           },
         });
 
         // Mount other
         await app.screensetsRegistry.executeActionsChain({
           action: {
-            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+            type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
             target: HAI3_SCREEN_DOMAIN,
-            payload: { extensionId: otherExtension.id },
+            payload: { subject: otherExtension.id },
           },
         });
       });

--- a/packages/react/__tests__/mfe/hooks/useDomainExtensions.test.tsx
+++ b/packages/react/__tests__/mfe/hooks/useDomainExtensions.test.tsx
@@ -53,8 +53,8 @@ describe('useDomainExtensions hook - Phase 21.7', () => {
     id: sidebarDomainId,
     sharedProperties: [],
     actions: [
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
     ],
     extensionsActions: [],
     defaultActionTimeout: 5000,
@@ -66,8 +66,8 @@ describe('useDomainExtensions hook - Phase 21.7', () => {
     id: popupDomainId,
     sharedProperties: [],
     actions: [
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
     ],
     extensionsActions: [],
     defaultActionTimeout: 5000,

--- a/packages/react/__tests__/mfe/hooks/useRegisteredPackages.test.tsx
+++ b/packages/react/__tests__/mfe/hooks/useRegisteredPackages.test.tsx
@@ -52,8 +52,8 @@ describe('useRegisteredPackages hook - Phase 39.6', () => {
     id: testDomainId,
     sharedProperties: [],
     actions: [
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+      'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
     ],
     extensionsActions: [],
     defaultActionTimeout: 5000,

--- a/packages/screensets/CLAUDE.md
+++ b/packages/screensets/CLAUDE.md
@@ -51,13 +51,13 @@ await registry.registerExtension(homeExtension);
 
 // Load, mount, unmount via executeActionsChain (the public API)
 await registry.executeActionsChain({
-  action: { type: HAI3_ACTION_LOAD_EXT, target: screenDomainId, payload: { extensionId: 'ext-id' } }
+  action: { type: HAI3_ACTION_LOAD_EXT, target: screenDomainId, payload: { subject: 'ext-id' } }
 });
 await registry.executeActionsChain({
-  action: { type: HAI3_ACTION_MOUNT_EXT, target: screenDomainId, payload: { extensionId: 'ext-id' } }
+  action: { type: HAI3_ACTION_MOUNT_EXT, target: screenDomainId, payload: { subject: 'ext-id' } }
 });
 await registry.executeActionsChain({
-  action: { type: HAI3_ACTION_UNMOUNT_EXT, target: screenDomainId, payload: { extensionId: 'ext-id' } }
+  action: { type: HAI3_ACTION_UNMOUNT_EXT, target: screenDomainId, payload: { subject: 'ext-id' } }
 });
 ```
 
@@ -114,7 +114,7 @@ import { ParentMfeBridge, ChildMfeBridge } from '@cyberfabric/screensets';
 
 // Example: child MFE executes an actions chain
 await bridge.executeActionsChain({
-  action: { type: HAI3_ACTION_MOUNT_EXT, target: 'screen', payload: { extensionId: 'other' } }
+  action: { type: HAI3_ACTION_MOUNT_EXT, target: 'screen', payload: { subject: 'other' } }
 });
 
 // Example: child MFE subscribes to theme changes
@@ -138,9 +138,9 @@ import {
 } from '@cyberfabric/screensets';
 
 // Action IDs
-HAI3_ACTION_LOAD_EXT     // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1'
-HAI3_ACTION_MOUNT_EXT    // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1'
-HAI3_ACTION_UNMOUNT_EXT  // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1'
+HAI3_ACTION_LOAD_EXT     // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~'
+HAI3_ACTION_MOUNT_EXT    // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~'
+HAI3_ACTION_UNMOUNT_EXT  // 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~'
 ```
 
 ## Shared Property Constants

--- a/packages/screensets/__tests__/mfe/gts/utilities.test.ts
+++ b/packages/screensets/__tests__/mfe/gts/utilities.test.ts
@@ -41,23 +41,23 @@ describe('HAI3 constants values', () => {
     });
   });
 
-  describe('action instance IDs', () => {
-    it('should have correct action instance IDs', () => {
+  describe('action schema type IDs', () => {
+    it('should have correct action schema type IDs', () => {
       expect(HAI3_ACTION_LOAD_EXT).toBe(
-        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1'
+        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~'
       );
       expect(HAI3_ACTION_MOUNT_EXT).toBe(
-        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1'
+        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~'
       );
       expect(HAI3_ACTION_UNMOUNT_EXT).toBe(
-        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1'
+        'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~'
       );
     });
 
-    it('should confirm action IDs do not end with ~', () => {
-      expect(HAI3_ACTION_LOAD_EXT.endsWith('~')).toBe(false);
-      expect(HAI3_ACTION_MOUNT_EXT.endsWith('~')).toBe(false);
-      expect(HAI3_ACTION_UNMOUNT_EXT.endsWith('~')).toBe(false);
+    it('should confirm action schema type IDs end with ~', () => {
+      expect(HAI3_ACTION_LOAD_EXT.endsWith('~')).toBe(true);
+      expect(HAI3_ACTION_MOUNT_EXT.endsWith('~')).toBe(true);
+      expect(HAI3_ACTION_UNMOUNT_EXT.endsWith('~')).toBe(true);
     });
   });
 });

--- a/packages/screensets/__tests__/mfe/mediator/actions-chains-mediator.test.ts
+++ b/packages/screensets/__tests__/mfe/mediator/actions-chains-mediator.test.ts
@@ -53,12 +53,11 @@ function createMockPlugin(): TypeSystemPlugin {
     },
     getSchema: (typeId: string) => schemas.get(typeId),
     register: (entity: unknown) => {
-      const entityWithId = entity as { id?: string; type?: string };
-      // Actions use 'type' field as identifier, others use 'id'
-      const identifier = entityWithId.type || entityWithId.id;
-      if (identifier) {
-        registeredEntities.set(identifier, entity);
-      }
+      const entityWithId = entity as { id?: string };
+      // GTS assigns id='' for anonymous instances (e.g. actions which have 'type' but no 'id').
+      // Store by entity.id so that validateInstance('') finds anonymous registrations.
+      const identifier = entityWithId.id ?? '';
+      registeredEntities.set(identifier, entity);
     },
     validateInstance: (instanceId: string): ValidationResult => {
       if (registeredEntities.has(instanceId)) {

--- a/packages/screensets/__tests__/mfe/runtime/domain-registration.test.ts
+++ b/packages/screensets/__tests__/mfe/runtime/domain-registration.test.ts
@@ -127,9 +127,9 @@ describe('Domain Registration', () => {
         id: 'gts.hai3.mfes.ext.domain.v1~hai3.screensets.layout.sidebar.v1',
         sharedProperties: [],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 5000,
@@ -153,8 +153,8 @@ describe('Domain Registration', () => {
 
       const domainState = registry.getDomainState(sidebarDomain.id);
       expect(domainState).toBeDefined();
-      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1');
-      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1');
+      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~');
+      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~');
     });
 
     it('should successfully register screen domain (load_ext only)', () => {
@@ -162,8 +162,8 @@ describe('Domain Registration', () => {
         id: 'gts.hai3.mfes.ext.domain.v1~hai3.screensets.layout.screen.v1',
         sharedProperties: [],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
           // Note: NO unmount_ext for screen domain (swap semantics)
         ],
         extensionsActions: [],
@@ -188,8 +188,8 @@ describe('Domain Registration', () => {
 
       const domainState = registry.getDomainState(screenDomain.id);
       expect(domainState).toBeDefined();
-      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1');
-      expect(domainState?.domain.actions).not.toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1');
+      expect(domainState?.domain.actions).toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~');
+      expect(domainState?.domain.actions).not.toContain('gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~');
     });
 
     it('should successfully register popup domain', () => {
@@ -197,9 +197,9 @@ describe('Domain Registration', () => {
         id: 'gts.hai3.mfes.ext.domain.v1~hai3.screensets.layout.popup.v1',
         sharedProperties: [],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 5000,
@@ -227,9 +227,9 @@ describe('Domain Registration', () => {
         id: 'gts.hai3.mfes.ext.domain.v1~hai3.screensets.layout.overlay.v1',
         sharedProperties: [],
         actions: [
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1',
-          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
+          'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~',
         ],
         extensionsActions: [],
         defaultActionTimeout: 5000,

--- a/packages/screensets/__tests__/mfe/runtime/dynamic-registration.test.ts
+++ b/packages/screensets/__tests__/mfe/runtime/dynamic-registration.test.ts
@@ -164,7 +164,7 @@ describe('Dynamic Registration', () => {
           action: {
             type: HAI3_ACTION_LOAD_EXT,
             target: testDomain.id,
-            payload: { extensionId: 'nonexistent' },
+            payload: { subject: 'nonexistent' },
           },
         })
       ).rejects.toThrow();
@@ -201,7 +201,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -209,7 +209,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_UNMOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -217,7 +217,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -256,7 +256,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -312,7 +312,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -340,7 +340,7 @@ describe('Dynamic Registration', () => {
           action: {
             type: HAI3_ACTION_MOUNT_EXT,
             target: testDomain.id,
-            payload: { extensionId: 'nonexistent' },
+            payload: { subject: 'nonexistent' },
           },
         })
       ).rejects.toThrow();
@@ -367,7 +367,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -375,7 +375,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_UNMOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -389,7 +389,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -444,7 +444,7 @@ describe('Dynamic Registration', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 

--- a/packages/screensets/__tests__/mfe/runtime/extension-lifecycle-actions.test.ts
+++ b/packages/screensets/__tests__/mfe/runtime/extension-lifecycle-actions.test.ts
@@ -153,7 +153,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_LOAD_EXT, {
-          extensionId: testExtension1.id,
+          subject: testExtension1.id,
         });
 
         expect(callbacks.loadExtension).toHaveBeenCalledWith(testExtension1.id);
@@ -191,7 +191,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension1.id,
+          subject: testExtension1.id,
         });
 
         expect(callbacks.mountExtension).toHaveBeenCalledWith(testExtension1.id, mockContainerProvider.mockContainer);
@@ -223,7 +223,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension1.id,
+          subject: testExtension1.id,
         });
 
         // Toggle domains do not use handleScreenSwap, so serializeOnDomain is not called
@@ -247,7 +247,7 @@ describe('Extension Lifecycle Actions', () => {
         const newExtId = 'gts.hai3.mfes.ext.extension.v1~test.lifecycle.actions.ext3.v1';
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: newExtId,
+          subject: newExtId,
         });
 
         // Verify unmount was called first, then mount
@@ -275,7 +275,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension2.id,
+          subject: testExtension2.id,
         });
 
         expect(callbacks.unmountExtension).not.toHaveBeenCalled();
@@ -293,7 +293,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension2.id,
+          subject: testExtension2.id,
         });
 
         // Verify unmount was NOT called
@@ -312,7 +312,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension2.id,
+          subject: testExtension2.id,
         });
 
         // serializeOnDomain must be called with the domain ID
@@ -359,8 +359,8 @@ describe('Extension Lifecycle Actions', () => {
         const ext2Id = 'gts.hai3.mfes.ext.extension.v1~test.concurrent.ext2.v1';
 
         // Fire two swaps concurrently
-        const swap1 = handler.handleAction(HAI3_ACTION_MOUNT_EXT, { extensionId: ext1Id });
-        const swap2 = handler.handleAction(HAI3_ACTION_MOUNT_EXT, { extensionId: ext2Id });
+        const swap1 = handler.handleAction(HAI3_ACTION_MOUNT_EXT, { subject: ext1Id });
+        const swap2 = handler.handleAction(HAI3_ACTION_MOUNT_EXT, { subject: ext2Id });
 
         await Promise.all([swap1, swap2]);
 
@@ -386,7 +386,7 @@ describe('Extension Lifecycle Actions', () => {
         );
 
         await handler.handleAction(HAI3_ACTION_UNMOUNT_EXT, {
-          extensionId: testExtension1.id,
+          subject: testExtension1.id,
         });
 
         expect(callbacks.unmountExtension).toHaveBeenCalledWith(testExtension1.id);
@@ -460,7 +460,7 @@ describe('Extension Lifecycle Actions', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: toggleDomain.id,
-          payload: { extensionId: testExtension1.id },
+          payload: { subject: testExtension1.id },
         },
       });
 
@@ -503,7 +503,7 @@ describe('Extension Lifecycle Actions', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: toggleDomain.id,
-          payload: { extensionId: testExtension1.id },
+          payload: { subject: testExtension1.id },
         },
       });
 
@@ -515,7 +515,7 @@ describe('Extension Lifecycle Actions', () => {
         action: {
           type: HAI3_ACTION_UNMOUNT_EXT,
           target: toggleDomain.id,
-          payload: { extensionId: testExtension1.id },
+          payload: { subject: testExtension1.id },
         },
       });
 
@@ -601,7 +601,7 @@ describe('Extension Lifecycle Actions', () => {
 
       // Mount extension
       await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-        extensionId: testExtension1.id,
+        subject: testExtension1.id,
       });
 
       // Verify getContainer was called with correct extensionId
@@ -610,7 +610,7 @@ describe('Extension Lifecycle Actions', () => {
 
       // Unmount extension
       await handler.handleAction(HAI3_ACTION_UNMOUNT_EXT, {
-        extensionId: testExtension1.id,
+        subject: testExtension1.id,
       });
 
       // Verify releaseContainer was called with correct extensionId
@@ -633,7 +633,7 @@ describe('Extension Lifecycle Actions', () => {
 
       // Mount first extension
       await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-        extensionId: testExtension2.id,
+        subject: testExtension2.id,
       });
 
       expect(getContainerSpy).toHaveBeenCalledWith(testExtension2.id);
@@ -649,7 +649,7 @@ describe('Extension Lifecycle Actions', () => {
 
       // Mount second extension (should unmount first due to swap semantics)
       await handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-        extensionId: testExtension3Id,
+        subject: testExtension3Id,
       });
 
       // Verify call order: releaseContainer(ext2), getContainer(ext3)
@@ -681,7 +681,7 @@ describe('Extension Lifecycle Actions', () => {
       // Attempt to mount (should propagate error)
       await expect(
         handler.handleAction(HAI3_ACTION_MOUNT_EXT, {
-          extensionId: testExtension1.id,
+          subject: testExtension1.id,
         })
       ).rejects.toThrow('Container creation failed');
     });

--- a/packages/screensets/__tests__/mfe/runtime/lifecycle-triggering.test.ts
+++ b/packages/screensets/__tests__/mfe/runtime/lifecycle-triggering.test.ts
@@ -318,7 +318,7 @@ describe('Lifecycle Stage Triggering', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -358,7 +358,7 @@ describe('Lifecycle Stage Triggering', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 
@@ -370,7 +370,7 @@ describe('Lifecycle Stage Triggering', () => {
         action: {
           type: HAI3_ACTION_UNMOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: testExtension.id },
+          payload: { subject: testExtension.id },
         },
       });
 

--- a/packages/screensets/__tests__/mfe/runtime/phase41-regression.test.ts
+++ b/packages/screensets/__tests__/mfe/runtime/phase41-regression.test.ts
@@ -152,7 +152,7 @@ describe('Phase 41 Regression Tests', () => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: testDomain.id,
-          payload: { extensionId: nonExistentExtensionId },
+          payload: { subject: nonExistentExtensionId },
         },
       });
 
@@ -175,7 +175,7 @@ describe('Phase 41 Regression Tests', () => {
           action: {
             type: HAI3_ACTION_MOUNT_EXT,
             target: testDomain.id,
-            payload: { extensionId: nonExistentExtensionId },
+            payload: { subject: nonExistentExtensionId },
           },
         })
       ).resolves.toBeUndefined();
@@ -184,20 +184,21 @@ describe('Phase 41 Regression Tests', () => {
 
   describe('41.5.4 - executeActionsChain does not log on successful chain', () => {
     it('should not log console.error when actions chain succeeds', async () => {
-      // Create a custom action type and register it with GTS
-      const customActionId = 'gts.hai3.mfes.comm.action.v1~hai3.test.phase41.custom_action.v1';
-      gtsPlugin.register({
-        id: customActionId,
-        type: customActionId,
-        target: testDomain.id,
-        payload: {},
+      // Register a custom action as a SCHEMA (type ID ends with ~) so GTS accepts it.
+      // Actions must be schemas; registering as instances (no trailing ~) causes GTS to
+      // reject validation with "not a schema".
+      const customActionSchemaId = 'gts.hai3.mfes.comm.action.v1~hai3.test.phase41.custom_action.v1~';
+      gtsPlugin.registerSchema({
+        $id: `gts://${customActionSchemaId}`,
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
       });
 
       // Register domain with a custom action
       const customDomain: ExtensionDomain = {
         id: 'gts.hai3.mfes.ext.domain.v1~hai3.test.phase41.custom_domain.v1',
         sharedProperties: [],
-        actions: [customActionId],
+        actions: [customActionSchemaId],
         extensionsActions: [],
         defaultActionTimeout: 3000,
         lifecycleStages: [
@@ -210,12 +211,12 @@ describe('Phase 41 Regression Tests', () => {
       gtsPlugin.register(customDomain);
       registry.registerDomain(customDomain, mockContainerProvider);
 
-      // Execute successful actions chain with a mocked domain handler
-      // The domain handler will be automatically created by the registry for the domain
-      // We just need to execute an action that the domain can handle
+      // Execute successful actions chain with a mocked domain handler.
+      // The domain handler will be automatically created by the registry for the domain.
+      // We just need to execute an action that the domain can handle.
       await registry.executeActionsChain({
         action: {
-          type: customActionId,
+          type: customActionSchemaId,
           target: customDomain.id,
           payload: {},
         },

--- a/packages/screensets/docs/mfe/example-mfe.md
+++ b/packages/screensets/docs/mfe/example-mfe.md
@@ -124,7 +124,7 @@ export const analyticsManifestSchema: JSONSchema = {
 ```typescript
 // Type IDs (reference only - no runtime generation)
 export const TYPE_IDS = {
-  // Actions
+  // Actions (instance IDs - no trailing ~)
   DATA_UPDATED: 'gts.hai3.mfes.comm.action.v1~acme.analytics.comm.data_updated.v1',
   REFRESH_REQUEST: 'gts.hai3.mfes.comm.action.v1~acme.analytics.comm.refresh_request.v1',
 
@@ -457,9 +457,9 @@ export async function registerAnalyticsMfe(runtime: ScreensetsRegistry) {
   // Step 6: Mount via actions chain (auto-loads if needed)
   await runtime.executeActionsChain({
     action: {
-      type: 'gts.hai3.mfes.ext.action.v1~hai3.mfes.ext.mount_ext.v1',
+      type: 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~',
       target: extension.domain,
-      payload: { extensionId: extension.id },
+      payload: { subject: extension.id },
     },
   });
 
@@ -500,10 +500,10 @@ await registry.registerDomain({
     'gts.hai3.mfes.comm.shared_property.v1~acme.analytics.theme.v1',
   ],
   actions: [
-    'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1',
+    'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~',
   ],
   extensionsActions: [
-    'gts.hai3.mfes.comm.action.v1~acme.analytics.comm.data_updated.v1',
+    'gts.hai3.mfes.comm.action.v1~acme.analytics.comm.data_updated.v1~',
   ],
   defaultActionTimeout: 5000,
   lifecycleStages: [

--- a/packages/screensets/src/mfe/constants/index.ts
+++ b/packages/screensets/src/mfe/constants/index.ts
@@ -55,26 +55,26 @@ export const HAI3_SCREEN_EXTENSION_TYPE = 'gts.hai3.mfes.ext.extension.v1~hai3.s
 export const HAI3_EXT_ACTION = 'gts.hai3.mfes.comm.action.v1~';
 
 // ============================================================================
-// Action Instance IDs (generic actions for all domains)
+// Action Schema Type IDs (generic actions for all domains)
 // ============================================================================
 
 /**
- * Load extension action instance ID.
+ * Load extension action schema type ID.
  * Preload an extension's bundle (fetch JS, no DOM rendering).
  */
-export const HAI3_ACTION_LOAD_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1';
+export const HAI3_ACTION_LOAD_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~';
 
 /**
- * Mount extension action instance ID.
+ * Mount extension action schema type ID.
  * Mount an extension into a domain (render to DOM).
  */
-export const HAI3_ACTION_MOUNT_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1';
+export const HAI3_ACTION_MOUNT_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~';
 
 /**
- * Unmount extension action instance ID.
+ * Unmount extension action schema type ID.
  * Unmount an extension from a domain (remove from DOM).
  */
-export const HAI3_ACTION_UNMOUNT_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1';
+export const HAI3_ACTION_UNMOUNT_EXT = 'gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~';
 
 // ============================================================================
 // Shared Property Type IDs (built-in property schemas for all domains)

--- a/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/load_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/load_ext.v1.json
@@ -1,5 +1,0 @@
-{
-  "id": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-  "type": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1",
-  "target": ""
-}

--- a/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/mount_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/mount_ext.v1.json
@@ -1,5 +1,0 @@
-{
-  "id": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1",
-  "type": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1",
-  "target": ""
-}

--- a/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/unmount_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/instances/ext/unmount_ext.v1.json
@@ -1,5 +1,0 @@
-{
-  "id": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1",
-  "type": "gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1",
-  "target": ""
-}

--- a/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/load_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/load_ext.v1.json
@@ -1,0 +1,36 @@
+{
+  "$id": "gts://gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.load_ext.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Schema for load_ext extension actions. Derives from action.v1 and requires a subject extension reference in payload.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "x-gts-ref": "/$id",
+      "$comment": "Self-reference to this action's schema type ID"
+    },
+    "target": {
+      "oneOf": [
+        { "x-gts-ref": "gts.hai3.mfes.ext.domain.v1~*" },
+        { "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*" }
+      ],
+      "$comment": "Type ID of the target ExtensionDomain or Extension"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*",
+          "$comment": "Extension ID that this action targets"
+        }
+      },
+      "required": ["subject"],
+      "$comment": "Action payload with required extension reference"
+    },
+    "timeout": {
+      "type": "number",
+      "minimum": 1,
+      "$comment": "Optional timeout override in milliseconds"
+    }
+  },
+  "required": ["type", "target", "payload"]
+}

--- a/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/mount_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/mount_ext.v1.json
@@ -1,0 +1,36 @@
+{
+  "$id": "gts://gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.mount_ext.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Schema for mount_ext extension actions. Derives from action.v1 and requires a subject extension reference in payload.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "x-gts-ref": "/$id",
+      "$comment": "Self-reference to this action's schema type ID"
+    },
+    "target": {
+      "oneOf": [
+        { "x-gts-ref": "gts.hai3.mfes.ext.domain.v1~*" },
+        { "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*" }
+      ],
+      "$comment": "Type ID of the target ExtensionDomain or Extension"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*",
+          "$comment": "Extension ID that this action targets"
+        }
+      },
+      "required": ["subject"],
+      "$comment": "Action payload with required extension reference"
+    },
+    "timeout": {
+      "type": "number",
+      "minimum": 1,
+      "$comment": "Optional timeout override in milliseconds"
+    }
+  },
+  "required": ["type", "target", "payload"]
+}

--- a/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/unmount_ext.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/schemas/ext/unmount_ext.v1.json
@@ -1,0 +1,36 @@
+{
+  "$id": "gts://gts.hai3.mfes.comm.action.v1~hai3.mfes.ext.unmount_ext.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Schema for unmount_ext extension actions. Derives from action.v1 and requires a subject extension reference in payload.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "x-gts-ref": "/$id",
+      "$comment": "Self-reference to this action's schema type ID"
+    },
+    "target": {
+      "oneOf": [
+        { "x-gts-ref": "gts.hai3.mfes.ext.domain.v1~*" },
+        { "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*" }
+      ],
+      "$comment": "Type ID of the target ExtensionDomain or Extension"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "x-gts-ref": "gts.hai3.mfes.ext.extension.v1~*",
+          "$comment": "Extension ID that this action targets"
+        }
+      },
+      "required": ["subject"],
+      "$comment": "Action payload with required extension reference"
+    },
+    "timeout": {
+      "type": "number",
+      "minimum": 1,
+      "$comment": "Optional timeout override in milliseconds"
+    }
+  },
+  "required": ["type", "target", "payload"]
+}

--- a/packages/screensets/src/mfe/gts/loader.ts
+++ b/packages/screensets/src/mfe/gts/loader.ts
@@ -8,7 +8,7 @@
  */
 
 import type { JSONSchema } from '../plugins/types';
-import type { LifecycleStage, Action } from '../types';
+import type { LifecycleStage } from '../types';
 
 // Import all schema JSON files
 import entrySchema from './hai3.mfes/schemas/mfe/entry.v1.json';
@@ -22,20 +22,20 @@ import lifecycleHookSchema from './hai3.mfes/schemas/lifecycle/hook.v1.json';
 import manifestSchema from './hai3.mfes/schemas/mfe/mf_manifest.v1.json';
 import entryMfSchema from './hai3.mfes/schemas/mfe/entry_mf.v1.json';
 
+// Import action schema JSON files (derived from action.v1, each requires payload.subject)
+import loadExtActionSchema from './hai3.mfes/schemas/ext/load_ext.v1.json';
+import mountExtActionSchema from './hai3.mfes/schemas/ext/mount_ext.v1.json';
+import unmountExtActionSchema from './hai3.mfes/schemas/ext/unmount_ext.v1.json';
+
 // Import lifecycle stage instances
 import lifecycleInitInstance from './hai3.mfes/instances/lifecycle/init.v1.json';
 import lifecycleActivatedInstance from './hai3.mfes/instances/lifecycle/activated.v1.json';
 import lifecycleDeactivatedInstance from './hai3.mfes/instances/lifecycle/deactivated.v1.json';
 import lifecycleDestroyedInstance from './hai3.mfes/instances/lifecycle/destroyed.v1.json';
 
-// Import action instances
-import loadExtActionInstance from './hai3.mfes/instances/ext/load_ext.v1.json';
-import mountExtActionInstance from './hai3.mfes/instances/ext/mount_ext.v1.json';
-import unmountExtActionInstance from './hai3.mfes/instances/ext/unmount_ext.v1.json';
-
 /**
  * Load all core MFE schema JSON files.
- * These are the 10 core schemas (8 core + 2 MF-specific).
+ * Returns 13 schemas: 8 core + 2 MF-specific + 3 extension action schemas.
  *
  * Application-specific derived schemas (theme, language, extension_screen) are
  * registered at the application layer via @cyberfabric/framework.
@@ -56,6 +56,10 @@ export function loadSchemas(): JSONSchema[] {
     // MF-specific types (2)
     manifestSchema as JSONSchema,
     entryMfSchema as JSONSchema,
+    // Extension action schemas (3) — derived from action.v1, require payload.subject
+    loadExtActionSchema as JSONSchema,
+    mountExtActionSchema as JSONSchema,
+    unmountExtActionSchema as JSONSchema,
   ];
 }
 
@@ -72,18 +76,4 @@ export function loadLifecycleStages(): LifecycleStage[] {
     lifecycleDeactivatedInstance,
     lifecycleDestroyedInstance,
   ] as LifecycleStage[];
-}
-
-/**
- * Load base action instances.
- * These are the generic extension lifecycle actions used by all domains.
- *
- * @returns Array of action instances
- */
-export function loadBaseActions(): Action[] {
-  return [
-    loadExtActionInstance,
-    mountExtActionInstance,
-    unmountExtActionInstance,
-  ] as Action[];
 }

--- a/packages/screensets/src/mfe/mediator/actions-chains-mediator.ts
+++ b/packages/screensets/src/mfe/mediator/actions-chains-mediator.ts
@@ -154,14 +154,13 @@ export class DefaultActionsChainsMediator extends ActionsChainsMediator {
       throw new Error('Chain timeout exceeded');
     }
 
-    // Register and validate the action instance
-    // Actions use their `type` field as the GTS entity identifier (no synthetic IDs)
-    // See design/mfe-actions.md line 88: MUST NOT generate synthetic IDs
-    // Note: createJsonEntity (in gts-ts) uses the `id` field for entity registration.
-    // Runtime actions only have `type`, so we set `id = type` to ensure the runtime
-    // action overwrites the pre-registered base action template.
-    this.typeSystem.register({ ...action, id: action.type });
-    const validation = this.typeSystem.validateInstance(action.type);
+    // Register and validate the action instance using the GTS anonymous instance pattern.
+    // Actions have a `type` field but no `id` field. GTS assigns id='' to entities
+    // without an explicit id (createJsonEntity default). For such instances GTS
+    // resolves the schema from the `type` field via schemaIdFields, so validation
+    // against the action's own schema happens without any synthetic ID injection.
+    this.typeSystem.register(action);
+    const validation = this.typeSystem.validateInstance('');
 
     if (!validation.valid) {
       const errorMsg = validation.errors.map(e => e.message).join(', ');

--- a/packages/screensets/src/mfe/plugins/gts/index.ts
+++ b/packages/screensets/src/mfe/plugins/gts/index.ts
@@ -27,7 +27,7 @@ import type {
   ValidationResult,
   JSONSchema,
 } from '../types';
-import { loadSchemas, loadLifecycleStages, loadBaseActions } from '../../gts/loader';
+import { loadSchemas, loadLifecycleStages } from '../../gts/loader';
 
 /**
  * Concrete GTS plugin class implementing TypeSystemPlugin.
@@ -50,8 +50,9 @@ export class GtsPlugin implements TypeSystemPlugin {
   constructor() {
     this.gtsStore = new GtsStore();
 
-    // Load and register all first-class citizen schemas from JSON files (13 schemas)
-    // These schemas are stored in packages/screensets/src/mfe/gts/hai3.mfe/schemas/
+    // Load and register all first-class citizen schemas from JSON files
+    // 13 schemas total: 8 core + 2 MF-specific + 3 extension action schemas
+    // These schemas are stored in packages/screensets/src/mfe/gts/hai3.mfes/schemas/
     const schemas = loadSchemas();
     for (const schema of schemas) {
       const entity: JsonEntity = createJsonEntity(schema);
@@ -66,12 +67,14 @@ export class GtsPlugin implements TypeSystemPlugin {
       this.gtsStore.register(entity);
     }
 
-    // Load and register base action instances from JSON files (3 instances)
-    // These instances are stored in packages/screensets/src/mfe/gts/hai3.mfe/instances/ext/
-    const baseActions = loadBaseActions();
-    for (const action of baseActions) {
-      const entity: JsonEntity = createJsonEntity(action);
-      this.gtsStore.register(entity);
+    // Validate all registered lifecycle stage instances against their schemas
+    for (const instance of lifecycleStages) {
+      const result = this.gtsStore.validateInstance(instance.id);
+      if (!result.ok || !result.valid) {
+        throw new Error(
+          `GTS validation failed for lifecycle stage '${instance.id}': ${result.error ?? 'invalid'}`
+        );
+      }
     }
 
   }

--- a/packages/screensets/src/mfe/runtime/extension-lifecycle-action-handler.ts
+++ b/packages/screensets/src/mfe/runtime/extension-lifecycle-action-handler.ts
@@ -114,14 +114,14 @@ export class ExtensionLifecycleActionHandler implements ActionHandler {
     switch (actionTypeId) {
       case HAI3_ACTION_LOAD_EXT: {
         this.requirePayload(actionTypeId, payload);
-        const extensionId = this.requireExtensionId(payload);
+        const extensionId = this.requireSubject(payload);
         await this.callbacks.loadExtension(extensionId);
         break;
       }
 
       case HAI3_ACTION_MOUNT_EXT: {
         this.requirePayload(actionTypeId, payload);
-        const extensionId = this.requireExtensionId(payload);
+        const extensionId = this.requireSubject(payload);
         if (this.domainSemantics === 'swap') {
           await this.handleScreenSwap(extensionId);
         } else {
@@ -134,7 +134,7 @@ export class ExtensionLifecycleActionHandler implements ActionHandler {
 
       case HAI3_ACTION_UNMOUNT_EXT: {
         this.requirePayload(actionTypeId, payload);
-        const extensionId = this.requireExtensionId(payload);
+        const extensionId = this.requireSubject(payload);
         await this.callbacks.unmountExtension(extensionId);
         this.containerProvider.releaseContainer(extensionId);
         break;
@@ -163,15 +163,15 @@ export class ExtensionLifecycleActionHandler implements ActionHandler {
     }
   }
 
-  private requireExtensionId(payload: Record<string, unknown>): string {
-    const { extensionId } = payload;
-    if (typeof extensionId !== 'string' || extensionId.length === 0) {
+  private requireSubject(payload: Record<string, unknown>): string {
+    const { subject } = payload;
+    if (typeof subject !== 'string' || subject.length === 0) {
       throw new MfeError(
-        'Action payload must contain a non-empty "extensionId" string',
+        'Action payload must contain a non-empty "subject" string',
         'LIFECYCLE_ACTION_INVALID_PAYLOAD'
       );
     }
-    return extensionId;
+    return subject;
   }
 
   // @cpt-begin:cpt-frontx-algo-screenset-registry-domain-semantics:p1:inst-1

--- a/packages/screensets/src/mfe/types/action-payloads.ts
+++ b/packages/screensets/src/mfe/types/action-payloads.ts
@@ -2,6 +2,8 @@
  * Action Payload Types
  *
  * Typed payload interfaces for extension lifecycle actions.
+ * The `subject` field carries an extension ID and is enforced at runtime
+ * via GTS schema validation (payload.subject with x-gts-ref to extension type).
  *
  * @packageDocumentation
  */
@@ -11,8 +13,8 @@
  * Preload an extension's bundle without mounting.
  */
 export interface LoadExtPayload {
-  /** The extension ID to load */
-  extensionId: string;
+  /** The extension ID to load (GTS subject reference) */
+  subject: string;
 }
 
 /**
@@ -24,8 +26,8 @@ export interface LoadExtPayload {
  * references), and shifts container management responsibility to the domain.
  */
 export interface MountExtPayload {
-  /** The extension ID to mount */
-  extensionId: string;
+  /** The extension ID to mount (GTS subject reference) */
+  subject: string;
 }
 
 /**
@@ -33,6 +35,6 @@ export interface MountExtPayload {
  * Unmount an extension from its container.
  */
 export interface UnmountExtPayload {
-  /** The extension ID to unmount */
-  extensionId: string;
+  /** The extension ID to unmount (GTS subject reference) */
+  subject: string;
 }

--- a/packages/screensets/src/mfe/types/action.ts
+++ b/packages/screensets/src/mfe/types/action.ts
@@ -15,8 +15,13 @@ export interface Action {
   type: string;
   /** Target type ID (ExtensionDomain or Extension) */
   target: string;
-  /** Optional action payload */
-  payload?: Record<string, unknown>;
+  /**
+   * Optional action payload.
+   * Lifecycle actions (load_ext, mount_ext, unmount_ext) require a `subject` field
+   * identifying the extension ID to act upon. This is enforced at runtime via GTS schema
+   * validation (payload.subject with x-gts-ref to extension type).
+   */
+  payload?: { subject?: string } & Record<string, unknown>;
   /** Optional timeout override in milliseconds (overrides domain's defaultActionTimeout) */
   timeout?: number;
 }

--- a/packages/studio/src/hooks/useRestoreStudioSettings.ts
+++ b/packages/studio/src/hooks/useRestoreStudioSettings.ts
@@ -79,7 +79,7 @@ export const useRestoreGtsPackage = (registry: ScreensetsRegistry | null | undef
           action: {
             type: HAI3_ACTION_MOUNT_EXT,
             target: HAI3_SCREEN_DOMAIN,
-            payload: { extensionId: firstExtension.id },
+            payload: { subject: firstExtension.id },
           },
         });
       } catch {

--- a/packages/studio/src/sections/MfePackageSelector.tsx
+++ b/packages/studio/src/sections/MfePackageSelector.tsx
@@ -78,7 +78,7 @@ export const MfePackageSelector: React.FC<MfePackageSelectorProps> = ({
       action: {
         type: HAI3_ACTION_MOUNT_EXT,
         target: HAI3_SCREEN_DOMAIN,
-        payload: { extensionId: firstExtension.id },
+        payload: { subject: firstExtension.id },
       },
     });
     eventBus.emit(StudioEvents.ActivePackageChanged, { activePackageId: selectedPackageId });

--- a/src/app/effects/bootstrapEffects.ts
+++ b/src/app/effects/bootstrapEffects.ts
@@ -7,7 +7,7 @@
  * Following flux architecture: Listen to events from actions, dispatch to slices.
  */
 
-import { trim } from 'lodash';
+import trim from 'lodash/trim';
 import { eventBus, setUser, setHeaderLoading, apiRegistry, type AppDispatch, type HeaderUser } from '@cyberfabric/react';
 import { AccountsApiService, type ApiUser } from '@/app/api';
 

--- a/src/app/layout/Menu.tsx
+++ b/src/app/layout/Menu.tsx
@@ -83,7 +83,7 @@ export const Menu: React.FC<MenuProps> = ({ children }) => {
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: HAI3_SCREEN_DOMAIN,
-          payload: { extensionId },
+          payload: { subject: extensionId },
         },
       });
       setMountedId(extensionId);

--- a/src/app/mfe/bootstrap.ts
+++ b/src/app/mfe/bootstrap.ts
@@ -131,7 +131,7 @@ export async function bootstrapMFE(
     action: {
       type: HAI3_ACTION_MOUNT_EXT,
       target: screenDomain.id,
-      payload: { extensionId: targetExtId },
+      payload: { subject: targetExtId },
     },
   });
 
@@ -154,7 +154,7 @@ export async function bootstrapMFE(
       chain.action.type === HAI3_ACTION_MOUNT_EXT &&
       chain.action.target === screenDomain.id
     ) {
-      const extensionId = chain.action.payload?.extensionId as string | undefined;
+      const extensionId = typeof chain.action.payload?.subject === 'string' ? chain.action.payload.subject : undefined;
       const route = screenRouteMap.get(extensionId ?? '');
       if (route && window.location.pathname !== route) {
         window.history.pushState(null, '', route);
@@ -171,7 +171,7 @@ export async function bootstrapMFE(
         action: {
           type: HAI3_ACTION_MOUNT_EXT,
           target: screenDomain.id,
-          payload: { extensionId: ext.id },
+          payload: { subject: ext.id },
         },
       });
     }

--- a/src/mfe_packages/demo-mfe/src/components/ui/spinner.tsx
+++ b/src/mfe_packages/demo-mfe/src/components/ui/spinner.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Loader2 } from "lucide-react"
-import { trim } from "lodash"
+import trim from "lodash/trim"
 
 import { cn } from "../../lib/utils"
 

--- a/src/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.tsx
+++ b/src/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.tsx
@@ -85,7 +85,7 @@ export const HelloWorldScreen: React.FC<HelloWorldScreenProps> = ({ bridge }) =>
       action: {
         type: HAI3_ACTION_MOUNT_EXT,
         target: HAI3_SCREEN_DOMAIN,
-        payload: { extensionId: THEME_EXTENSION_ID },
+        payload: { subject: THEME_EXTENSION_ID },
       },
     });
   }, [bridge]);

--- a/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
+++ b/src/mfe_packages/shared/vite-plugin-frontx-externalize.ts
@@ -1,7 +1,7 @@
 // @cpt-dod:cpt-frontx-dod-mfe-isolation-externalize-plugin:p1
 // @cpt-flow:cpt-frontx-flow-mfe-isolation-build:p2
 import type { Plugin, ResolvedConfig } from 'vite';
-import { trim } from 'lodash';
+import trim from 'lodash/trim';
 
 export interface Hai3MfeExternalizeOptions {
   shared: string[];


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#248](https://github.com/cyberfabric/cyberware-frontx/pull/248) | **Author:** GeraBart | **Opened:** 2026-03-31T05:44:46Z | **Status:** merged on 2026-04-01T11:09:40Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Closes https://github.com/constructorfabric/frontx/issues/247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Migrated extension action definitions to schema-based patterns for enhanced validation and consistency across the framework.

* **Tests**
  * Updated test fixtures and assertions to align with revised action structure and validation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#248 -->