### PR TITLE
[PR #230] fix(publish): pin internal @hai3/* peer deps to exact version at publish time

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -134,6 +134,19 @@ jobs:
             return 1
           }
 
+          # Pin @hai3/* peer dependencies to the package's own version before publishing.
+          # Prevents npm from resolving internal peers via the 'latest' dist-tag, which
+          # would produce an incompatible mix when installing from pre-release channels.
+          pin_peer_deps() {
+            jq --arg v "$1" '
+              if .peerDependencies then
+                .peerDependencies |= with_entries(
+                  if (.key | startswith("@hai3/")) and .value == "*" then .value = $v else . end
+                )
+              else . end
+            ' package.json > package.json.tmp && mv package.json.tmp package.json
+          }
+
           # Sort packages by layer (L1=SDK, L2=Framework, L3=React, L4=Studio, L5=CLI)
           SORTED=$(echo "$PACKAGES" | jq -c 'sort_by(.dir |
             if . == "state" or . == "screensets" or . == "api" or . == "i18n" or . == "uikit" then 1
@@ -171,6 +184,9 @@ jobs:
             echo "Publishing $NAME@$VERSION with tag '$NPM_TAG'..."
 
             cd "packages/$DIR"
+
+            echo "Pinning internal @hai3/* peer deps to $VERSION..."
+            pin_peer_deps "$VERSION" || { echo "FAILED: peer dep pinning failed for $NAME"; exit 1; }
 
             if ! publish_with_retry "$NPM_TAG"; then
               echo "FAILED: $NAME@$VERSION publish failed after retries"

--- a/architecture/ADR/0017-peer-dep-version-pinning.md
+++ b/architecture/ADR/0017-peer-dep-version-pinning.md
@@ -1,0 +1,100 @@
+---
+status: accepted
+date: 2026-03-19
+---
+
+# Pin Internal Peer Dependency Versions at Publish Time
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [CI script: replace `"*"` with exact version in peer deps at publish time](#ci-script-replace-with-exact-version-in-peer-deps-at-publish-time)
+  - [Migrate to pnpm with `workspace:*` protocol](#migrate-to-pnpm-with-workspace-protocol)
+  - [Installation documentation](#installation-documentation)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-hai3-adr-peer-dep-version-pinning`
+## Context and Problem Statement
+
+When consumers install `@hai3/*` packages from the alpha dist-tag, npm auto-resolves `"*"` peer dependencies using the `latest` dist-tag, which points to the previous stable release. A user running `npm install @hai3/react@alpha` receives `@hai3/react@0.4.0-alpha.0` paired with `@hai3/framework@0.3.x` — an incompatible combination. The root cause is that all internal `@hai3/*` peer dependencies declare `"*"` as their version range, which gives npm no signal that alpha versions must be installed together.
+
+## Decision Drivers
+
+* Installing from the alpha channel must produce a fully compatible package set without manual intervention
+* Fix must not require consumers to list every `@hai3/*` package explicitly when installing
+* Solution must be reversible if a pnpm migration is done later
+* Change complexity must be proportional to the problem — a narrow publishing fix, not an infrastructure overhaul
+
+## Considered Options
+
+* CI script: replace `"*"` with exact version in peer deps at publish time
+* Migrate to pnpm with `workspace:*` protocol
+* Installation documentation
+
+## Decision Outcome
+
+Chosen option: "CI script: replace `\"*\"` with exact version in peer deps at publish time", because it directly solves the incompatible resolution with a single pre-publish step in the existing CI workflow, requires no package manager migration, and produces the same published artefact as the pnpm `workspace:*` approach. If pnpm migration happens later, `workspace:*` replaces this script automatically with no behavioural change to consumers.
+
+### Consequences
+
+* Good, because alpha channel installs produce a compatible package set without any change to consumer workflow
+* Good, because the fix is scoped to one CI file — low blast radius and easy to revert
+* Good, because the same mechanism applies uniformly to all pre-release channels (alpha, beta, rc) and to stable releases
+* Bad, because the script is custom code that duplicates what pnpm's `workspace:*` does natively; it requires maintenance if new internal peer deps are added
+* Bad, because source `package.json` files continue to show `"*"`, which does not reflect the actual published constraint and can mislead developers reading the file locally
+
+### Confirmation
+
+Confirmed when `npm install @hai3/react@alpha` automatically installs `@hai3/framework` at the matching alpha version rather than the latest stable. Verified by inspecting the published `package.json` on the NPM registry — `peerDependencies["@hai3/framework"]` must equal the package's own version string (e.g., `"0.4.0-alpha.0"`).
+
+## Pros and Cons of the Options
+
+### CI script: replace `"*"` with exact version in peer deps at publish time
+
+A Node.js one-liner in `.github/workflows/publish-packages.yml` runs inside each package directory before `npm publish`. It reads `package.json`, replaces `"*"` with the package's own version for all internal `@hai3/*` peer dependencies, and writes the file back. The change is local to the CI runner — source files are never modified.
+
+* Good, because it is narrow, reversible, and requires no tooling changes
+* Good, because the published artefact has an exact peer dep range, guiding both npm auto-install and manual installers
+* Neutral, because the source `package.json` still shows `"*"` — consistent with how `workspace:*` works in pnpm (source vs. published differ by design)
+* Bad, because it is custom logic that must be updated if the set of internal packages changes
+
+### Migrate to pnpm with `workspace:*` protocol
+
+Replace npm workspaces with pnpm. Declare internal peer deps as `"workspace:*"`. At `pnpm publish`, pnpm automatically replaces `workspace:*` with the exact version — the industry-standard solution for monorepos.
+
+* Good, because `workspace:*` is a first-class language feature, not custom code
+* Good, because it brings additional benefits: faster installs, strict dependency isolation, disk-space deduplication
+* Bad, because migration requires ~70 changes across 10+ files (scripts, CI workflows, templates, lock files) and carries moderate risk
+
+### Installation documentation
+
+Document that users installing alpha packages must explicitly specify every peer dependency with the `@alpha` tag: `npm install @hai3/react@alpha @hai3/framework@alpha @hai3/state@alpha ...`.
+
+* Good, because no code change is required
+* Bad, because it shifts the burden to consumers and is brittle — the list of packages must be maintained separately
+* Bad, because it is not a real fix; consumers who miss the documentation will still get a broken install
+
+## More Information
+
+- Related ADR: `cpt-hai3-adr-automated-layer-ordered-publishing` — the CI publishing workflow this decision extends
+- Workflow: `.github/workflows/publish-packages.yml`
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses:
+
+* `cpt-hai3-fr-pub-ci` — the CI publish workflow is where the fix is implemented
+* `cpt-hai3-fr-pub-metadata` — peer dependency declarations are part of the package metadata contract

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -121,7 +121,8 @@ Requirements that significantly influence architecture decisions.
 `cpt-hai3-adr-symbol-based-mock-plugin-identification`,
 `cpt-hai3-adr-global-shared-property-broadcast`,
 `cpt-hai3-adr-cli-template-based-code-generation`,
-`cpt-hai3-adr-two-tier-cli-e2e-verification`
+`cpt-hai3-adr-two-tier-cli-e2e-verification`,
+`cpt-hai3-adr-peer-dep-version-pinning`
 
 #### Functional Drivers
 

--- a/architecture/features/feature-publishing-pipeline/FEATURE.md
+++ b/architecture/features/feature-publishing-pipeline/FEATURE.md
@@ -17,6 +17,7 @@
   - [Publish with Retry](#publish-with-retry)
   - [Detect Version Changes](#detect-version-changes)
   - [Validate Package Metadata](#validate-package-metadata)
+  - [Pin Peer Dependencies](#pin-peer-dependencies)
   - [Layer Sort Order](#layer-sort-order)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Workflow Run State](#workflow-run-state)
@@ -31,6 +32,7 @@
   - [Build Order vs. Publish Order](#build-order-vs-publish-order)
   - [Prerelease Dist-Tag Strategy](#prerelease-dist-tag-strategy)
   - [Fail-Fast vs. Continue-on-Error](#fail-fast-vs-continue-on-error)
+  - [Peer Dependency Version Pinning](#peer-dependency-version-pinning)
   - [Architecture Enforcement Connection](#architecture-enforcement-connection)
 
 <!-- /toc -->
@@ -78,7 +80,7 @@ exactly one publish of that version; subsequent re-runs of the same workflow ski
 - DECOMPOSITION: [feature #11 — Publishing Pipeline](../../DECOMPOSITION.md#211-publishing-pipeline)
 - DESIGN: [Layer Isolation principle](../../DESIGN.md#layer-isolation), [ESM-First constraint](../../DESIGN.md#esm-first-module-format)
 - OpenSpec: [`openspec/specs/publishing/spec.md`](../../../openspec/specs/publishing/spec.md)
-- ADR: `cpt-hai3-adr-automated-layer-ordered-publishing`, `cpt-hai3-adr-esm-first-module-format`
+- ADR: `cpt-hai3-adr-automated-layer-ordered-publishing`, `cpt-hai3-adr-esm-first-module-format`, `cpt-hai3-adr-peer-dep-version-pinning`
 - Workflow source: [`.github/workflows/publish-packages.yml`](../../../.github/workflows/publish-packages.yml)
 
 ---
@@ -118,9 +120,10 @@ exactly one publish of that version; subsequent re-runs of the same workflow ski
 2. [x] `p1` - CI/CD queries NPM registry: `npm view <name>@<version> version` — `inst-npm-view`
 3. [x] `p1` - IF the version already exists on NPM THEN CI/CD logs "Skipping `<name>@<version>` — already exists on NPM" and continues to the next package — `inst-skip-existing`
 4. [x] `p1` - CI/CD changes working directory to `packages/<dir>` — `inst-cd-pkg`
-5. [x] `p1` - CI/CD calls `cpt-hai3-algo-publishing-pipeline-publish-with-retry` with the resolved dist-tag — `inst-call-retry-algo`
-6. [x] `p1` - IF all retry attempts fail THEN CI/CD logs "FAILED: `<name>@<version>` publish failed after retries" and exits with status 1, stopping all further publishing — `inst-fail-fast`
-7. [x] `p1` - IF publish succeeds THEN CI/CD logs "SUCCESS: Published `<name>@<version>`" and records the package in the published list — `inst-record-success`
+5. [x] `p1` - CI/CD runs `cpt-hai3-algo-publishing-pipeline-pin-peer-deps` to replace `"*"` peer dependency ranges for internal `@hai3/*` packages with the package's own version string — `inst-pin-peer-deps`
+6. [x] `p1` - CI/CD calls `cpt-hai3-algo-publishing-pipeline-publish-with-retry` with the resolved dist-tag — `inst-call-retry-algo`
+7. [x] `p1` - IF all retry attempts fail THEN CI/CD logs "FAILED: `<name>@<version>` publish failed after retries" and exits with status 1, stopping all further publishing — `inst-fail-fast`
+8. [x] `p1` - IF publish succeeds THEN CI/CD logs "SUCCESS: Published `<name>@<version>`" and records the package in the published list — `inst-record-success`
 
 ---
 
@@ -205,6 +208,24 @@ Required fields for all packages:
 
 1. [x] `p2` - FOR EACH required field: IF the field is absent or has an incorrect value THEN RETURN error identifying the missing field and the package — `inst-field-check`
 2. [x] `p2` - IF all fields are present and valid THEN RETURN valid — `inst-metadata-valid`
+
+---
+
+### Pin Peer Dependencies
+
+- [x] `p1` - **ID**: `cpt-hai3-algo-publishing-pipeline-pin-peer-deps`
+
+Rewrites `"*"` version ranges for internal `@hai3/*` peer dependencies in
+`package.json` to the package's own version string before publish. Operates
+inside the package directory (`packages/<dir>`). The rewrite is applied only
+to the working copy on the CI runner — source files are never modified.
+
+1. [x] `p1` - Read `package.json` from the current working directory — `inst-read-pkg`
+2. [x] `p1` - Read `version` from the parsed package metadata — `inst-read-version`
+3. [x] `p1` - IF `peerDependencies` is absent or empty THEN RETURN success — `inst-no-peers`
+4. [x] `p1` - FOR EACH entry in `peerDependencies`: IF the key starts with `@hai3/` AND the value is `"*"` THEN set the value to `version` — `inst-rewrite-peers`
+5. [x] `p1` - Write the modified `package.json` back to disk — `inst-write-pkg`
+6. [x] `p1` - RETURN success — `inst-done`
 
 ---
 
@@ -347,6 +368,7 @@ fail-fast error handling. The workflow triggers on push to `main` only.
 - `cpt-hai3-algo-publishing-pipeline-layer-sort`
 - `cpt-hai3-algo-publishing-pipeline-resolve-dist-tag`
 - `cpt-hai3-algo-publishing-pipeline-publish-with-retry`
+- `cpt-hai3-algo-publishing-pipeline-pin-peer-deps`
 
 **Covers (PRD)**:
 - `cpt-hai3-fr-pub-ci`
@@ -394,6 +416,7 @@ publishes. Packages whose version already exists on NPM are silently skipped.
 - [ ] All published packages include `"type": "module"`, dual ESM/CJS `exports`, and complete metadata fields (`author`, `license`, `publishConfig`, `engines`)
 - [ ] TypeScript declarations (`index.d.ts`) are included in the published tarball
 - [ ] The `npm pack` output for any package contains only `dist/` files and documented extras — no raw `.ts` source files
+- [ ] Published packages have internal `@hai3/*` peer dependencies set to the exact version string rather than `"*"` (e.g., `"0.4.0-alpha.0"` instead of `"*"`)
 
 ---
 
@@ -422,6 +445,18 @@ entire run. This is intentional. If a lower-layer package fails to publish, allo
 higher-layer packages to publish would produce an inconsistent registry state where consumers
 see a new `@hai3/framework` but cannot resolve its new `@hai3/state` dependency. Fail-fast
 and the fixed layer order together guarantee registry consistency.
+
+### Peer Dependency Version Pinning
+
+Alpha and other pre-release versions cannot rely on the `latest` dist-tag to resolve internal
+peer dependencies: `latest` points to the previous stable release, producing an incompatible
+combination when a consumer installs from any pre-release channel. The
+`cpt-hai3-algo-publishing-pipeline-pin-peer-deps` algorithm replaces `"*"` with the exact
+version string in the CI runner's working copy before each `npm publish`, ensuring that
+consumers who install from any dist-tag receive a fully compatible set of `@hai3/*` packages.
+The rewrite is CI-only — source `package.json` files intentionally retain `"*"` and are
+never modified. See ADR `cpt-hai3-adr-peer-dep-version-pinning` for the decision rationale
+and alternatives considered.
 
 ### Architecture Enforcement Connection
 


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#230](https://github.com/cyberfabric/cyberware-frontx/pull/230) | **Author:** dingoatemytokens | **Opened:** 2026-03-19T01:11:14Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Adds `pin_peer_deps` to the CI publish workflow — replaces `"*"` peer dependency ranges for `@hai3/*` packages with the exact version string before `npm publish`. Fixes incompatible installs from alpha/pre-release channels where npm would resolve peers via `latest` (old stable).

Docs: ADR-0017, FEATURE spec updated with new algo and acceptance criterion.

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#230 -->