### PR TITLE
[PR #219] cleanup: unused entries field removed from mf manifest

### DIFF
--- a/architecture/features/feature-screenset-registry/FEATURE.md
+++ b/architecture/features/feature-screenset-registry/FEATURE.md
@@ -381,7 +381,7 @@ All MFE TypeScript interfaces are defined with the correct shapes as derived fro
 
 - `MfeEntry`: `id`, `requiredProperties`, `actions`, `domainActions`, optional `optionalProperties`
 - `MfeEntryMF` extends `MfeEntry`: adds `manifest` (`string | MfManifest`), `exposedModule`
-- `MfManifest`: `id`, `remoteEntry`, `remoteName`, optional `sharedDependencies`, optional `entries`; `SharedDependencyConfig` has `name`, optional `requiredVersion`; no `singleton` field
+- `MfManifest`: `id`, `remoteEntry`, `remoteName`, optional `sharedDependencies`; `SharedDependencyConfig` has `name`, optional `requiredVersion`; no `singleton` field
 - `ExtensionDomain`: `id`, `sharedProperties`, `actions`, `extensionsActions`, `defaultActionTimeout` (required number), `lifecycleStages` (required), `extensionsLifecycleStages` (required), optional `extensionsTypeId`, optional `lifecycle`
 - `Extension`: `id`, `domain`, `entry`, optional `lifecycle`
 - `ScreenExtension` extends `Extension`: adds required `presentation` (`ExtensionPresentation`)

--- a/packages/screensets/src/mfe/gts/hai3.mfes/schemas/mfe/mf_manifest.v1.json
+++ b/packages/screensets/src/mfe/gts/hai3.mfes/schemas/mfe/mf_manifest.v1.json
@@ -25,10 +25,6 @@
         },
         "required": ["name"]
       }
-    },
-    "entries": {
-      "type": "array",
-      "items": { "x-gts-ref": "gts.hai3.mfes.mfe.entry.v1~hai3.mfes.mfe.entry_mf.v1~*" }
     }
   },
   "required": ["id", "remoteEntry", "remoteName"]

--- a/packages/screensets/src/mfe/types/mf-manifest.ts
+++ b/packages/screensets/src/mfe/types/mf-manifest.ts
@@ -47,6 +47,4 @@ export interface MfManifest {
   remoteName: string;
   /** Optional override for shared dependency configuration */
   sharedDependencies?: SharedDependencyConfig[];
-  /** Convenience field for discovery - lists MfeEntryMF type IDs */
-  entries?: string[];
 }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#219](https://github.com/cyberfabric/cyberware-frontx/pull/219) | **Author:** GeraBart | **Opened:** 2026-03-13T12:10:56Z | **Status:** merged on 2026-03-16T02:19:36Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Fix of https://github.com/HAI3org/HAI3/issues/215

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#219 -->