### PR TITLE
[PR #155] Add issue templates for architecture discussion, bug report, documentation issue, and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture_discussion.md
+++ b/.github/ISSUE_TEMPLATE/architecture_discussion.md
@@ -1,0 +1,57 @@
+---
+name: Architecture Discussion
+about: Discuss architectural changes, design decisions, or planning
+title: "[ARCH] "
+labels: architecture
+assignees: ''
+
+---
+
+## Topic
+What architectural aspect are you discussing?
+
+## Context
+Provide background on why this discussion is important:
+- Is this addressing a limitation?
+- Is this about scalability or performance?
+- Is this a breaking change or new capability?
+- Is this a refactoring effort?
+
+## Current State
+Describe the current architecture or implementation:
+
+## Proposed Changes
+What changes or improvements are you proposing?
+
+## Rationale
+Why would this change be beneficial? What problems does it solve?
+
+## Affected Components
+Which HAI3 components or packages are affected?
+- [ ] Core Framework (@hai3/framework)
+- [ ] React Integration (@hai3/react)
+- [ ] Screensets (@hai3/screensets)
+- [ ] CLI (@hai3/cli)
+- [ ] Internationalization (@hai3/i18n)
+- [ ] State Management (@hai3/state)
+- [ ] Studio (@hai3/studio)
+- [ ] UI Kit (@hai3/uikit)
+- [ ] Multiple packages
+
+## Breaking Changes
+Will this introduce breaking changes? If so, describe the migration path.
+
+## Performance / Security Implications
+Are there any performance or security implications?
+
+## Discussion Points
+What specific aspects would you like feedback on?
+1. 
+2. 
+3. 
+
+## References
+Links to related issues, specs, or documentation:
+
+## Additional Context
+Add any mockups, diagrams, or other supporting material.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report a bug or issue you've encountered
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+## Description
+A clear and concise description of what the bug is.
+
+## Environment
+- **HAI3 Version**: (e.g., 0.1.0)
+- **Node.js Version**: (e.g., v25.1.0)
+- **OS**: (e.g., Linux, macOS, Windows)
+- **Package(s) Affected**: (e.g., @hai3/framework, @hai3/react, @hai3/cli)
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+A clear and concise description of what actually happened.
+
+## Error Message / Stack Trace
+If applicable, provide the error message or stack trace:
+```
+[paste error here]
+```
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Additional Context
+Add any other context about the problem here.
+
+## Possible Solution
+If you have ideas for how to solve this, please share them here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion Forum
+    url: https://github.com/HAI3org/HAI3/discussions
+    about: Ask questions and share ideas in our discussion forum
+  - name: Check Existing Issues
+    url: https://github.com/HAI3org/HAI3/issues
+    about: Search for similar issues before creating a new one

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,36 @@
+---
+name: Documentation Issue
+about: Suggest improvements to documentation or report missing docs
+title: "[DOCS] "
+labels: documentation
+assignees: ''
+
+---
+
+## Location
+Which documentation page or section needs improvement?
+- [ ] README.md
+- [ ] CONTRIBUTING.md
+- [ ] QUICK_START.md
+- [ ] API Documentation
+- [ ] Package-specific docs
+- [ ] Other: 
+
+## Issue
+Describe the documentation issue:
+- Is something unclear or confusing?
+- Is there missing information?
+- Are there outdated examples?
+- Is there a broken link?
+
+## Suggested Improvement
+What would make the documentation better?
+
+## Current Content
+If applicable, paste the current documentation text that needs improvement.
+
+## Proposed Content
+If applicable, suggest how the documentation should be updated.
+
+## Additional Context
+Add any other context that would help improve the documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature Request
+about: Suggest an idea for HAI3
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+
+---
+
+## Description
+A clear and concise description of the feature you want to propose.
+
+## Problem Statement
+What problem does this feature solve? Is it related to an existing limitation or workflow?
+
+## Proposed Solution
+A clear and concise description of how you would like this feature to work.
+
+## Use Case / Example
+Provide concrete examples of how this feature would be used:
+- Use case 1
+- Use case 2
+- Use case 3
+
+## Affected Package(s)
+Which HAI3 package(s) would this impact?
+- [ ] @hai3/framework
+- [ ] @hai3/react
+- [ ] @hai3/screensets
+- [ ] @hai3/cli
+- [ ] @hai3/i18n
+- [ ] @hai3/state
+- [ ] @hai3/studio
+- [ ] @hai3/uikit
+
+## Alternative Solutions
+Have you considered any alternative approaches or workarounds?
+
+## Additional Context
+Add any other context, mockups, or references that might help understand the feature request.
+
+## Priority
+- [ ] Low - Nice to have
+- [ ] Medium - Improves workflow
+- [ ] High - Blocking or critical for use case


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#155](https://github.com/cyberfabric/cyberware-frontx/pull/155) | **Author:** m231-a | **Opened:** 2026-01-29T18:26:08Z | **Status:** merged on 2026-01-30T09:27:43Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Introduce new issue templates to streamline the process of reporting bugs, discussing architectural changes, suggesting documentation improvements, and proposing new features. These templates provide structured guidance for users, ensuring that all necessary information is captured effectively.

Fixes #310

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#155 -->