### PR TITLE
[PR #226] feat(cli): add npm/pnpm/yarn support across create/update/template flows

### DIFF
--- a/.github/workflows/cli-pr.yml
+++ b/.github/workflows/cli-pr.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs:
   cli-pr-e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package-manager: [npm, pnpm, yarn]
 
     steps:
       - name: Checkout code
@@ -28,6 +32,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Activate test package manager
+        run: corepack prepare ${{ matrix.package-manager }}@latest --activate
+
       - name: Install dependencies
         run: npm ci
 
@@ -38,11 +45,12 @@ jobs:
         run: npm run test:e2e:pr --workspace=@hai3/cli
         env:
           CLI_E2E_ARTIFACT_DIR: .artifacts/cli-e2e/pr
+          CLI_E2E_PM: ${{ matrix.package-manager }}
 
       - name: Upload CLI E2E artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cli-pr-e2e-logs
+          name: cli-pr-e2e-logs-${{ matrix.package-manager }}
           path: .artifacts/cli-e2e/pr
           retention-days: 14

--- a/architecture/features/feature-cli-tooling/FEATURE.md
+++ b/architecture/features/feature-cli-tooling/FEATURE.md
@@ -22,6 +22,7 @@
 - [3. Processes / Business Logic (CDSL)](#3-processes-business-logic-cdsl)
   - [Validate Project Name](#validate-project-name)
   - [Generate Project Files](#generate-project-files)
+  - [Resolve Package Manager Policy](#resolve-package-manager-policy)
   - [Layer Command Variant Selection](#layer-command-variant-selection)
   - [Detect Release Channel](#detect-release-channel)
   - [Sync Templates](#sync-templates)
@@ -63,13 +64,13 @@ Problem: Without tooling, developers must manually assemble multi-file project s
 
 Primary value: A single `hai3 create` command produces a complete, layered HAI3 project with correct dependencies, IDE configs, and AI skill integrations in under a minute.
 
-Key assumptions: The CLI is installed globally (`npm install -g @hai3/cli`). It runs in Node.js 18+ environments. Templates are packaged into the CLI build and are not loaded from the network at runtime.
+Key assumptions: The CLI runs in Node.js 18+ environments. It may be installed globally via a supported package manager (`npm` or `pnpm`; `yarn` global install is not managed by the CLI update flow). Templates are packaged into the CLI build and are not loaded from the network at runtime.
 
 ### 1.2 Purpose
 
 Enable `cpt-hai3-actor-developer` and `cpt-hai3-actor-cli` to scaffold new HAI3 projects and layer packages, generate layout components on demand, keep AI assistant configurations current, apply codemod migrations across major version upgrades, and validate component structure rules — all through a consistent programmatic interface usable by both humans and AI agents.
 
-Success criteria: A developer runs `hai3 create my-app`, changes into the directory, runs `npm install && npm run dev`, and has a working HAI3 application with all AI configurations set up correctly.
+Success criteria: A developer runs `hai3 create my-app`, selects or passes a supported package manager (`npm`, `pnpm`, or `yarn`), changes into the directory, runs the generated manager-appropriate install and dev commands, and has a working HAI3 application with all AI configurations set up correctly.
 
 ### 1.3 Actors
 
@@ -97,17 +98,18 @@ Success criteria: A developer runs `hai3 create my-app`, changes into the direct
 
 **Actors**: `cpt-hai3-actor-developer`, `cpt-hai3-actor-cli`
 
-1. [x] - `p1` - Developer invokes `hai3 create <project-name>` with optional flags (`--layer`, `--uikit`, `--studio`, `--no-studio`) - `inst-invoke-create`
+1. [x] - `p1` - Developer invokes `hai3 create <project-name>` with optional flags (`--layer`, `--uikit`, `--studio`, `--no-studio`, `--package-manager`) - `inst-invoke-create`
 2. [x] - `p1` - Algorithm: validate project name using `cpt-hai3-algo-cli-tooling-validate-project-name` - `inst-run-name-validation`
 3. [x] - `p1` - **IF** target directory already exists **THEN** prompt developer to confirm overwrite; **IF** developer declines **RETURN** with abort message - `inst-check-dir-exists`
 4. [x] - `p1` - **IF** `--layer` flag is not `app` **THEN** skip uikit/studio prompts and proceed to layer package generation - `inst-branch-layer`
 5. [x] - `p1` - **IF** `--studio` flag is absent **THEN** prompt developer: "Include Studio (development overlay)?" - `inst-prompt-studio`
 6. [x] - `p1` - **IF** `--uikit` flag is absent **THEN** prompt developer to select UIKit option from `['hai3', 'none']` - `inst-prompt-uikit`
-7. [x] - `p1` - Algorithm: generate project files using `cpt-hai3-algo-cli-tooling-generate-project` - `inst-run-generate-project`
-8. [x] - `p1` - Write all generated files to the target directory on disk - `inst-write-files`
-9. [x] - `p1` - Execute `aiSyncCommand` against the newly created project root to generate IDE configuration files - `inst-run-ai-sync-after-create`
-10. [x] - `p1` - Log success message and next-step instructions (`cd <name>`, `npm install`, `npm run dev`) to the developer - `inst-log-success-create`
-11. [x] - `p1` - **RETURN** `CreateCommandResult` with `projectPath` and list of written file paths - `inst-return-create`
+7. [x] - `p1` - **IF** `--package-manager` flag is absent **THEN** prompt developer to select one of `npm`, `pnpm`, or `yarn` - `inst-prompt-package-manager`
+8. [x] - `p1` - Algorithm: generate project files using `cpt-hai3-algo-cli-tooling-generate-project` - `inst-run-generate-project`
+9. [x] - `p1` - Write all generated files to the target directory on disk - `inst-write-files`
+10. [x] - `p1` - Execute `aiSyncCommand` against the newly created project root to generate IDE configuration files - `inst-run-ai-sync-after-create`
+11. [x] - `p1` - Log success message and next-step instructions (`cd <name>`, manager-appropriate install command, manager-appropriate dev/build command) to the developer - `inst-log-success-create`
+12. [x] - `p1` - **RETURN** `CreateCommandResult` with `projectPath` and list of written file paths - `inst-return-create`
 
 ### Scaffold Layout
 
@@ -131,7 +133,7 @@ Success criteria: A developer runs `hai3 create my-app`, changes into the direct
 1. [x] - `p1` - Developer invokes `hai3 update` with optional flags (`--alpha`, `--stable`, `--templates-only`, `--skip-ai-sync`) - `inst-invoke-update`
 2. [x] - `p1` - **IF** both `--alpha` and `--stable` are specified **RETURN** validation error `CONFLICTING_OPTIONS` - `inst-check-conflicting-update-flags`
 3. [x] - `p1` - Algorithm: resolve release channel using `cpt-hai3-algo-cli-tooling-detect-release-channel` - `inst-run-detect-channel`
-4. [x] - `p1` - **IF** `--templates-only` is not set **THEN** install `@hai3/cli@<tag>` globally via `npm install -g` - `inst-update-cli-global`
+4. [x] - `p1` - **IF** `--templates-only` is not set **THEN** install `@hai3/cli@<tag>` globally using the detected project package manager; **IF** the manager is `yarn` **THEN** skip global CLI update with a warning because yarn global install is not managed by the command - `inst-update-cli-global`
 5. [x] - `p1` - **IF** `--templates-only` is not set **AND** inside a HAI3 project **THEN** locate all `@hai3/*` entries in project `package.json` and install each with the resolved tag - `inst-update-project-packages`
 6. [x] - `p1` - **IF** inside a HAI3 project **THEN** sync templates using `cpt-hai3-algo-cli-tooling-sync-templates` - `inst-run-sync-templates`
 7. [x] - `p1` - **IF** inside a HAI3 project **AND** `--skip-ai-sync` is not set **THEN** execute `aiSyncCommand` with `detectPackages: true` - `inst-run-ai-sync-after-update`
@@ -200,14 +202,14 @@ Success criteria: A developer runs `hai3 create my-app`, changes into the direct
 
 **Actors**: `cpt-hai3-actor-build-system`, `cpt-hai3-actor-cli`
 
-1. [x] - `p1` - CI triggers `.github/workflows/cli-pr.yml` on pull request to `main`; job `cli-pr-e2e` starts on `ubuntu-latest` with Node 24.14.x - `inst-e2e-pr-trigger`
+1. [x] - `p1` - CI triggers `.github/workflows/cli-pr.yml` on pull request to `main`; job `cli-pr-e2e` starts on `ubuntu-latest` with Node 24.14.x and a matrix over `package-manager in [npm, pnpm, yarn]` - `inst-e2e-pr-trigger`
 2. [x] - `p1` - Build `@hai3/cli` via `npm run build --workspace=@hai3/cli` - `inst-e2e-pr-build-cli`
 3. [x] - `p1` - Algorithm: create harness using `cpt-hai3-algo-cli-tooling-e2e-harness-step` with suite name `pr` - `inst-e2e-pr-create-harness`
-4. [x] - `p1` - Run `hai3 create smoke-app --no-studio --uikit hai3` in a temporary workspace - `inst-e2e-pr-create-app`
+4. [x] - `p1` - Run `hai3 create smoke-app --no-studio --uikit hai3 --package-manager <matrix package-manager>` in a temporary workspace - `inst-e2e-pr-create-app`
 5. [x] - `p1` - Assert scaffolded files exist: `hai3.config.json`, `package.json`, `.ai/GUIDELINES.md`, `src/app/layout/Layout.tsx`, `scripts/generate-mfe-manifests.ts` - `inst-e2e-pr-assert-files`
-6. [x] - `p1` - Assert generated `package.json` declares `engines.node >=24.14.0` - `inst-e2e-pr-assert-engines`
-7. [x] - `p1` - Run `git init` in generated project, then `npm install --no-audit --no-fund` - `inst-e2e-pr-git-init-install`
-8. [x] - `p1` - Run `npm run build` and `npm run type-check` on generated project - `inst-e2e-pr-build-typecheck`
+6. [x] - `p1` - Assert generated `package.json` declares `packageManager`, manager-specific `engines`, manager-specific workspace/config files when applicable, and `hai3.config.json.packageManager` equals the selected manager - `inst-e2e-pr-assert-engines`
+7. [x] - `p1` - Run `git init` in generated project, then the manager-appropriate install command (`npm install --no-audit --no-fund`, `pnpm install --no-frozen-lockfile`, or `yarn install --no-immutable`) - `inst-e2e-pr-git-init-install`
+8. [x] - `p1` - Run manager-appropriate build and type-check commands on the generated project - `inst-e2e-pr-build-typecheck`
 9. [x] - `p1` - Run `hai3 validate components` on clean scaffold and assert exit code 0 - `inst-e2e-pr-validate-clean`
 10. [x] - `p1` - Inject invalid screen file with inline style and hex color, run `hai3 validate components` and assert exit code 1 - `inst-e2e-pr-validate-bad`
 11. [x] - `p1` - Run `hai3 scaffold layout -f` and assert success - `inst-e2e-pr-scaffold-layout`
@@ -224,14 +226,15 @@ Success criteria: A developer runs `hai3 create my-app`, changes into the direct
 1. [x] - `p2` - CI triggers `.github/workflows/cli-nightly.yml` on schedule (daily 03:00 UTC) or manual dispatch - `inst-e2e-nightly-trigger`
 2. [x] - `p2` - Build `@hai3/cli` via `npm run build --workspace=@hai3/cli` - `inst-e2e-nightly-build-cli`
 3. [x] - `p2` - Algorithm: create harness using `cpt-hai3-algo-cli-tooling-e2e-harness-step` with suite name `nightly` - `inst-e2e-nightly-create-harness`
-4. [x] - `p2` - Run `hai3 create nightly-app --no-studio --uikit hai3`, then install, build, and type-check - `inst-e2e-nightly-create-default`
-5. [x] - `p2` - Run `hai3 migrate --list` and `hai3 migrate --status` on the default app - `inst-e2e-nightly-migrate-commands`
-6. [x] - `p2` - Run `hai3 ai sync --tool all --diff` twice and assert both succeed (idempotency) - `inst-e2e-nightly-ai-sync-idempotent`
-7. [x] - `p2` - Run `hai3 create nightly-custom --no-studio --uikit none`, assert `@hai3/uikit` not in dependencies, then install, build, and type-check - `inst-e2e-nightly-custom-uikit`
-8. [x] - `p2` - **FOR EACH** layer in `[sdk, framework, react]`: run `hai3 create nightly-{layer} --layer {layer}`, then install, build, and type-check - `inst-e2e-nightly-layer-scaffolds`
-9. [x] - `p2` - Run `hai3 create "Invalid Name"` and assert exit code 1 - `inst-e2e-nightly-invalid-name`
-10. [x] - `p2` - Upload step logs and JSON summary as CI artifacts (runs even on failure) - `inst-e2e-nightly-upload-artifacts`
-11. [x] - `p2` - **RETURN** harness completion status `passed` or `failed` - `inst-e2e-nightly-return`
+4. [x] - `p2` - Run `hai3 create nightly-app --no-studio --uikit hai3 --package-manager npm`, then install, build, and type-check - `inst-e2e-nightly-create-default`
+5. [x] - `p2` - Run `hai3 create nightly-pnpm --no-studio --uikit hai3 --package-manager pnpm` and `hai3 create nightly-yarn --no-studio --uikit hai3 --package-manager yarn`; assert manager-specific metadata/files, then install, build, and type-check using manager-appropriate commands - `inst-e2e-nightly-create-alt-managers`
+6. [x] - `p2` - Run `hai3 migrate --list` and `hai3 migrate --status` on the default app - `inst-e2e-nightly-migrate-commands`
+7. [x] - `p2` - Run `hai3 ai sync --tool all --diff` twice and assert both succeed (idempotency) - `inst-e2e-nightly-ai-sync-idempotent`
+8. [x] - `p2` - Run `hai3 create nightly-custom --no-studio --uikit none`, assert `@hai3/uikit` not in dependencies, then install, build, and type-check - `inst-e2e-nightly-custom-uikit`
+9. [x] - `p2` - **FOR EACH** layer in `[sdk, framework, react]`: run `hai3 create nightly-{layer} --layer {layer}`, assert README install snippet includes the generated package name, then install, build, and type-check - `inst-e2e-nightly-layer-scaffolds`
+10. [x] - `p2` - Run `hai3 create "Invalid Name"` and assert exit code 1 - `inst-e2e-nightly-invalid-name`
+11. [x] - `p2` - Upload step logs and JSON summary as CI artifacts (runs even on failure) - `inst-e2e-nightly-upload-artifacts`
+12. [x] - `p2` - **RETURN** harness completion status `passed` or `failed` - `inst-e2e-nightly-return`
 
 ---
 
@@ -265,9 +268,25 @@ Constructs the complete set of `GeneratedFile` entries for a new HAI3 project fr
 11. [x] - `p1` - Copy user command stubs from `templates/.ai/commands/user/` - `inst-copy-user-commands`
 12. [x] - `p1` - Copy `eslint-plugin-local/` and `scripts/` directories; **IF** `uikit === 'none'` exclude `scripts/generate-colors.ts` - `inst-copy-support-dirs`
 13. [x] - `p1` - Copy root config files: `CLAUDE.md`, `README.md`, `eslint.config.js`, `tsconfig.json`, `vite.config.ts`, `.dependency-cruiser.cjs`, `.pre-commit-config.yaml`, `.npmrc`, `.nvmrc`; **IF** `uikit === 'hai3'` also include `postcss.config.ts` - `inst-copy-root-configs`
-14. [x] - `p1` - Generate `hai3.config.json` dynamically with `{ hai3: true, layer, uikit }` - `inst-generate-hai3-config`
-15. [x] - `p1` - Generate `package.json` dynamically with resolved dependencies: always include core `@hai3/*` packages at `alpha` tag; include `@hai3/uikit` only if `uikit === 'hai3'`; include `@hai3/studio` in devDependencies only if `studio === true`; set `type: "module"` and `engines: { node: ">=24.14.0" }` - `inst-generate-package-json`
-16. [x] - `p1` - **RETURN** complete `GeneratedFile[]` array - `inst-return-generated-files`
+14. [x] - `p1` - Generate `hai3.config.json` dynamically with `{ hai3: true, layer, uikit, packageManager }`; include `linkerMode: "node-modules"` when the selected manager is `yarn` - `inst-generate-hai3-config`
+15. [x] - `p1` - Generate `package.json` dynamically with resolved dependencies: always include core `@hai3/*` packages at `alpha` tag; include `@hai3/uikit` only if `uikit === 'hai3'`; include `@hai3/studio` in devDependencies only if `studio === true`; set manager-specific `packageManager`, centralized manager-specific `engines`, and `workspaces: ["eslint-plugin-local"]` - `inst-generate-package-json`
+16. [x] - `p1` - Generate manager-specific workspace/config files (`pnpm-workspace.yaml` for pnpm, `.yarnrc.yml` for yarn) - `inst-generate-package-manager-workspace-files`
+17. [x] - `p1` - Rewrite npm-centric command snippets in generated text files to manager-specific commands using `cpt-hai3-algo-cli-tooling-package-manager-policy` - `inst-transform-package-manager-text`
+18. [x] - `p1` - **RETURN** complete `GeneratedFile[]` array - `inst-return-generated-files`
+
+### Resolve Package Manager Policy
+
+- [x] `p1` - **ID**: `cpt-hai3-algo-cli-tooling-package-manager-policy`
+
+Provides package-manager-aware command generation, metadata parsing, engine policy, workspace-file generation, and npm-to-target-manager text transformation.
+
+1. [x] - `p1` - Parse `package.json.packageManager` values into `{ manager, version }`; reject unsupported manager identifiers - `inst-parse-package-manager-field`
+2. [x] - `p1` - Resolve package manager context with priority: explicit HAI3 config manager -> `package.json.packageManager` -> default `npm`; preserve legacy `hai3.config.json.packageManagerVersion` only as backwards-compatible fallback - `inst-detect-package-manager`
+3. [x] - `p1` - Build `package.json.packageManager` values from a centralized policy that defines exact default versions per supported manager - `inst-build-package-manager-field`
+4. [x] - `p1` - Build manager-specific `engines` entries from the same centralized policy while keeping the Node engine range separate - `inst-build-package-manager-engines`
+5. [x] - `p1` - Build manager-specific shell commands for install, script execution, workspace script execution, package add/update, and global install where supported - `inst-build-package-manager-commands`
+6. [x] - `p1` - Generate manager-specific workspace/config files required by the scaffolded project (`pnpm-workspace.yaml`, `.yarnrc.yml`) - `inst-build-package-manager-workspace-files`
+7. [x] - `p1` - Transform npm-centric snippets in docs, scripts, and synced template files into target-manager-specific commands; short-circuit for `npm` - `inst-transform-package-manager-text`
 
 ### Layer Command Variant Selection
 
@@ -287,10 +306,11 @@ Selects the most specific command file variant for a given HAI3 architecture lay
 
 Determines whether the globally installed `@hai3/cli` is on the `alpha` or `stable` channel.
 
-1. [x] - `p1` - **TRY** run `npm list -g @hai3/cli --json` and parse output to extract the installed version string - `inst-run-npm-list`
-2. [x] - `p1` - **IF** version string contains `-alpha`, `-beta`, or `-rc` **RETURN** `'alpha'` - `inst-check-prerelease-tag`
-3. [x] - `p1` - **RETURN** `'stable'` - `inst-return-stable`
-4. [x] - `p1` - **CATCH** any error from npm invocation **RETURN** `'stable'` as safe default - `inst-catch-detect-error`
+1. [x] - `p1` - **TRY** locate the current `@hai3/cli` `package.json` by walking upward from the executing module path until a package with `name: "@hai3/cli"` is found - `inst-read-cli-package-version`
+2. [x] - `p1` - Read the current CLI version string from that `package.json` - `inst-read-cli-version-string`
+3. [x] - `p1` - **IF** version string contains `-alpha`, `-beta`, or `-rc` **RETURN** `'alpha'` - `inst-check-prerelease-tag`
+4. [x] - `p1` - **RETURN** `'stable'` - `inst-return-stable`
+5. [x] - `p1` - **CATCH** any error from version lookup **RETURN** `'stable'` as safe default - `inst-catch-detect-error`
 
 ### Sync Templates
 
@@ -301,7 +321,9 @@ Updates project template-derived files (AI target docs, IDE configs, command ada
 1. [x] - `p2` - Determine project layer from `hai3.config.json`; default to `'app'` if not present - `inst-read-project-layer`
 2. [x] - `p2` - **FOR EACH** `.ai/targets/*.md` file in the bundled templates: apply layer-aware filtering and overwrite the project file if applicable - `inst-sync-ai-targets`
 3. [x] - `p2` - **FOR EACH** IDE config directory (`.claude/`, `.cursor/`, `.windsurf/`): overwrite IDE config files from templates - `inst-sync-ide-configs`
-4. [x] - `p2` - **RETURN** list of directories that were updated - `inst-return-synced-dirs`
+4. [x] - `p2` - Skip generation-only `src/app/App.no-*` and `src/app/main.no-uikit.tsx` template variants when syncing into existing projects, and remove stale copies if they exist - `inst-skip-variant-app-files`
+5. [x] - `p2` - After syncing, detect the project package manager and rewrite npm-centric text snippets in synced files to the active manager using `cpt-hai3-algo-cli-tooling-package-manager-policy` - `inst-transform-synced-files`
+6. [x] - `p2` - **RETURN** list of directories that were updated - `inst-return-synced-dirs`
 
 ### Generate AI Configuration for Tool
 
@@ -491,11 +513,13 @@ The `copy-templates.ts` build script assembles the full template set into `packa
 - Build script: `packages/cli/scripts/copy-templates.ts` — copies sources, generates `manifest.json`, bundles commands with layer suffixes, calls `copyOpenSpecSkills()`
 - Generator: `src/generators/project.ts` — `generateProject(input: ProjectGeneratorInput): Promise<GeneratedFile[]>`; reads manifest, applies uikit/studio/layer conditionals, returns file list
 - Layer package generator: `src/generators/layerPackage.ts` — `generateLayerPackage({ packageName, layer })`
+- Package manager policy: `src/core/packageManager.ts` — centralized exact/default PM versions, minimum engine ranges, command builders, workspace-file helpers, and npm-snippet transformation
 - Templates dir: `src/core/templates.ts` — `getTemplatesDir()` resolves to `packages/cli/templates/` from the installed package location
 - OpenSpec skills: 10 skill directories per editor (claude, cursor, windsurf) × 3 editors = 30 `SKILL.md` files; 10 Copilot OPSX command files
 
 **Implements**:
 - `cpt-hai3-algo-cli-tooling-generate-project`
+- `cpt-hai3-algo-cli-tooling-package-manager-policy`
 - `cpt-hai3-algo-cli-tooling-build-templates`
 
 **Covers (PRD)**:
@@ -530,7 +554,7 @@ The `copy-templates.ts` build script assembles the full template set into `packa
 
 - [x] `p1` - **ID**: `cpt-hai3-dod-cli-tooling-ai-sync`
 
-`aiSyncCommand` generates IDE-specific rule files and command adapter stubs for Claude Code, GitHub Copilot, Cursor, and Windsurf. Supports four-tier command precedence (project > company > hai3 > packages). Preserves user custom rules from `.ai/rules/app.md` across syncs. Supports `--diff` preview mode.
+`aiSyncCommand` generates IDE-specific rule files and command adapter stubs for Claude Code, GitHub Copilot, Cursor, and Windsurf. Supports four-tier command precedence (project > company > hai3 > packages). Preserves user custom rules from `.ai/rules/app.md` across syncs. Supports `--diff` preview mode. Emits package-manager-aware architecture-check command hints in generated tool instructions.
 
 **Implementation details**:
 - Command: `src/commands/ai/sync.ts` — `aiSyncCommand: CommandDefinition<AiSyncArgs, AiSyncResult>`
@@ -602,7 +626,7 @@ The `copy-templates.ts` build script assembles the full template set into `packa
 
 - [x] `p1` - **ID**: `cpt-hai3-dod-cli-tooling-e2e-pr`
 
-A required GitHub Actions workflow (`cli-pr-e2e`) verifies the critical CLI scaffold path on every pull request to `main`. The workflow runs on `ubuntu-latest` with Node 24.14.x, builds the CLI, then exercises the default scaffold through create, install, build, type-check, validate (positive + negative), scaffold layout, and ai sync. Step-level logs and a JSON summary are uploaded as CI artifacts unconditionally.
+A required GitHub Actions workflow (`cli-pr-e2e`) verifies the critical CLI scaffold path on every pull request to `main`. The workflow runs on `ubuntu-latest` with Node 24.14.x, builds the CLI, then exercises the scaffold through create, install, build, type-check, validate (positive + negative), scaffold layout, and ai sync across a matrix of `npm`, `pnpm`, and `yarn`. Step-level logs and a JSON summary are uploaded as CI artifacts unconditionally.
 
 **Implementation details**:
 - Workflow: `.github/workflows/cli-pr.yml` — job `cli-pr-e2e`, trigger `pull_request` on `main`
@@ -625,7 +649,7 @@ A required GitHub Actions workflow (`cli-pr-e2e`) verifies the critical CLI scaf
 
 - [x] `p2` - **ID**: `cpt-hai3-dod-cli-tooling-e2e-nightly`
 
-A non-required nightly/manual GitHub Actions workflow covers broader CLI scenarios beyond the PR gate: custom UIKit (`--uikit none`), layer scaffolds (`sdk`, `framework`, `react`), migrate commands (`--list`, `--status`), invalid-name rejection, and ai sync idempotency. Runs on the same harness infrastructure as the PR workflow.
+A non-required nightly/manual GitHub Actions workflow covers broader CLI scenarios beyond the PR gate: alternate package managers (`pnpm`, `yarn`), custom UIKit (`--uikit none`), layer scaffolds (`sdk`, `framework`, `react`), migrate commands (`--list`, `--status`), invalid-name rejection, and ai sync idempotency. Runs on the same harness infrastructure as the PR workflow.
 
 **Implementation details**:
 - Workflow: `.github/workflows/cli-nightly.yml` — job `cli-nightly-e2e`, triggers `schedule` (03:00 UTC) and `workflow_dispatch`
@@ -649,6 +673,7 @@ A non-required nightly/manual GitHub Actions workflow covers broader CLI scenari
 ## 6. Acceptance Criteria
 
 - [x] `hai3 create my-app` scaffolds a complete HAI3 application with correct `package.json`, `hai3.config.json`, `CLAUDE.md`, and all four AI tool configuration files
+- [x] `hai3 create my-app --package-manager <npm|pnpm|yarn>` records the selected manager in generated metadata, emits manager-specific next-step commands, and generates required workspace/config files for the selected manager
 - [x] `hai3 create my-sdk --layer sdk` generates a minimal SDK-layer package with only sdk-applicable target files and command variants
 - [x] `hai3 scaffold layout` writes layout components to `src/app/layout/` inside an existing project; skips existing files unless `--force` is passed
 - [x] `hai3 ai sync` regenerates `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/hai3.mdc`, `.windsurf/rules/hai3.md`, and command adapters; preserves `.ai/rules/app.md` content across runs
@@ -657,10 +682,12 @@ A non-required nightly/manual GitHub Actions workflow covers broader CLI scenari
 - [x] `hai3 migrate --dry-run` previews changes without modifying source files and without updating `.hai3/migrations.json`
 - [x] `hai3 migrate` is idempotent: running it twice does not re-apply an already applied migration
 - [x] `hai3 update --alpha` and `hai3 update --stable` cannot be combined; the command exits with `CONFLICTING_OPTIONS` when both flags are present
+- [x] `hai3 update` auto-detects the current release channel from the currently running CLI package version, not from an npm-specific global listing
+- [x] Template-derived docs and scripts emitted by `hai3 create` or `hai3 update --templates-only` contain concrete manager-specific commands for npm, pnpm, and yarn
 - [x] CLI build produces exactly 30 OpenSpec skill `SKILL.md` files (10 per editor × 3 editors) and 10 Copilot OPSX command files in `packages/cli/templates/`
 - [x] `executeCommand(createCommand, args, { interactive: false, answers })` returns `{ success: true, data }` without prompts — programmatic API is fully functional
 - [x] `selectCommandVariant` returns `null` for any command that has no applicable variant for the given layer, ensuring layer packages do not receive irrelevant commands
-- [x] `.github/workflows/cli-pr.yml` defines required job `cli-pr-e2e` on `ubuntu-latest` with Node 24.14.x; exercises the full default scaffold path (create, git init, install, build, type-check, validate positive + negative, scaffold layout, ai sync)
-- [x] `.github/workflows/cli-nightly.yml` runs on schedule and manual dispatch; covers `--uikit none`, layer scaffolds (`sdk`, `framework`, `react`), migrate commands, invalid-name rejection, and ai sync idempotency
+- [x] `.github/workflows/cli-pr.yml` defines required job `cli-pr-e2e` on `ubuntu-latest` with Node 24.14.x; runs a matrix across `npm`, `pnpm`, and `yarn`; exercises create, git init, manager-specific install, build, type-check, validate positive + negative, scaffold layout, and ai sync
+- [x] `.github/workflows/cli-nightly.yml` runs on schedule and manual dispatch; covers npm/pnpm/yarn scaffolds, `--uikit none`, layer scaffolds (`sdk`, `framework`, `react`), migrate commands, invalid-name rejection, and ai sync idempotency
 - [x] Both e2e workflows upload step-level logs and JSON summary as CI artifacts even when the scenario fails
 - [x] `npm run test:e2e:pr` and `npm run test:e2e:nightly` in `packages/cli` enable local execution of the same scenarios run in CI

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,14 +56,12 @@ Creates a new HAI3 project or SDK layer package with the specified name.
 - `--layer`, `-l` - Create a package for a specific SDK layer (`sdk`, `framework`, `react`)
 - `--uikit` - UI Kit to use (`hai3` or `custom`)
 - `--studio` / `--no-studio` - Include or exclude Studio package
-- `--no-git` - Skip git initialization
-- `--no-install` - Skip npm install
+- `--package-manager` - Package manager to use (`npm`, `pnpm`, `yarn`)
 
 **Interactive Options (when `--layer` not specified):**
 - UI Kit selection (HAI3 reference implementation or custom)
 - Development overlay inclusion (Studio package)
-- Git repository initialization
-- Automatic dependency installation
+- Package manager selection (`npm` default, `pnpm`, `yarn`)
 
 **Output (App Project - default):**
 - Fully configured Vite + React + TypeScript project

--- a/packages/cli/scripts/e2e-nightly.mjs
+++ b/packages/cli/scripts/e2e-nightly.mjs
@@ -95,6 +95,10 @@ try {
   );
   const appConfig = harness.readJson(path.join(appRoot, 'hai3.config.json'));
   harness.assert(
+    appConfig.packageManager === 'npm',
+    'npm app hai3.config.json must set packageManager to npm'
+  );
+  harness.assert(
     !('packageManagerVersion' in appConfig),
     'npm app hai3.config.json must not include packageManagerVersion'
   );
@@ -120,6 +124,10 @@ try {
   harness.assertPathExists(path.join(pnpmRoot, 'pnpm-workspace.yaml'));
   const pnpmConfig = harness.readJson(path.join(pnpmRoot, 'hai3.config.json'));
   harness.assert(
+    pnpmConfig.packageManager === 'pnpm',
+    'pnpm app hai3.config.json must set packageManager to pnpm'
+  );
+  harness.assert(
     !('packageManagerVersion' in pnpmConfig),
     'pnpm app hai3.config.json must not include packageManagerVersion'
   );
@@ -143,6 +151,10 @@ try {
   );
   harness.assertPathExists(path.join(yarnRoot, '.yarnrc.yml'));
   const yarnConfig = harness.readJson(path.join(yarnRoot, 'hai3.config.json'));
+  harness.assert(
+    yarnConfig.packageManager === 'yarn',
+    'yarn app hai3.config.json must set packageManager to yarn'
+  );
   harness.assert(
     !('packageManagerVersion' in yarnConfig),
     'yarn app hai3.config.json must not include packageManagerVersion'

--- a/packages/cli/scripts/e2e-nightly.mjs
+++ b/packages/cli/scripts/e2e-nightly.mjs
@@ -16,6 +16,11 @@ import { CLI_ENTRY, createHarness, shouldSkipInstall } from './e2e-lib.mjs';
 const harness = createHarness('nightly');
 // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-create-harness
 const skipInstall = shouldSkipInstall();
+const expectedManagerEngines = {
+  npm: '>=10.0.0',
+  pnpm: '>=10.0.0',
+  yarn: '>=4.0.0',
+};
 
 function runScriptArgs(packageManager, scriptName) {
   if (packageManager === 'yarn') {
@@ -82,6 +87,16 @@ try {
     command: 'node',
     args: [CLI_ENTRY, 'create', 'nightly-app', '--no-studio', '--uikit', 'hai3', '--package-manager', 'npm'],
   });
+  const appPackageJson = harness.readJson(path.join(appRoot, 'package.json'));
+  harness.assert(
+    appPackageJson.engines?.npm === expectedManagerEngines.npm,
+    `npm app should require npm ${expectedManagerEngines.npm}`
+  );
+  const appConfig = harness.readJson(path.join(appRoot, 'hai3.config.json'));
+  harness.assert(
+    !('packageManagerVersion' in appConfig),
+    'npm app hai3.config.json must not include packageManagerVersion'
+  );
   maybeInstallAndCheck(appRoot, 'npm', true);
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-create-default
 
@@ -97,7 +112,16 @@ try {
     pnpmPackageJson.packageManager?.startsWith('pnpm@'),
     'pnpm app should set packageManager to pnpm'
   );
+  harness.assert(
+    pnpmPackageJson.engines?.pnpm === expectedManagerEngines.pnpm,
+    `pnpm app should require pnpm ${expectedManagerEngines.pnpm}`
+  );
   harness.assertPathExists(path.join(pnpmRoot, 'pnpm-workspace.yaml'));
+  const pnpmConfig = harness.readJson(path.join(pnpmRoot, 'hai3.config.json'));
+  harness.assert(
+    !('packageManagerVersion' in pnpmConfig),
+    'pnpm app hai3.config.json must not include packageManagerVersion'
+  );
   maybeInstallAndCheck(pnpmRoot, 'pnpm', true);
 
   const yarnRoot = path.join(workspace, 'nightly-yarn');
@@ -112,7 +136,16 @@ try {
     yarnPackageJson.packageManager?.startsWith('yarn@'),
     'yarn app should set packageManager to yarn'
   );
+  harness.assert(
+    yarnPackageJson.engines?.yarn === expectedManagerEngines.yarn,
+    `yarn app should require yarn ${expectedManagerEngines.yarn}`
+  );
   harness.assertPathExists(path.join(yarnRoot, '.yarnrc.yml'));
+  const yarnConfig = harness.readJson(path.join(yarnRoot, 'hai3.config.json'));
+  harness.assert(
+    !('packageManagerVersion' in yarnConfig),
+    'yarn app hai3.config.json must not include packageManagerVersion'
+  );
   maybeInstallAndCheck(yarnRoot, 'yarn', true);
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-migrate-commands

--- a/packages/cli/scripts/e2e-nightly.mjs
+++ b/packages/cli/scripts/e2e-nightly.mjs
@@ -63,10 +63,38 @@ try {
     name: 'create-hai3-app',
     cwd: workspace,
     command: 'node',
-    args: [CLI_ENTRY, 'create', 'nightly-app', '--no-studio', '--uikit', 'hai3'],
+    args: [CLI_ENTRY, 'create', 'nightly-app', '--no-studio', '--uikit', 'hai3', '--package-manager', 'npm'],
   });
   maybeInstallAndCheck(appRoot, true);
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-create-default
+
+  const pnpmRoot = path.join(workspace, 'nightly-pnpm');
+  harness.runStep({
+    name: 'create-pnpm-app',
+    cwd: workspace,
+    command: 'node',
+    args: [CLI_ENTRY, 'create', 'nightly-pnpm', '--no-studio', '--uikit', 'hai3', '--package-manager', 'pnpm'],
+  });
+  const pnpmPackageJson = harness.readJson(path.join(pnpmRoot, 'package.json'));
+  harness.assert(
+    pnpmPackageJson.packageManager?.startsWith('pnpm@'),
+    'pnpm app should set packageManager to pnpm'
+  );
+  harness.assertPathExists(path.join(pnpmRoot, 'pnpm-workspace.yaml'));
+
+  const yarnRoot = path.join(workspace, 'nightly-yarn');
+  harness.runStep({
+    name: 'create-yarn-app',
+    cwd: workspace,
+    command: 'node',
+    args: [CLI_ENTRY, 'create', 'nightly-yarn', '--no-studio', '--uikit', 'hai3', '--package-manager', 'yarn'],
+  });
+  const yarnPackageJson = harness.readJson(path.join(yarnRoot, 'package.json'));
+  harness.assert(
+    yarnPackageJson.packageManager?.startsWith('yarn@'),
+    'yarn app should set packageManager to yarn'
+  );
+  harness.assertPathExists(path.join(yarnRoot, '.yarnrc.yml'));
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-migrate-commands
   harness.runStep({
@@ -106,7 +134,7 @@ try {
     name: 'create-custom-app',
     cwd: workspace,
     command: 'node',
-    args: [CLI_ENTRY, 'create', 'nightly-custom', '--no-studio', '--uikit', 'none'],
+    args: [CLI_ENTRY, 'create', 'nightly-custom', '--no-studio', '--uikit', 'none', '--package-manager', 'npm'],
   });
   const customPackageJson = harness.readJson(path.join(customRoot, 'package.json'));
   harness.assert(

--- a/packages/cli/scripts/e2e-nightly.mjs
+++ b/packages/cli/scripts/e2e-nightly.mjs
@@ -1,5 +1,6 @@
 // @cpt-flow:cpt-hai3-flow-cli-tooling-e2e-nightly:p2
 // @cpt-dod:cpt-hai3-dod-cli-tooling-e2e-nightly:p1
+import fs from 'fs';
 import path from 'path';
 import process from 'node:process';
 import { CLI_ENTRY, createHarness, shouldSkipInstall } from './e2e-lib.mjs';
@@ -206,6 +207,11 @@ try {
       command: 'node',
       args: [CLI_ENTRY, 'create', projectName, '--layer', layer],
     });
+    const layerReadme = fs.readFileSync(path.join(projectRoot, 'README.md'), 'utf8');
+    harness.assert(
+      layerReadme.includes(`npm install ${projectName}`),
+      `Layer README must include install command with package name for ${projectName}`
+    );
     maybeInstallAndCheck(projectRoot, 'npm', true);
   }
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-layer-scaffolds

--- a/packages/cli/scripts/e2e-nightly.mjs
+++ b/packages/cli/scripts/e2e-nightly.mjs
@@ -17,9 +17,26 @@ const harness = createHarness('nightly');
 // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-create-harness
 const skipInstall = shouldSkipInstall();
 
-function maybeInstallAndCheck(projectRoot, includeTypeCheck = true) {
+function runScriptArgs(packageManager, scriptName) {
+  if (packageManager === 'yarn') {
+    return [scriptName];
+  }
+  return ['run', scriptName];
+}
+
+function installArgs(packageManager) {
+  if (packageManager === 'npm') {
+    return ['install', '--no-audit', '--no-fund'];
+  }
+  if (packageManager === 'pnpm') {
+    return ['install', '--no-frozen-lockfile'];
+  }
+  return ['install', '--no-immutable'];
+}
+
+function maybeInstallAndCheck(projectRoot, packageManager = 'npm', includeTypeCheck = true) {
   if (skipInstall) {
-    harness.log(`Skipping npm install/build for ${projectRoot}`);
+    harness.log(`Skipping ${packageManager} install/build for ${projectRoot}`);
     return;
   }
 
@@ -31,25 +48,25 @@ function maybeInstallAndCheck(projectRoot, includeTypeCheck = true) {
   });
 
   harness.runStep({
-    name: `npm-install-${path.basename(projectRoot)}`,
+    name: `${packageManager}-install-${path.basename(projectRoot)}`,
     cwd: projectRoot,
-    command: 'npm',
-    args: ['install', '--no-audit', '--no-fund'],
+    command: packageManager,
+    args: installArgs(packageManager),
   });
 
   harness.runStep({
     name: `build-${path.basename(projectRoot)}`,
     cwd: projectRoot,
-    command: 'npm',
-    args: ['run', 'build'],
+    command: packageManager,
+    args: runScriptArgs(packageManager, 'build'),
   });
 
   if (includeTypeCheck) {
     harness.runStep({
       name: `type-check-${path.basename(projectRoot)}`,
       cwd: projectRoot,
-      command: 'npm',
-      args: ['run', 'type-check'],
+      command: packageManager,
+      args: runScriptArgs(packageManager, 'type-check'),
     });
   }
 }
@@ -65,7 +82,7 @@ try {
     command: 'node',
     args: [CLI_ENTRY, 'create', 'nightly-app', '--no-studio', '--uikit', 'hai3', '--package-manager', 'npm'],
   });
-  maybeInstallAndCheck(appRoot, true);
+  maybeInstallAndCheck(appRoot, 'npm', true);
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-create-default
 
   const pnpmRoot = path.join(workspace, 'nightly-pnpm');
@@ -81,6 +98,7 @@ try {
     'pnpm app should set packageManager to pnpm'
   );
   harness.assertPathExists(path.join(pnpmRoot, 'pnpm-workspace.yaml'));
+  maybeInstallAndCheck(pnpmRoot, 'pnpm', true);
 
   const yarnRoot = path.join(workspace, 'nightly-yarn');
   harness.runStep({
@@ -95,6 +113,7 @@ try {
     'yarn app should set packageManager to yarn'
   );
   harness.assertPathExists(path.join(yarnRoot, '.yarnrc.yml'));
+  maybeInstallAndCheck(yarnRoot, 'yarn', true);
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-migrate-commands
   harness.runStep({
@@ -141,7 +160,7 @@ try {
     !('@hai3/uikit' in (customPackageJson.dependencies || {})),
     'Custom app should not depend on @hai3/uikit'
   );
-  maybeInstallAndCheck(customRoot, true);
+  maybeInstallAndCheck(customRoot, 'npm', true);
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-custom-uikit
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-layer-scaffolds
@@ -154,7 +173,7 @@ try {
       command: 'node',
       args: [CLI_ENTRY, 'create', projectName, '--layer', layer],
     });
-    maybeInstallAndCheck(projectRoot, true);
+    maybeInstallAndCheck(projectRoot, 'npm', true);
   }
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-nightly:p2:inst-e2e-nightly-layer-scaffolds
 

--- a/packages/cli/scripts/e2e-pr-smoke.mjs
+++ b/packages/cli/scripts/e2e-pr-smoke.mjs
@@ -16,6 +16,24 @@ import { CLI_ENTRY, createHarness, shouldSkipInstall } from './e2e-lib.mjs';
 const harness = createHarness('pr');
 // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-create-harness
 const skipInstall = shouldSkipInstall();
+const packageManager = process.env.CLI_E2E_PM || 'npm';
+
+function runScriptArgs(scriptName) {
+  if (packageManager === 'yarn') {
+    return [scriptName];
+  }
+  return ['run', scriptName];
+}
+
+function installArgs() {
+  if (packageManager === 'npm') {
+    return ['install', '--no-audit', '--no-fund'];
+  }
+  if (packageManager === 'pnpm') {
+    return ['install', '--no-frozen-lockfile'];
+  }
+  return ['install'];
+}
 
 function runProjectValidation(projectRoot) {
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-validate-clean
@@ -68,7 +86,16 @@ try {
     name: 'create-app',
     cwd: workspace,
     command: 'node',
-    args: [CLI_ENTRY, 'create', 'smoke-app', '--no-studio', '--uikit', 'hai3'],
+    args: [
+      CLI_ENTRY,
+      'create',
+      'smoke-app',
+      '--no-studio',
+      '--uikit',
+      'hai3',
+      '--package-manager',
+      packageManager,
+    ],
   });
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-create-app
 
@@ -86,6 +113,16 @@ try {
     packageJson.engines?.node === '>=24.14.0',
     'Generated project must pin node >=24.14.0'
   );
+  harness.assert(
+    packageJson.packageManager?.startsWith(`${packageManager}@`),
+    `Generated project must set packageManager to ${packageManager}`
+  );
+  if (packageManager === 'pnpm') {
+    harness.assertPathExists(path.join(projectRoot, 'pnpm-workspace.yaml'));
+  }
+  if (packageManager === 'yarn') {
+    harness.assertPathExists(path.join(projectRoot, '.yarnrc.yml'));
+  }
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-assert-engines
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-git-init-install
@@ -98,10 +135,10 @@ try {
     });
 
     harness.runStep({
-      name: 'npm-install',
+      name: `${packageManager}-install`,
       cwd: projectRoot,
-      command: 'npm',
-      args: ['install', '--no-audit', '--no-fund'],
+      command: packageManager,
+      args: installArgs(),
     });
     // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-git-init-install
 
@@ -109,19 +146,19 @@ try {
     harness.runStep({
       name: 'build-generated-project',
       cwd: projectRoot,
-      command: 'npm',
-      args: ['run', 'build'],
+      command: packageManager,
+      args: runScriptArgs('build'),
     });
 
     harness.runStep({
       name: 'type-check-generated-project',
       cwd: projectRoot,
-      command: 'npm',
-      args: ['run', 'type-check'],
+      command: packageManager,
+      args: runScriptArgs('type-check'),
     });
     // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-build-typecheck
   } else {
-    harness.log('Skipping npm install/build/type-check');
+    harness.log(`Skipping ${packageManager} install/build/type-check`);
   }
 
   runProjectValidation(projectRoot);

--- a/packages/cli/scripts/e2e-pr-smoke.mjs
+++ b/packages/cli/scripts/e2e-pr-smoke.mjs
@@ -32,7 +32,7 @@ function installArgs() {
   if (packageManager === 'pnpm') {
     return ['install', '--no-frozen-lockfile'];
   }
-  return ['install'];
+  return ['install', '--no-immutable'];
 }
 
 function runProjectValidation(projectRoot) {

--- a/packages/cli/scripts/e2e-pr-smoke.mjs
+++ b/packages/cli/scripts/e2e-pr-smoke.mjs
@@ -1,5 +1,6 @@
 // @cpt-flow:cpt-hai3-flow-cli-tooling-e2e-pr:p1
 // @cpt-dod:cpt-hai3-dod-cli-tooling-e2e-pr:p1
+import fs from 'fs';
 import path from 'path';
 import process from 'node:process';
 import { CLI_ENTRY, createHarness, shouldSkipInstall } from './e2e-lib.mjs';
@@ -136,6 +137,12 @@ try {
   harness.assert(
     !('packageManagerVersion' in hai3Config),
     'Generated hai3.config.json must not include packageManagerVersion'
+  );
+  const readmeContent = fs.readFileSync(path.join(projectRoot, 'README.md'), 'utf8');
+  harness.assert(
+    readmeContent.includes(`${packageManager} install`) ||
+      (packageManager === 'yarn' && readmeContent.includes('yarn dev')),
+    'Generated README must include concrete package-manager setup commands'
   );
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-assert-engines
 

--- a/packages/cli/scripts/e2e-pr-smoke.mjs
+++ b/packages/cli/scripts/e2e-pr-smoke.mjs
@@ -17,6 +17,11 @@ const harness = createHarness('pr');
 // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-create-harness
 const skipInstall = shouldSkipInstall();
 const packageManager = process.env.CLI_E2E_PM || 'npm';
+const expectedManagerEngines = {
+  npm: '>=10.0.0',
+  pnpm: '>=10.0.0',
+  yarn: '>=4.0.0',
+};
 
 function runScriptArgs(scriptName) {
   if (packageManager === 'yarn') {
@@ -117,12 +122,21 @@ try {
     packageJson.packageManager?.startsWith(`${packageManager}@`),
     `Generated project must set packageManager to ${packageManager}`
   );
+  harness.assert(
+    packageJson.engines?.[packageManager] === expectedManagerEngines[packageManager],
+    `Generated project engines must require ${packageManager} ${expectedManagerEngines[packageManager]}`
+  );
   if (packageManager === 'pnpm') {
     harness.assertPathExists(path.join(projectRoot, 'pnpm-workspace.yaml'));
   }
   if (packageManager === 'yarn') {
     harness.assertPathExists(path.join(projectRoot, '.yarnrc.yml'));
   }
+  const hai3Config = harness.readJson(path.join(projectRoot, 'hai3.config.json'));
+  harness.assert(
+    !('packageManagerVersion' in hai3Config),
+    'Generated hai3.config.json must not include packageManagerVersion'
+  );
   // @cpt-end:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-assert-engines
 
   // @cpt-begin:cpt-hai3-flow-cli-tooling-e2e-pr:p1:inst-e2e-pr-git-init-install

--- a/packages/cli/scripts/e2e-pr-smoke.mjs
+++ b/packages/cli/scripts/e2e-pr-smoke.mjs
@@ -135,6 +135,10 @@ try {
   }
   const hai3Config = harness.readJson(path.join(projectRoot, 'hai3.config.json'));
   harness.assert(
+    hai3Config.packageManager === packageManager,
+    `Generated hai3.config.json must set packageManager to ${packageManager}`
+  );
+  harness.assert(
     !('packageManagerVersion' in hai3Config),
     'Generated hai3.config.json must not include packageManagerVersion'
   );

--- a/packages/cli/src/commands/ai/sync.ts
+++ b/packages/cli/src/commands/ai/sync.ts
@@ -570,7 +570,9 @@ export const aiSyncCommand: CommandDefinition<AiSyncArgs, AiSyncResult> = {
     const tool = (args.tool ?? 'all') as AiTool;
     const detectPackages = args.detectPackages ?? false;
     const showDiff = args.diff ?? false;
+    // @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
     const packageManager = (await detectPackageManager(projectRoot!, ctx.config)).manager;
+    // @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 
     if (showDiff) {
       logger.info('Showing diff of AI assistant configuration changes...');

--- a/packages/cli/src/commands/ai/sync.ts
+++ b/packages/cli/src/commands/ai/sync.ts
@@ -6,6 +6,8 @@ import path from 'path';
 import fs from 'fs-extra';
 import lodash from 'lodash';
 import type { CommandDefinition } from '../../core/command.js';
+import type { PackageManager } from '../../core/types.js';
+import { detectPackageManager, getRunScriptCommand } from '../../core/packageManager.js';
 
 const { trim } = lodash;
 import { validationOk, validationError } from '../../core/types.js';
@@ -180,8 +182,10 @@ ${userRules}
 async function generateCopilotInstructions(
   projectRoot: string,
   userRules: string | null,
+  packageManager: PackageManager,
   options: GenerateOptions = {}
 ): Promise<{ file: string; changed: boolean }> {
+  const archCheckCommand = getRunScriptCommand(packageManager, 'arch:check');
   let content = `# HAI3 Development Guidelines for GitHub Copilot
 
 Always read \`.ai/GUIDELINES.md\` before making changes.
@@ -203,7 +207,7 @@ For detailed guidance, use these resources:
 3. **FORBIDDEN**: Direct slice dispatch from UI components
 4. **FORBIDDEN**: Hardcoded colors or inline styles
 5. **REQUIRED**: Use \`@hai3/uikit\` components for all UI
-6. **REQUIRED**: Run \`npm run arch:check\` before committing
+6. **REQUIRED**: Run \`${archCheckCommand}\` before committing
 
 ## Available Commands
 
@@ -566,6 +570,7 @@ export const aiSyncCommand: CommandDefinition<AiSyncArgs, AiSyncResult> = {
     const tool = (args.tool ?? 'all') as AiTool;
     const detectPackages = args.detectPackages ?? false;
     const showDiff = args.diff ?? false;
+    const packageManager = (await detectPackageManager(projectRoot!, ctx.config)).manager;
 
     if (showDiff) {
       logger.info('Showing diff of AI assistant configuration changes...');
@@ -640,7 +645,12 @@ export const aiSyncCommand: CommandDefinition<AiSyncArgs, AiSyncResult> = {
     }
 
     if (tool === 'all' || tool === 'copilot') {
-      const result = await generateCopilotInstructions(projectRoot!, userRules, genOptions);
+      const result = await generateCopilotInstructions(
+        projectRoot!,
+        userRules,
+        packageManager,
+        genOptions
+      );
       if (result.changed) filesGenerated.push(result.file);
       if (!showDiff) {
         const copilotCount = await generateCopilotCommands(

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -3,7 +3,18 @@
 import fs from 'fs-extra';
 import path from 'path';
 import type { CommandDefinition } from '../../core/command.js';
-import { validationOk, validationError, type LayerType } from '../../core/types.js';
+import {
+  validationOk,
+  validationError,
+  type LayerType,
+  type PackageManager,
+} from '../../core/types.js';
+import {
+  DEFAULT_PACKAGE_MANAGER,
+  getInstallCommand,
+  getRunScriptCommand,
+  isSupportedPackageManager,
+} from '../../core/packageManager.js';
 import { generateProject } from '../../generators/project.js';
 import { generateLayerPackage } from '../../generators/layerPackage.js';
 import { writeGeneratedFiles } from '../../utils/fs.js';
@@ -17,6 +28,7 @@ export interface CreateCommandArgs {
   projectName: string;
   studio?: boolean;
   uikit?: 'hai3' | 'none';
+  packageManager?: PackageManager;
   layer?: LayerType;
 }
 
@@ -64,6 +76,12 @@ export const createCommand: CommandDefinition<
       type: 'string',
       choices: ['sdk', 'framework', 'react', 'app'],
     },
+    {
+      name: 'package-manager',
+      description: 'Package manager to use',
+      type: 'string',
+      choices: ['npm', 'pnpm', 'yarn'],
+    },
   ],
 
   validate(args, ctx) {
@@ -91,6 +109,13 @@ export const createCommand: CommandDefinition<
       }
     }
     // @cpt-end:cpt-hai3-algo-cli-tooling-validate-project-name:p1:inst-check-layer-enum
+
+    if (args.packageManager && !isSupportedPackageManager(args.packageManager)) {
+      return validationError(
+        'INVALID_PACKAGE_MANAGER',
+        "Invalid package manager. Valid options: npm, pnpm, yarn"
+      );
+    }
     // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-run-name-validation
 
     // Check if directory exists
@@ -106,6 +131,7 @@ export const createCommand: CommandDefinition<
     const { logger, prompt } = ctx;
     const projectPath = path.join(ctx.cwd, args.projectName);
     const layer = args.layer ?? 'app';
+    let packageManager = args.packageManager ?? DEFAULT_PACKAGE_MANAGER;
 
     // @cpt-begin:cpt-hai3-flow-cli-tooling-create-project:p1:inst-check-dir-exists
     // Check for existing directory
@@ -138,6 +164,7 @@ export const createCommand: CommandDefinition<
       const files = await generateLayerPackage({
         packageName: args.projectName,
         layer,
+        packageManager,
       });
 
       // Write files
@@ -162,8 +189,8 @@ export const createCommand: CommandDefinition<
       logger.newline();
       logger.log('Next steps:');
       logger.log(`  cd ${args.projectName}`);
-      logger.log('  npm install');
-      logger.log('  npm run build');
+      logger.log(`  ${getInstallCommand(packageManager)}`);
+      logger.log(`  ${getRunScriptCommand(packageManager, 'build')}`);
       logger.newline();
       logger.log(`This is a ${layer}-layer package.`);
       logger.log('See .ai/GUIDELINES.md for layer-specific rules.');
@@ -215,10 +242,25 @@ export const createCommand: CommandDefinition<
     }
     // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-prompt-uikit
 
+    if (args.packageManager === undefined) {
+      promptQuestions.push({
+        name: 'packageManager',
+        type: 'list' as const,
+        message: 'Select package manager:',
+        choices: [
+          { name: 'npm (default)', value: 'npm' },
+          { name: 'pnpm', value: 'pnpm' },
+          { name: 'yarn', value: 'yarn' },
+        ],
+        default: DEFAULT_PACKAGE_MANAGER,
+      });
+    }
+
     if (promptQuestions.length > 0) {
       const answers = await prompt<{
         studio?: boolean;
         uikit?: 'hai3' | 'none';
+        packageManager?: PackageManager;
       }>(promptQuestions);
 
       if (studio === undefined) {
@@ -226,6 +268,9 @@ export const createCommand: CommandDefinition<
       }
       if (uikit === undefined) {
         uikit = answers.uikit;
+      }
+      if (args.packageManager === undefined) {
+        packageManager = answers.packageManager ?? DEFAULT_PACKAGE_MANAGER;
       }
     }
 
@@ -239,6 +284,7 @@ export const createCommand: CommandDefinition<
       projectName: args.projectName,
       studio: studio!,
       uikit: uikit || 'hai3',
+      packageManager,
       layer,
     });
     // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-run-generate-project
@@ -271,8 +317,8 @@ export const createCommand: CommandDefinition<
     logger.log('Next steps:');
     logger.log(`  cd ${args.projectName}`);
     logger.log('  git init');
-    logger.log('  npm install');
-    logger.log('  npm run dev');
+    logger.log(`  ${getInstallCommand(packageManager)}`);
+    logger.log(`  ${getRunScriptCommand(packageManager, 'dev')}`);
     logger.newline();
     // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-log-success-create
 

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -242,6 +242,7 @@ export const createCommand: CommandDefinition<
     }
     // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-prompt-uikit
 
+    // @cpt-begin:cpt-hai3-flow-cli-tooling-create-project:p1:inst-prompt-package-manager
     if (args.packageManager === undefined) {
       promptQuestions.push({
         name: 'packageManager',
@@ -255,6 +256,7 @@ export const createCommand: CommandDefinition<
         default: DEFAULT_PACKAGE_MANAGER,
       });
     }
+    // @cpt-end:cpt-hai3-flow-cli-tooling-create-project:p1:inst-prompt-package-manager
 
     if (promptQuestions.length > 0) {
       const answers = await prompt<{

--- a/packages/cli/src/commands/scaffold/layout.ts
+++ b/packages/cli/src/commands/scaffold/layout.ts
@@ -3,6 +3,10 @@
 import path from 'path';
 import type { CommandDefinition } from '../../core/command.js';
 import { validationOk, validationError } from '../../core/types.js';
+import {
+  detectPackageManager,
+  getAddPackagesCommand,
+} from '../../core/packageManager.js';
 import { copyLayoutTemplates } from '../../generators/layoutFromTemplate.js';
 import { writeGeneratedFiles } from '../../utils/fs.js';
 
@@ -91,8 +95,10 @@ export const scaffoldLayoutCommand: CommandDefinition<
     }
     logger.newline();
 
+    const packageManager = (await detectPackageManager(projectRoot!, ctx.config)).manager;
+
     logger.info('Note: Make sure @hai3/uikit is installed:');
-    logger.log('  npm install @hai3/uikit');
+    logger.log(`  ${getAddPackagesCommand(packageManager, ['@hai3/uikit'])}`);
     logger.newline();
 
     const layoutPath = path.join(projectRoot!, 'src', 'app', 'layout');

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -7,6 +7,12 @@ import path from 'path';
 import type { CommandDefinition } from '../../core/command.js';
 import { validationOk, validationError } from '../../core/types.js';
 import { syncTemplates } from '../../core/templates.js';
+import {
+  DEFAULT_PACKAGE_MANAGER,
+  detectPackageManager,
+  getAddPackagesCommand,
+  getGlobalInstallCommand,
+} from '../../core/packageManager.js';
 import { aiSyncCommand } from '../ai/sync.js';
 
 /**
@@ -115,6 +121,9 @@ export const updateCommand: CommandDefinition<
 
   async execute(args, ctx): Promise<UpdateCommandResult> {
     const { logger, projectRoot } = ctx;
+    const packageManagerCtx = projectRoot
+      ? await detectPackageManager(projectRoot, ctx.config)
+      : { manager: DEFAULT_PACKAGE_MANAGER };
 
     let cliUpdated = false;
     let projectUpdated = false;
@@ -148,9 +157,21 @@ export const updateCommand: CommandDefinition<
       // Update CLI
       logger.info('Checking for CLI updates...');
       try {
-        execSync(`npm install -g @hai3/cli${tag}`, { stdio: 'pipe' });
-        cliUpdated = true;
-        logger.success(`@hai3/cli updated (${channel})`);
+        const cliUpdateTarget = `@hai3/cli${tag}`;
+        const globalInstallCmd = getGlobalInstallCommand(
+          packageManagerCtx.manager,
+          cliUpdateTarget
+        );
+
+        if (!globalInstallCmd) {
+          logger.warn(
+            `Global CLI update is not supported for ${packageManagerCtx.manager}. Skipping global update.`
+          );
+        } else {
+          execSync(globalInstallCmd, { stdio: 'pipe' });
+          cliUpdated = true;
+          logger.success(`@hai3/cli updated (${channel})`);
+        }
       } catch {
         logger.info('@hai3/cli is already up to date');
       }
@@ -186,7 +207,10 @@ export const updateCommand: CommandDefinition<
           try {
             // Install each package with the appropriate tag
             const packagesWithTag = packagesToUpdate.map(pkg => `${pkg}${tag}`);
-            const updateCmd = `npm install ${packagesWithTag.join(' ')}`;
+            const updateCmd = getAddPackagesCommand(
+              packageManagerCtx.manager,
+              packagesWithTag
+            );
             execSync(updateCmd, { cwd: projectRoot, stdio: 'inherit' });
             projectUpdated = true;
             updatedPackages.push(...packagesToUpdate);
@@ -225,6 +249,9 @@ export const updateCommand: CommandDefinition<
         for (const file of synced) {
           logger.info(`  - ${file}`);
         }
+        logger.info(
+          `Tip: run \`${packageManagerCtx.manager} install\` to refresh workspace dependencies after template sync.`
+        );
       } else {
         logger.info('Templates are already up to date');
       }

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -4,6 +4,7 @@
 import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import type { CommandDefinition } from '../../core/command.js';
 import { validationOk, validationError } from '../../core/types.js';
 import { syncTemplates } from '../../core/templates.js';
@@ -45,11 +46,21 @@ export interface UpdateCommandResult {
  */
 function detectCurrentChannel(): 'alpha' | 'stable' {
   try {
-    // @cpt-begin:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-run-npm-list
-    const output = execSync('npm list -g @hai3/cli --json', { stdio: 'pipe' }).toString();
-    const data = JSON.parse(output);
-    const version = data.dependencies?.['@hai3/cli']?.version || '';
-    // @cpt-end:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-run-npm-list
+    const currentFile = fileURLToPath(import.meta.url);
+    let searchDir = path.dirname(currentFile);
+    let version = '';
+
+    while (searchDir !== path.dirname(searchDir)) {
+      const packageJsonPath = path.join(searchDir, 'package.json');
+      if (fs.pathExistsSync(packageJsonPath)) {
+        const packageJson = fs.readJsonSync(packageJsonPath);
+        if (packageJson.name === '@hai3/cli' && typeof packageJson.version === 'string') {
+          version = packageJson.version;
+          break;
+        }
+      }
+      searchDir = path.dirname(searchDir);
+    }
 
     // @cpt-begin:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-check-prerelease-tag
     // Check for prerelease identifiers (alpha, beta, rc, etc.)

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -50,17 +50,21 @@ function detectCurrentChannel(): 'alpha' | 'stable' {
     let searchDir = path.dirname(currentFile);
     let version = '';
 
+    // @cpt-begin:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-read-cli-package-version
     while (searchDir !== path.dirname(searchDir)) {
       const packageJsonPath = path.join(searchDir, 'package.json');
       if (fs.pathExistsSync(packageJsonPath)) {
         const packageJson = fs.readJsonSync(packageJsonPath);
+        // @cpt-begin:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-read-cli-version-string
         if (packageJson.name === '@hai3/cli' && typeof packageJson.version === 'string') {
           version = packageJson.version;
           break;
         }
+        // @cpt-end:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-read-cli-version-string
       }
       searchDir = path.dirname(searchDir);
     }
+    // @cpt-end:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-read-cli-package-version
 
     // @cpt-begin:cpt-hai3-algo-cli-tooling-detect-release-channel:p1:inst-check-prerelease-tag
     // Check for prerelease identifiers (alpha, beta, rc, etc.)

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -5,6 +5,7 @@
 export type { CommandContext, CommandDefinition } from './command.js';
 export type {
   Hai3Config,
+  PackageManager,
   ScreensetCategory,
   ArgDefinition,
   OptionDefinition,
@@ -15,6 +16,22 @@ export type {
   GeneratedFile,
 } from './types.js';
 export { validationOk, validationError } from './types.js';
+export {
+  SUPPORTED_PACKAGE_MANAGERS,
+  DEFAULT_PACKAGE_MANAGER,
+  isSupportedPackageManager,
+  parsePackageManagerField,
+  packageManagerFieldValue,
+  detectPackageManager,
+  getInstallCommand,
+  getRunScriptCommand,
+  getWorkspaceRunScriptCommand,
+  getExecCommand,
+  getAddPackagesCommand,
+  getGlobalInstallCommand,
+  getManagerWorkspaceFiles,
+  transformPackageManagerText,
+} from './packageManager.js';
 export { Logger } from './logger.js';
 export type { PromptFn, PromptQuestion } from './prompt.js';
 export { createInteractivePrompt, createProgrammaticPrompt } from './prompt.js';

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -19,9 +19,12 @@ export { validationOk, validationError } from './types.js';
 export {
   SUPPORTED_PACKAGE_MANAGERS,
   DEFAULT_PACKAGE_MANAGER,
+  PACKAGE_MANAGER_POLICY,
   isSupportedPackageManager,
   parsePackageManagerField,
   packageManagerFieldValue,
+  getPackageManagerEngineRange,
+  getPackageManagerEngines,
   detectPackageManager,
   getInstallCommand,
   getRunScriptCommand,

--- a/packages/cli/src/core/packageManager.ts
+++ b/packages/cli/src/core/packageManager.ts
@@ -1,0 +1,181 @@
+import fs from 'fs-extra';
+import path from 'path';
+import type { Hai3Config, PackageManager } from './types.js';
+
+export const SUPPORTED_PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn'];
+export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'npm';
+
+const DEFAULT_VERSIONS: Record<PackageManager, string> = {
+  npm: '11.0.0',
+  pnpm: '9.0.0',
+  yarn: '4.0.0',
+};
+
+export interface PackageManagerContext {
+  manager: PackageManager;
+  version?: string;
+  linkerMode?: 'node-modules' | 'pnp';
+}
+
+export function isSupportedPackageManager(value: unknown): value is PackageManager {
+  return typeof value === 'string' && SUPPORTED_PACKAGE_MANAGERS.includes(value as PackageManager);
+}
+
+export function parsePackageManagerField(value: string | undefined): PackageManagerContext | null {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const managerId = value.split('@')[0];
+  if (!isSupportedPackageManager(managerId)) {
+    return null;
+  }
+  const atIndex = value.indexOf('@');
+  const version = atIndex > -1 ? value.slice(atIndex + 1) : undefined;
+  return {
+    manager: managerId,
+    version,
+  };
+}
+
+export function packageManagerFieldValue(
+  manager: PackageManager,
+  version: string = DEFAULT_VERSIONS[manager]
+): string {
+  return `${manager}@${version}`;
+}
+
+export async function detectPackageManager(
+  projectRoot: string,
+  config?: Hai3Config | null
+): Promise<PackageManagerContext> {
+  if (config?.packageManager && isSupportedPackageManager(config.packageManager)) {
+    return {
+      manager: config.packageManager,
+      version: config.packageManagerVersion,
+      linkerMode: config.linkerMode,
+    };
+  }
+
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  if (await fs.pathExists(packageJsonPath)) {
+    try {
+      const packageJson = await fs.readJson(packageJsonPath);
+      const fromField = parsePackageManagerField(packageJson.packageManager);
+      if (fromField) {
+        return fromField;
+      }
+    } catch {
+      // Fall through to default.
+    }
+  }
+
+  return { manager: DEFAULT_PACKAGE_MANAGER };
+}
+
+export function getInstallCommand(manager: PackageManager): string {
+  if (manager === 'yarn') {
+    return 'yarn install';
+  }
+  return `${manager} install`;
+}
+
+export function getRunScriptCommand(manager: PackageManager, scriptName: string): string {
+  if (manager === 'yarn') {
+    return `yarn ${scriptName}`;
+  }
+  return `${manager} run ${scriptName}`;
+}
+
+export function getWorkspaceRunScriptCommand(
+  manager: PackageManager,
+  workspaceName: string,
+  scriptName: string
+): string {
+  if (manager === 'pnpm') {
+    return `pnpm --filter ${workspaceName} run ${scriptName}`;
+  }
+  if (manager === 'yarn') {
+    return `yarn workspace ${workspaceName} run ${scriptName}`;
+  }
+  return `npm run ${scriptName} --workspace=${workspaceName}`;
+}
+
+export function getExecCommand(manager: PackageManager, command: string): string {
+  if (manager === 'npm') {
+    return `npm exec -- ${command}`;
+  }
+  return `${manager} exec ${command}`;
+}
+
+export function getAddPackagesCommand(
+  manager: PackageManager,
+  packages: string[],
+  options?: { dev?: boolean }
+): string {
+  const pkgList = packages.join(' ');
+  if (manager === 'npm') {
+    return options?.dev ? `npm install -D ${pkgList}` : `npm install ${pkgList}`;
+  }
+  if (manager === 'pnpm') {
+    return options?.dev ? `pnpm add -D ${pkgList}` : `pnpm add ${pkgList}`;
+  }
+  return options?.dev ? `yarn add -D ${pkgList}` : `yarn add ${pkgList}`;
+}
+
+export function getGlobalInstallCommand(manager: PackageManager, target: string): string | null {
+  if (manager === 'npm') {
+    return `npm install -g ${target}`;
+  }
+  if (manager === 'pnpm') {
+    return `pnpm add -g ${target}`;
+  }
+  return null;
+}
+
+export function getManagerWorkspaceFiles(manager: PackageManager): Array<{ path: string; content: string }> {
+  if (manager === 'pnpm') {
+    return [
+      {
+        path: 'pnpm-workspace.yaml',
+        content: 'packages:\n  - eslint-plugin-local\n',
+      },
+    ];
+  }
+  if (manager === 'yarn') {
+    return [
+      {
+        path: '.yarnrc.yml',
+        content: 'nodeLinker: node-modules\n',
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Transform npm-focused command snippets to the configured package manager.
+ * This is intentionally string-based so it can be used for docs, templates and comments.
+ */
+export function transformPackageManagerText(content: string, manager: PackageManager): string {
+  if (manager === 'npm') {
+    return content;
+  }
+
+  let transformed = content;
+
+  transformed = transformed.replace(
+    /\bnpm run ([\w:-]+)\s+--workspace=([@/\w.-]+)/g,
+    (_match, scriptName: string, workspaceName: string) =>
+      getWorkspaceRunScriptCommand(manager, workspaceName, scriptName)
+  );
+
+  transformed = transformed.replace(
+    /\bnpm run ([\w:-]+)/g,
+    (_match, scriptName: string) => getRunScriptCommand(manager, scriptName)
+  );
+
+  transformed = transformed.replace(/\bnpm ci\b/g, getInstallCommand(manager));
+  transformed = transformed.replace(/\bnpm install(?!\s+-g)\b/g, getInstallCommand(manager));
+
+  return transformed;
+}

--- a/packages/cli/src/core/packageManager.ts
+++ b/packages/cli/src/core/packageManager.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import type { Hai3Config, PackageManager } from './types.js';
 
+// @cpt-algo:cpt-hai3-algo-cli-tooling-package-manager-policy:p1
 export const SUPPORTED_PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn'];
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'npm';
 
@@ -41,6 +42,7 @@ export function isSupportedPackageManager(value: unknown): value is PackageManag
   return typeof value === 'string' && SUPPORTED_PACKAGE_MANAGERS.includes(value as PackageManager);
 }
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-parse-package-manager-field
 export function parsePackageManagerField(value: string | undefined): PackageManagerContext | null {
   if (!value || typeof value !== 'string') {
     return null;
@@ -56,14 +58,18 @@ export function parsePackageManagerField(value: string | undefined): PackageMana
     version,
   };
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-parse-package-manager-field
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-field
 export function packageManagerFieldValue(
   manager: PackageManager,
   version: string = PACKAGE_MANAGER_POLICY[manager].defaultVersion
 ): string {
   return `${manager}@${version}`;
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-field
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-engines
 export function getPackageManagerEngineRange(manager: PackageManager): string {
   return PACKAGE_MANAGER_POLICY[manager].minEngine;
 }
@@ -77,7 +83,9 @@ export function getPackageManagerEngines(
     [manager]: getPackageManagerEngineRange(manager),
   };
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-engines
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 export async function detectPackageManager(
   projectRoot: string,
   config?: Hai3Config | null
@@ -112,7 +120,9 @@ export async function detectPackageManager(
 
   return { manager: DEFAULT_PACKAGE_MANAGER };
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 export function getInstallCommand(manager: PackageManager): string {
   if (manager === 'yarn') {
     return 'yarn install';
@@ -162,6 +172,7 @@ export function getAddPackagesCommand(
   }
   return options?.dev ? `yarn add -D ${pkgList}` : `yarn add ${pkgList}`;
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 
 export function getGlobalInstallCommand(manager: PackageManager, target: string): string | null {
   if (manager === 'npm') {
@@ -173,6 +184,7 @@ export function getGlobalInstallCommand(manager: PackageManager, target: string)
   return null;
 }
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-workspace-files
 export function getManagerWorkspaceFiles(manager: PackageManager): Array<{ path: string; content: string }> {
   if (manager === 'pnpm') {
     return [
@@ -192,11 +204,13 @@ export function getManagerWorkspaceFiles(manager: PackageManager): Array<{ path:
   }
   return [];
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-workspace-files
 
 /**
  * Transform npm-focused command snippets to the configured package manager.
  * This is intentionally string-based so it can be used for docs, templates and comments.
  */
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-transform-package-manager-text
 export function transformPackageManagerText(content: string, manager: PackageManager): string {
   if (manager === 'npm') {
     return content;
@@ -220,3 +234,4 @@ export function transformPackageManagerText(content: string, manager: PackageMan
 
   return transformed;
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-transform-package-manager-text

--- a/packages/cli/src/core/packageManager.ts
+++ b/packages/cli/src/core/packageManager.ts
@@ -5,10 +5,30 @@ import type { Hai3Config, PackageManager } from './types.js';
 export const SUPPORTED_PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn'];
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'npm';
 
-const DEFAULT_VERSIONS: Record<PackageManager, string> = {
-  npm: '11.0.0',
-  pnpm: '9.0.0',
-  yarn: '4.0.0',
+interface PackageManagerPolicy {
+  /**
+   * Default exact PM version written to package.json.packageManager.
+   */
+  defaultVersion: string;
+  /**
+   * Minimum supported PM range written to package.json.engines.
+   */
+  minEngine: string;
+}
+
+export const PACKAGE_MANAGER_POLICY: Record<PackageManager, PackageManagerPolicy> = {
+  npm: {
+    defaultVersion: '11.0.0',
+    minEngine: '>=10.0.0',
+  },
+  pnpm: {
+    defaultVersion: '10.0.0',
+    minEngine: '>=10.0.0',
+  },
+  yarn: {
+    defaultVersion: '4.0.0',
+    minEngine: '>=4.0.0',
+  },
 };
 
 export interface PackageManagerContext {
@@ -39,34 +59,55 @@ export function parsePackageManagerField(value: string | undefined): PackageMana
 
 export function packageManagerFieldValue(
   manager: PackageManager,
-  version: string = DEFAULT_VERSIONS[manager]
+  version: string = PACKAGE_MANAGER_POLICY[manager].defaultVersion
 ): string {
   return `${manager}@${version}`;
+}
+
+export function getPackageManagerEngineRange(manager: PackageManager): string {
+  return PACKAGE_MANAGER_POLICY[manager].minEngine;
+}
+
+export function getPackageManagerEngines(
+  manager: PackageManager,
+  nodeRange: string
+): Record<string, string> {
+  return {
+    node: nodeRange,
+    [manager]: getPackageManagerEngineRange(manager),
+  };
 }
 
 export async function detectPackageManager(
   projectRoot: string,
   config?: Hai3Config | null
 ): Promise<PackageManagerContext> {
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  let packageJsonContext: PackageManagerContext | null = null;
+
+  if (await fs.pathExists(packageJsonPath)) {
+    try {
+      const packageJson = await fs.readJson(packageJsonPath);
+      packageJsonContext = parsePackageManagerField(packageJson.packageManager);
+    } catch {
+      // Fall through to other sources.
+    }
+  }
+
   if (config?.packageManager && isSupportedPackageManager(config.packageManager)) {
     return {
       manager: config.packageManager,
-      version: config.packageManagerVersion,
+      version:
+        config.packageManagerVersion ??
+        (packageJsonContext?.manager === config.packageManager
+          ? packageJsonContext.version
+          : undefined),
       linkerMode: config.linkerMode,
     };
   }
 
-  const packageJsonPath = path.join(projectRoot, 'package.json');
-  if (await fs.pathExists(packageJsonPath)) {
-    try {
-      const packageJson = await fs.readJson(packageJsonPath);
-      const fromField = parsePackageManagerField(packageJson.packageManager);
-      if (fromField) {
-        return fromField;
-      }
-    } catch {
-      // Fall through to default.
-    }
+  if (packageJsonContext) {
+    return packageJsonContext;
   }
 
   return { manager: DEFAULT_PACKAGE_MANAGER };

--- a/packages/cli/src/core/templates.ts
+++ b/packages/cli/src/core/templates.ts
@@ -72,6 +72,10 @@ async function transformPathForPackageManager(
   targetPath: string,
   manager: 'npm' | 'pnpm' | 'yarn'
 ): Promise<void> {
+  if (manager === 'npm') {
+    return;
+  }
+
   if (!(await fs.pathExists(targetPath))) {
     return;
   }
@@ -190,6 +194,7 @@ async function syncDirectory(
       }
     }
 
+    // @cpt-begin:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-skip-variant-app-files
     // Remove stale template-variant files that may have been synced previously.
     if (relativePath === 'src/app' || relativePath === 'src\\app') {
       for (const variantFile of variantAppFiles) {
@@ -199,6 +204,7 @@ async function syncDirectory(
         }
       }
     }
+    // @cpt-end:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-skip-variant-app-files
     return;
   }
 
@@ -271,9 +277,11 @@ export async function syncTemplates(
   }
 
   const packageManager = (await detectPackageManager(projectRoot)).manager;
+  // @cpt-begin:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-transform-synced-files
   for (const syncedPath of synced) {
     await transformPathForPackageManager(path.join(projectRoot, syncedPath), packageManager);
   }
+  // @cpt-end:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-transform-synced-files
 
   // @cpt-begin:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-return-synced-dirs
   return synced;

--- a/packages/cli/src/core/templates.ts
+++ b/packages/cli/src/core/templates.ts
@@ -21,6 +21,10 @@ import {
   isTargetApplicableToLayer,
   type LayerType,
 } from './layers.js';
+import {
+  detectPackageManager,
+  transformPackageManagerText,
+} from './packageManager.js';
 
 /**
  * Items to EXCLUDE from template sync (internal CLI files only)
@@ -48,6 +52,50 @@ export interface TemplateLogger {
   warn?: (msg: string) => void;
 }
 
+function shouldTransformFile(filePath: string): boolean {
+  const ext = path.extname(filePath);
+  const textExtensions = new Set([
+    '.md',
+    '.mdc',
+    '.ts',
+    '.tsx',
+    '.js',
+    '.cjs',
+    '.mjs',
+    '.yaml',
+    '.yml',
+  ]);
+  return textExtensions.has(ext);
+}
+
+async function transformPathForPackageManager(
+  targetPath: string,
+  manager: 'npm' | 'pnpm' | 'yarn'
+): Promise<void> {
+  if (!(await fs.pathExists(targetPath))) {
+    return;
+  }
+
+  const stats = await fs.stat(targetPath);
+  if (stats.isDirectory()) {
+    const entries = await fs.readdir(targetPath);
+    for (const entry of entries) {
+      await transformPathForPackageManager(path.join(targetPath, entry), manager);
+    }
+    return;
+  }
+
+  if (!shouldTransformFile(targetPath)) {
+    return;
+  }
+
+  const content = await fs.readFile(targetPath, 'utf-8');
+  const transformed = transformPackageManagerText(content, manager);
+  if (transformed !== content) {
+    await fs.writeFile(targetPath, transformed);
+  }
+}
+
 /**
  * Sync a directory, preserving user content in specific subdirectories
  *
@@ -59,6 +107,13 @@ async function syncDirectory(
   destDir: string,
   relativePath: string
 ): Promise<void> {
+  const variantAppFiles = new Set([
+    'App.no-studio.tsx',
+    'App.no-uikit.tsx',
+    'App.no-uikit.no-studio.tsx',
+    'main.no-uikit.tsx',
+  ]);
+
   // Special handling for src/screensets/ - preserve user screensets
   if (relativePath === 'src/screensets' || relativePath === 'src\\screensets') {
     await fs.ensureDir(destDir);
@@ -113,6 +168,16 @@ async function syncDirectory(
     const entries = await fs.readdir(srcDir, { withFileTypes: true });
 
     for (const entry of entries) {
+      // Template variant files are only used during project generation and
+      // must never be synced into existing projects.
+      if (
+        (relativePath === 'src/app' || relativePath === 'src\\app') &&
+        entry.isFile() &&
+        variantAppFiles.has(entry.name)
+      ) {
+        continue;
+      }
+
       const srcPath = path.join(srcDir, entry.name);
       const destPath = path.join(destDir, entry.name);
       const subRelativePath = path.join(relativePath, entry.name);
@@ -122,6 +187,16 @@ async function syncDirectory(
       } else {
         // Files in src/ root (like main.tsx, App.tsx) are replaced
         await fs.copy(srcPath, destPath, { overwrite: true });
+      }
+    }
+
+    // Remove stale template-variant files that may have been synced previously.
+    if (relativePath === 'src/app' || relativePath === 'src\\app') {
+      for (const variantFile of variantAppFiles) {
+        const variantPath = path.join(destDir, variantFile);
+        if (await fs.pathExists(variantPath)) {
+          await fs.remove(variantPath);
+        }
       }
     }
     return;
@@ -193,6 +268,11 @@ export async function syncTemplates(
     } catch (err) {
       logger.info(`  Warning: Could not sync ${name}: ${err}`);
     }
+  }
+
+  const packageManager = (await detectPackageManager(projectRoot)).manager;
+  for (const syncedPath of synced) {
+    await transformPathForPackageManager(path.join(projectRoot, syncedPath), packageManager);
   }
 
   // @cpt-begin:cpt-hai3-algo-cli-tooling-sync-templates:p2:inst-return-synced-dirs

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -6,6 +6,7 @@
  * Layer types for SDK architecture
  */
 export type LayerType = 'sdk' | 'framework' | 'react' | 'app';
+export type PackageManager = 'npm' | 'pnpm' | 'yarn';
 
 /**
  * HAI3 project configuration stored in hai3.config.json
@@ -18,6 +19,12 @@ export interface Hai3Config {
   layer?: LayerType;
   /** UI Kit selection: 'none' means no UIKit, any other string is the UIKit identifier */
   uikit?: string;
+  /** Selected package manager for this project */
+  packageManager?: PackageManager;
+  /** Optional package manager version recorded at project creation */
+  packageManagerVersion?: string;
+  /** Optional linker mode (used by yarn) */
+  linkerMode?: 'node-modules' | 'pnp';
 }
 
 /**

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -21,7 +21,10 @@ export interface Hai3Config {
   uikit?: string;
   /** Selected package manager for this project */
   packageManager?: PackageManager;
-  /** Optional package manager version recorded at project creation */
+  /**
+   * Optional legacy package manager version.
+   * Kept for backwards compatibility with older generated configs.
+   */
   packageManagerVersion?: string;
   /** Optional linker mode (used by yarn) */
   linkerMode?: 'node-modules' | 'pnp';

--- a/packages/cli/src/generators/layerPackage.ts
+++ b/packages/cli/src/generators/layerPackage.ts
@@ -459,7 +459,6 @@ Apache-2.0
         hai3: true,
         layer,
         packageManager,
-        packageManagerVersion: packageManagerFieldValue(packageManager).split('@')[1],
       },
       null,
       2

--- a/packages/cli/src/generators/layerPackage.ts
+++ b/packages/cli/src/generators/layerPackage.ts
@@ -1,7 +1,14 @@
 // @cpt-flow:cpt-hai3-flow-cli-tooling-scaffold-layout:p1
 import path from 'path';
 import fs from 'fs-extra';
-import type { GeneratedFile, LayerType } from '../core/types.js';
+import type { GeneratedFile, LayerType, PackageManager } from '../core/types.js';
+import {
+  DEFAULT_PACKAGE_MANAGER,
+  getInstallCommand,
+  getRunScriptCommand,
+  packageManagerFieldValue,
+  transformPackageManagerText,
+} from '../core/packageManager.js';
 import { getTemplatesDir } from '../core/templates.js';
 import { isTargetApplicableToLayer, selectCommandVariant } from '../core/layers.js';
 
@@ -13,6 +20,8 @@ export interface LayerPackageInput {
   packageName: string;
   /** SDK layer */
   layer: LayerType;
+  /** Package manager to configure package for */
+  packageManager?: PackageManager;
 }
 
 /**
@@ -300,7 +309,7 @@ function getTsConfig(layer: LayerType): string {
  */
 // @cpt-begin:cpt-hai3-flow-cli-tooling-scaffold-layout:p1:inst-write-layout-files
 export async function generateLayerPackage(input: LayerPackageInput): Promise<GeneratedFile[]> {
-  const { packageName, layer } = input;
+  const { packageName, layer, packageManager = DEFAULT_PACKAGE_MANAGER } = input;
   const files: GeneratedFile[] = [];
   const deps = getLayerDependencies(layer);
 
@@ -309,6 +318,7 @@ export async function generateLayerPackage(input: LayerPackageInput): Promise<Ge
     name: packageName,
     version: '0.1.0',
     type: 'module',
+    packageManager: packageManagerFieldValue(packageManager),
     main: './dist/index.cjs',
     module: './dist/index.js',
     types: './dist/index.d.ts',
@@ -397,7 +407,7 @@ A HAI3 ${layer}-layer package.
 ## Installation
 
 \`\`\`bash
-npm install ${packageName}
+${getInstallCommand(packageManager)}
 \`\`\`
 
 ## Usage
@@ -411,10 +421,10 @@ console.log(VERSION);
 ## Development
 
 \`\`\`bash
-npm run dev     # Watch mode
-npm run build   # Production build
-npm run lint    # ESLint
-npm run type-check  # TypeScript check
+${getRunScriptCommand(packageManager, 'dev')}     # Watch mode
+${getRunScriptCommand(packageManager, 'build')}   # Production build
+${getRunScriptCommand(packageManager, 'lint')}    # ESLint
+${getRunScriptCommand(packageManager, 'type-check')}  # TypeScript check
 \`\`\`
 
 ## Layer: ${layer}
@@ -448,6 +458,8 @@ Apache-2.0
       {
         hai3: true,
         layer,
+        packageManager,
+        packageManagerVersion: packageManagerFieldValue(packageManager).split('@')[1],
       },
       null,
       2
@@ -525,6 +537,12 @@ Apache-2.0
         // Copy to .ai/commands/ directory
         files.push({ path: `.ai/commands/${baseName}`, content });
       }
+    }
+  }
+
+  for (const file of files) {
+    if (/\.(md|mdc|ts|tsx|js|cjs|mjs|yaml|yml)$/.test(file.path)) {
+      file.content = transformPackageManagerText(file.content, packageManager);
     }
   }
 

--- a/packages/cli/src/generators/layerPackage.ts
+++ b/packages/cli/src/generators/layerPackage.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import type { GeneratedFile, LayerType, PackageManager } from '../core/types.js';
 import {
   DEFAULT_PACKAGE_MANAGER,
-  getInstallCommand,
+  getAddPackagesCommand,
   getRunScriptCommand,
   packageManagerFieldValue,
   transformPackageManagerText,
@@ -407,7 +407,7 @@ A HAI3 ${layer}-layer package.
 ## Installation
 
 \`\`\`bash
-${getInstallCommand(packageManager)}
+${getAddPackagesCommand(packageManager, [packageName])}
 \`\`\`
 
 ## Usage

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -2,7 +2,19 @@
 // @cpt-dod:cpt-hai3-dod-cli-tooling-templates:p1
 import path from 'path';
 import fs from 'fs-extra';
-import type { GeneratedFile, Hai3Config, LayerType } from '../core/types.js';
+import type {
+  GeneratedFile,
+  Hai3Config,
+  LayerType,
+  PackageManager,
+} from '../core/types.js';
+import {
+  DEFAULT_PACKAGE_MANAGER,
+  getManagerWorkspaceFiles,
+  getWorkspaceRunScriptCommand,
+  packageManagerFieldValue,
+  transformPackageManagerText,
+} from '../core/packageManager.js';
 import { getTemplatesDir } from '../core/templates.js';
 import { isTargetApplicableToLayer, selectCommandVariant } from '../core/layers.js';
 
@@ -16,6 +28,8 @@ export interface ProjectGeneratorInput {
   studio: boolean;
   /** UIKit option: 'hai3' (default) or 'none' */
   uikit?: 'hai3' | 'none';
+  /** Package manager to configure generated project for */
+  packageManager?: PackageManager;
   /** Project layer (SDK architecture tier) */
   layer?: LayerType;
 }
@@ -50,6 +64,22 @@ async function readDirRecursive(
   return files;
 }
 
+function shouldTransformForPackageManager(filePath: string): boolean {
+  const textExtensions = new Set([
+    '.md',
+    '.mdc',
+    '.ts',
+    '.tsx',
+    '.js',
+    '.cjs',
+    '.mjs',
+    '.yaml',
+    '.yml',
+  ]);
+  const ext = path.extname(filePath);
+  return textExtensions.has(ext);
+}
+
 /**
  * Generate all files for a new HAI3 project
  * Combines template files with dynamically generated config files
@@ -57,7 +87,13 @@ async function readDirRecursive(
 export async function generateProject(
   input: ProjectGeneratorInput
 ): Promise<GeneratedFile[]> {
-  const { projectName, studio, uikit = 'hai3', layer = 'app' } = input;
+  const {
+    projectName,
+    studio,
+    uikit = 'hai3',
+    packageManager = DEFAULT_PACKAGE_MANAGER,
+    layer = 'app',
+  } = input;
   const templatesDir = getTemplatesDir();
   const files: GeneratedFile[] = [];
 
@@ -337,6 +373,9 @@ export async function generateProject(
     hai3: true,
     layer,
     uikit,
+    packageManager,
+    packageManagerVersion: packageManagerFieldValue(packageManager).split('@')[1],
+    ...(packageManager === 'yarn' ? { linkerMode: 'node-modules' as const } : {}),
   };
   files.push({
     path: 'hai3.config.json',
@@ -404,39 +443,47 @@ export async function generateProject(
     dependencies['@hai3/uikit'] = 'alpha';
   }
 
+  const workspaceBuildCommand = getWorkspaceRunScriptCommand(
+    packageManager,
+    'eslint-plugin-local',
+    'build'
+  );
+
   const packageJson = {
     name: projectName,
     version: '0.1.0',
     private: true,
     type: 'module',
+    packageManager: packageManagerFieldValue(packageManager),
     engines: {
       node: '>=24.14.0',
-      npm: '>=11.0.0',
+      ...(packageManager === 'npm' ? { npm: '>=11.0.0' } : {}),
+      ...(packageManager === 'pnpm' ? { pnpm: '>=9.0.0' } : {}),
+      ...(packageManager === 'yarn' ? { yarn: '>=4.0.0' } : {}),
     },
     workspaces: ['eslint-plugin-local'],
     scripts: {
-      'generate:mfe-manifests': 'npx tsx scripts/generate-mfe-manifests.ts',
+      'generate:mfe-manifests': 'tsx scripts/generate-mfe-manifests.ts',
       dev: uikit === 'hai3'
-        ? 'npm run generate:mfe-manifests && npm run generate:colors && vite'
-        : 'npm run generate:mfe-manifests && vite',
-      'dev:all': 'npm run generate:mfe-manifests && npx tsx scripts/dev-all.ts',
-      'check:mcp': 'npx tsx scripts/check-mcp.ts',
+        ? 'tsx scripts/generate-mfe-manifests.ts && tsx scripts/generate-colors.ts && vite'
+        : 'tsx scripts/generate-mfe-manifests.ts && vite',
+      'dev:all': 'tsx scripts/generate-mfe-manifests.ts && tsx scripts/dev-all.ts',
+      'check:mcp': 'tsx scripts/check-mcp.ts',
       build: uikit === 'hai3'
-        ? 'npm run generate:mfe-manifests && npm run generate:colors && vite build'
-        : 'npm run generate:mfe-manifests && vite build',
+        ? 'tsx scripts/generate-mfe-manifests.ts && tsx scripts/generate-colors.ts && vite build'
+        : 'tsx scripts/generate-mfe-manifests.ts && vite build',
       preview: 'vite preview',
-      lint: 'npm run build --workspace=eslint-plugin-local && eslint . --max-warnings 0',
+      lint: `${workspaceBuildCommand} && eslint . --max-warnings 0`,
       'type-check': uikit === 'hai3'
-        ? 'npm run generate:mfe-manifests && npm run generate:colors && tsc --noEmit'
-        : 'npm run generate:mfe-manifests && tsc --noEmit',
-      ...(uikit === 'hai3' && { 'generate:colors': 'npx tsx scripts/generate-colors.ts' }),
-      'arch:check': 'npx tsx scripts/test-architecture.ts',
-      'arch:deps':
-        'npx dependency-cruiser src/ --config .dependency-cruiser.cjs --output-type err-long',
-      'ai:sync': 'npx hai3 ai sync',
-      'prek:install': 'npx prek install',
-      'prek:run': 'npx prek run --all-files',
-      postinstall: 'npx prek install',
+        ? 'tsx scripts/generate-mfe-manifests.ts && tsx scripts/generate-colors.ts && tsc --noEmit'
+        : 'tsx scripts/generate-mfe-manifests.ts && tsc --noEmit',
+      ...(uikit === 'hai3' && { 'generate:colors': 'tsx scripts/generate-colors.ts' }),
+      'arch:check': 'tsx scripts/test-architecture.ts',
+      'arch:deps': 'dependency-cruiser src/ --config .dependency-cruiser.cjs --output-type err-long',
+      'ai:sync': 'hai3 ai sync',
+      'prek:install': 'prek install',
+      'prek:run': 'prek run --all-files',
+      postinstall: 'prek install',
     },
     dependencies,
     devDependencies,
@@ -446,7 +493,18 @@ export async function generateProject(
     path: 'package.json',
     content: JSON.stringify(packageJson, null, 2) + '\n',
   });
+
+  const workspaceFiles = getManagerWorkspaceFiles(packageManager);
+  files.push(...workspaceFiles);
   // @cpt-end:cpt-hai3-algo-cli-tooling-generate-project:p1:inst-generate-package-json
+
+  // Rewrite npm-centric snippets in template-derived text files.
+  for (const file of files) {
+    if (!shouldTransformForPackageManager(file.path)) {
+      continue;
+    }
+    file.content = transformPackageManagerText(file.content, packageManager);
+  }
 
   // @cpt-begin:cpt-hai3-algo-cli-tooling-generate-project:p1:inst-return-generated-files
   return files;

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -10,6 +10,7 @@ import type {
 } from '../core/types.js';
 import {
   DEFAULT_PACKAGE_MANAGER,
+  getPackageManagerEngines,
   getManagerWorkspaceFiles,
   getWorkspaceRunScriptCommand,
   packageManagerFieldValue,
@@ -374,7 +375,6 @@ export async function generateProject(
     layer,
     uikit,
     packageManager,
-    packageManagerVersion: packageManagerFieldValue(packageManager).split('@')[1],
     ...(packageManager === 'yarn' ? { linkerMode: 'node-modules' as const } : {}),
   };
   files.push({
@@ -455,12 +455,7 @@ export async function generateProject(
     private: true,
     type: 'module',
     packageManager: packageManagerFieldValue(packageManager),
-    engines: {
-      node: '>=24.14.0',
-      ...(packageManager === 'npm' ? { npm: '>=11.0.0' } : {}),
-      ...(packageManager === 'pnpm' ? { pnpm: '>=9.0.0' } : {}),
-      ...(packageManager === 'yarn' ? { yarn: '>=4.0.0' } : {}),
-    },
+    engines: getPackageManagerEngines(packageManager, '>=24.14.0'),
     workspaces: ['eslint-plugin-local'],
     scripts: {
       'generate:mfe-manifests': 'tsx scripts/generate-mfe-manifests.ts',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,10 @@ program
   .option('--studio', 'Include Studio package')
   .option('--no-studio', 'Exclude Studio package')
   .option('--uikit <type>', "UI kit to use ('hai3' for @hai3/uikit, 'none' for no UI kit)")
+  .option(
+    '--package-manager <manager>',
+    "Package manager to use ('npm', 'pnpm', 'yarn')"
+  )
   .option('-l, --layer <type>', 'Create a package for a specific SDK layer (sdk, framework, react)')
   .action(async (projectName: string, options: Record<string, unknown>) => {
     const result = await executeCommand(
@@ -60,6 +64,7 @@ program
         projectName,
         studio: options.studio as boolean | undefined,
         uikit: options.uikit as 'hai3' | 'none' | undefined,
+        packageManager: options.packageManager as 'npm' | 'pnpm' | 'yarn' | undefined,
         layer: options.layer as 'sdk' | 'framework' | 'react' | 'app' | undefined,
       },
       { interactive: true }

--- a/packages/cli/src/utils/projectValidation.ts
+++ b/packages/cli/src/utils/projectValidation.ts
@@ -83,7 +83,9 @@ export async function runProjectValidation(
 
   const steps: ValidationStepResult[] = [];
   const checksToRun = checks ?? ['typeCheck', 'lint', 'archCheck'];
+  // @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
   const manager = (await detectPackageManager(projectRoot)).manager;
+  // @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 
   logger.newline();
   logger.info('Running validation...');

--- a/packages/cli/src/utils/projectValidation.ts
+++ b/packages/cli/src/utils/projectValidation.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import type { Logger } from '../core/logger.js';
+import { detectPackageManager, getRunScriptCommand } from '../core/packageManager.js';
 
 /**
  * Result of a single validation step
@@ -63,9 +64,9 @@ function runCheck(
  * Run project validation after scaffolding commands
  *
  * This runs:
- * 1. TypeScript type checking (npm run type-check)
- * 2. ESLint (npm run lint)
- * 3. Architecture checks (npm run arch:check)
+ * 1. TypeScript type checking
+ * 2. ESLint
+ * 3. Architecture checks
  *
  * @param options - Validation options
  * @returns Validation result
@@ -82,6 +83,7 @@ export async function runProjectValidation(
 
   const steps: ValidationStepResult[] = [];
   const checksToRun = checks ?? ['typeCheck', 'lint', 'archCheck'];
+  const manager = (await detectPackageManager(projectRoot)).manager;
 
   logger.newline();
   logger.info('Running validation...');
@@ -90,7 +92,11 @@ export async function runProjectValidation(
   // TypeScript check
   if (checksToRun.includes('typeCheck')) {
     logger.log('  Checking TypeScript...');
-    const typeCheck = runCheck('TypeScript', 'npm run type-check', projectRoot);
+    const typeCheck = runCheck(
+      'TypeScript',
+      getRunScriptCommand(manager, 'type-check'),
+      projectRoot
+    );
     steps.push(typeCheck);
     if (typeCheck.success) {
       logger.success('  TypeScript: OK');
@@ -102,7 +108,7 @@ export async function runProjectValidation(
   // ESLint
   if (checksToRun.includes('lint')) {
     logger.log('  Running ESLint...');
-    const lint = runCheck('ESLint', 'npm run lint', projectRoot);
+    const lint = runCheck('ESLint', getRunScriptCommand(manager, 'lint'), projectRoot);
     steps.push(lint);
     if (lint.success) {
       logger.success('  ESLint: OK');
@@ -114,7 +120,11 @@ export async function runProjectValidation(
   // Architecture check
   if (checksToRun.includes('archCheck')) {
     logger.log('  Checking architecture...');
-    const archCheck = runCheck('Architecture', 'npm run arch:check', projectRoot);
+    const archCheck = runCheck(
+      'Architecture',
+      getRunScriptCommand(manager, 'arch:check'),
+      projectRoot
+    );
     steps.push(archCheck);
     if (archCheck.success) {
       logger.success('  Architecture: OK');

--- a/packages/cli/template-sources/project/README.md
+++ b/packages/cli/template-sources/project/README.md
@@ -3,10 +3,10 @@
 ## First Time Setup
 
 1. Open terminal in your project folder
-2. Run: `npm install`
-3. Run: `npm run dev`
+2. Install dependencies with your selected package manager (for example: `<package-manager> install`)
+3. Start the development server with your selected package manager (for example: `<package-manager> run dev`)
 4. Open http://localhost:5173 in your browser
-5. Run: `npm install -g @hai3/cli@alpha` (enables screenset scaffolding commands)
+5. Install HAI3 CLI globally (recommended with npm): `npm install -g @hai3/cli@alpha`
 6. Ask the AI: "Set up Chrome DevTools MCP server so you can see my browser"
 
 ## Creating Your First Screenset

--- a/packages/cli/template-sources/project/README.md
+++ b/packages/cli/template-sources/project/README.md
@@ -3,8 +3,8 @@
 ## First Time Setup
 
 1. Open terminal in your project folder
-2. Install dependencies with your selected package manager (for example: `<package-manager> install`)
-3. Start the development server with your selected package manager (for example: `<package-manager> run dev`)
+2. Install dependencies: `npm install`
+3. Start the development server: `npm run dev`
 4. Open http://localhost:5173 in your browser
 5. Install HAI3 CLI globally (recommended with npm): `npm install -g @hai3/cli@alpha`
 6. Ask the AI: "Set up Chrome DevTools MCP server so you can see my browser"

--- a/packages/cli/template-sources/project/scripts/dev-all.ts
+++ b/packages/cli/template-sources/project/scripts/dev-all.ts
@@ -24,6 +24,8 @@ interface MfeInfo {
   port: number;
 }
 
+type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
 // Scan src/mfe_packages/ and extract port from each package's scripts
 function getMFEPackages(): MfeInfo[] {
   if (!existsSync(MFE_PACKAGES_DIR)) {
@@ -66,15 +68,39 @@ function getMFEPackages(): MfeInfo[] {
   return mfes;
 }
 
+function getPackageManager(): PackageManager {
+  const rootPkgPath = join(process.cwd(), 'package.json');
+  try {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8')) as {
+      packageManager?: string;
+      scripts?: Record<string, string>;
+    };
+    const managerId = rootPkg.packageManager?.split('@')[0];
+    if (managerId === 'pnpm' || managerId === 'yarn') {
+      return managerId;
+    }
+  } catch {
+    // ignore and use default
+  }
+  return 'npm';
+}
+
+function runScriptCommand(packageManager: PackageManager, scriptName: string): string {
+  if (packageManager === 'yarn') {
+    return `yarn ${scriptName}`;
+  }
+  return `${packageManager} run ${scriptName}`;
+}
+
 // Determine main app command based on available scripts
-function getMainAppCommand(): string {
+function getMainAppCommand(packageManager: PackageManager): string {
   const rootPkgPath = join(process.cwd(), 'package.json');
   try {
     const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8')) as {
       scripts?: Record<string, string>;
     };
     if (rootPkg.scripts?.['generate:colors']) {
-      return 'npm run generate:colors && vite';
+      return `${runScriptCommand(packageManager, 'generate:colors')} && vite`;
     }
   } catch {
     // ignore — fall through to default
@@ -83,15 +109,15 @@ function getMainAppCommand(): string {
 }
 
 // Build commands for main app + all MFEs
-function buildCommands(mfes: MfeInfo[]): string[] {
+function buildCommands(mfes: MfeInfo[], packageManager: PackageManager): string[] {
   const commands: string[] = [];
 
   // Add main app
-  commands.push(getMainAppCommand());
+  commands.push(getMainAppCommand(packageManager));
 
   // Add each MFE
   for (const mfe of mfes) {
-    commands.push(`cd src/mfe_packages/${mfe.name} && npm run dev`);
+    commands.push(`cd src/mfe_packages/${mfe.name} && ${runScriptCommand(packageManager, 'dev')}`);
   }
 
   return commands;
@@ -114,7 +140,8 @@ async function main() {
     console.log();
   }
 
-  const commands = buildCommands(mfes);
+  const packageManager = getPackageManager();
+  const commands = buildCommands(mfes, packageManager);
 
   // Quote each command properly for concurrently
   const quotedCommands = commands.map((cmd) => `"${cmd.replace(/"/g, '\\"')}"`);

--- a/packages/cli/template-sources/project/scripts/dev-all.ts
+++ b/packages/cli/template-sources/project/scripts/dev-all.ts
@@ -68,6 +68,7 @@ function getMFEPackages(): MfeInfo[] {
   return mfes;
 }
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 function getPackageManager(): PackageManager {
   const rootPkgPath = join(process.cwd(), 'package.json');
   try {
@@ -84,13 +85,16 @@ function getPackageManager(): PackageManager {
   }
   return 'npm';
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 function runScriptCommand(packageManager: PackageManager, scriptName: string): string {
   if (packageManager === 'yarn') {
     return `yarn ${scriptName}`;
   }
   return `${packageManager} run ${scriptName}`;
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 
 // Determine main app command based on available scripts
 function getMainAppCommand(packageManager: PackageManager): string {

--- a/packages/cli/template-sources/project/scripts/test-architecture.ts
+++ b/packages/cli/template-sources/project/scripts/test-architecture.ts
@@ -10,6 +10,8 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 interface Colors {
   red: string;
@@ -68,16 +70,43 @@ interface ArchCheck {
   description: string;
 }
 
+type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
+function detectPackageManager(): PackageManager {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
+    ) as { packageManager?: string };
+    const managerId = packageJson.packageManager?.split('@')[0];
+    if (managerId === 'pnpm' || managerId === 'yarn') {
+      return managerId;
+    }
+  } catch {
+    // ignore and use default
+  }
+  return 'npm';
+}
+
+function runScriptCommand(packageManager: PackageManager, scriptName: string): string {
+  if (packageManager === 'yarn') {
+    return `yarn ${scriptName}`;
+  }
+  return `${packageManager} run ${scriptName}`;
+}
+
 /**
  * Standalone architecture checks
  * These run in all HAI3 projects (standalone and monorepo)
  */
-function getStandaloneChecks(): ArchCheck[] {
+function getStandaloneChecks(packageManager: PackageManager = detectPackageManager()): ArchCheck[] {
   return [
-    { command: 'npm run generate:colors', description: 'Generate theme colors' },
-    { command: 'npm run lint -- --max-warnings 0', description: 'ESLint rules' },
-    { command: 'npm run type-check', description: 'TypeScript type check' },
-    { command: 'npm run arch:deps', description: 'Dependency rules' },
+    { command: runScriptCommand(packageManager, 'generate:colors'), description: 'Generate theme colors' },
+    {
+      command: runScriptCommand(packageManager, 'lint'),
+      description: 'ESLint rules'
+    },
+    { command: runScriptCommand(packageManager, 'type-check'), description: 'TypeScript type check' },
+    { command: runScriptCommand(packageManager, 'arch:deps'), description: 'Dependency rules' },
   ];
 }
 
@@ -105,7 +134,11 @@ function runValidation(checks: ArchCheck[], title: string): ValidationResult {
  * Run standalone architecture validation
  */
 function validateArchitecture(): ValidationResult {
-  return runValidation(getStandaloneChecks(), 'HAI3 Architecture Validation');
+  const packageManager = detectPackageManager();
+  return runValidation(
+    getStandaloneChecks(packageManager),
+    `HAI3 Architecture Validation (${packageManager})`
+  );
 }
 
 function displayResults({ passed, total, success }: ValidationResult): void {

--- a/packages/cli/template-sources/project/scripts/test-architecture.ts
+++ b/packages/cli/template-sources/project/scripts/test-architecture.ts
@@ -72,6 +72,7 @@ interface ArchCheck {
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn';
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 function detectPackageManager(): PackageManager {
   try {
     const packageJson = JSON.parse(
@@ -86,13 +87,16 @@ function detectPackageManager(): PackageManager {
   }
   return 'npm';
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-detect-package-manager
 
+// @cpt-begin:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 function runScriptCommand(packageManager: PackageManager, scriptName: string): string {
   if (packageManager === 'yarn') {
     return `yarn ${scriptName}`;
   }
   return `${packageManager} run ${scriptName}`;
 }
+// @cpt-end:cpt-hai3-algo-cli-tooling-package-manager-policy:p1:inst-build-package-manager-commands
 
 /**
  * Standalone architecture checks


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#226](https://github.com/cyberfabric/cyberware-frontx/pull/226) | **Author:** gs-layer | **Opened:** 2026-03-17T13:19:32Z | **Status:** merged on 2026-03-19T05:23:55Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary
This PR adds first-class multi-package-manager support for HAI3 CLI.

Supported managers:
- npm (default)
- pnpm
- yarn

Key outcomes:
- `hai3 create` now supports selecting package manager in wizard and via CLI flag.
- Generated projects and layer packages now persist package-manager metadata.
- CLI command hints, scripts, and synced templates are manager-aware.
- `hai3 update` uses the detected manager for package updates.
- CI smoke coverage runs CLI PR E2E with npm, pnpm, and yarn.

## What changed
- Added package-manager core module for detection and command generation.
- Added `--package-manager <npm|pnpm|yarn>` support to `create`.
- Updated project/layer generators:
  - `package.json` -> `packageManager` field
  - manager-specific files (`pnpm-workspace.yaml`, `.yarnrc.yml`)
  - manager-aware README and script text
- Updated template sync:
  - transforms npm command snippets to selected manager
  - skips and cleans generation-only app variants (`App.no-*`, `main.no-uikit.tsx`)
- Added compatibility fallback in standalone arch script so monorepo `arch:check` continues to work when calling `getStandaloneChecks()` without explicit manager.
- Updated AI sync/copilot instructions to use manager-appropriate `arch:check` command.
- Updated update flow:
  - manager-aware package update commands
  - post-sync tip to run manager install
- Updated CLI E2E:
  - matrix in `.github/workflows/cli-pr.yml` for npm/pnpm/yarn
  - smoke script consumes `CLI_E2E_PM`

## Validation
Local checks run:
- `npm run build --workspace=@hai3/cli`
- `npm run arch:check` (monorepo)
- `CLI_E2E_PM=npm npm run test:e2e:pr --workspace=@hai3/cli -- --skip-install`
- `CLI_E2E_PM=pnpm npm run test:e2e:pr --workspace=@hai3/cli -- --skip-install`
- `CLI_E2E_PM=yarn npm run test:e2e:pr --workspace=@hai3/cli -- --skip-install`

Manual verification:
- `qa-pnpm`: `update --templates-only` no longer leaves `App.no-*` files.
- `pnpm run arch:check` passes after `pnpm install` post-template-sync.

## Notes for reviewers
- Global CLI self-update is intentionally skipped for yarn (no stable global install path).
- After `update --templates-only`, run manager install (`npm|pnpm|yarn install`) before architecture checks.

## Pre-merge checklist
- [x] `npm ci`
- [x] `npm run arch:check`
- [x] `npm run build --workspace=@hai3/cli`
- [x] `npm run test:e2e:pr --workspace=@hai3/cli`
- [x] Confirm required checks in PR: `validate`, `cli-pr-e2e`
- [x] Version bump for affected package(s) if release is expected (`@hai3/cli`)

Closes #357 


---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#226 -->