### PR TITLE
[PR #220] fix: add missing .gitignore to mfe-package template and _blank-mfe

### DIFF
--- a/packages/cli/template-sources/mfe-package/.gitignore
+++ b/packages/cli/template-sources/mfe-package/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+dist-ssr
+.vite
+*.local

--- a/src/mfe_packages/_blank-mfe/.gitignore
+++ b/src/mfe_packages/_blank-mfe/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+dist-ssr
+.vite
+*.local


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#220](https://github.com/cyberfabric/cyberware-frontx/pull/220) | **Author:** billpliske | **Opened:** 2026-03-16T16:40:58Z | **Status:** merged on 2026-03-18T03:31:53Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

  When adding a new screenset by copying the mfe-package template,
  the resulting folder had no .gitignore. Added standard Vite ignores
  (node_modules, dist, .vite, etc.) to both template sources.
  
  Fixes issue #311 
  
  Signed-off-by: billpliske <bpliske&#219;gmail.com>

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#220 -->