### PR TITLE
[PR #151] fix(cli): Clean UIKit=none projects by removing styling infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24581,7 +24581,7 @@
     },
     "packages/cli": {
       "name": "@hai3/cli",
-      "version": "0.2.0-alpha.15",
+      "version": "0.2.0-alpha.16",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hai3/cli",
-  "version": "0.2.0-alpha.15",
+  "version": "0.2.0-alpha.16",
   "description": "HAI3 CLI - Project scaffolding and screenset management tools",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/screenset/copy.ts
+++ b/packages/cli/src/commands/screenset/copy.ts
@@ -11,7 +11,7 @@ import {
 } from '../../generators/transform.js';
 import { toPascalCase } from '../../generators/utils.js';
 import { copyDirectoryWithTransform } from '../../utils/fs.js';
-import { getScreensetsDir, screensetExists } from '../../utils/project.js';
+import { getScreensetsDir, screensetExists, loadConfig } from '../../utils/project.js';
 import { isCamelCase, isReservedScreensetName } from '../../utils/validation.js';
 
 /**
@@ -112,6 +112,17 @@ export const screensetCopyCommand: CommandDefinition<
     const { source, target } = args;
     // Default category to 'drafts' for copies
     const category: ScreensetCategory = args.category ?? 'drafts';
+
+    // Check if UIKit is configured - screensets require a UI kit
+    const config = await loadConfig(projectRoot!);
+    if (!config?.uikit || config.uikit === 'none') {
+      throw new Error(
+        'Cannot copy screenset: No UI kit configured.\n' +
+        'Screensets require UI components (Button, Card, etc.) from a UI kit.\n' +
+        'Please install a UI kit first, then update hai3.config.json with your uikit identifier.\n' +
+        'Example: { "hai3": true, "layer": "app", "uikit": "@hai3/uikit" }'
+      );
+    }
 
     const screensetsDir = getScreensetsDir(projectRoot!);
     const sourcePath = path.join(screensetsDir, source);

--- a/packages/cli/src/commands/screenset/create.ts
+++ b/packages/cli/src/commands/screenset/create.ts
@@ -4,7 +4,7 @@ import type { ScreensetCategory } from '../../core/types.js';
 import { validationOk, validationError } from '../../core/types.js';
 import { generateScreensetFromTemplate } from '../../generators/screensetFromTemplate.js';
 import { writeGeneratedFiles } from '../../utils/fs.js';
-import { getScreensetsDir, screensetExists } from '../../utils/project.js';
+import { getScreensetsDir, screensetExists, loadConfig } from '../../utils/project.js';
 import { isCamelCase, isReservedScreensetName } from '../../utils/validation.js';
 import { runProjectValidation, skipValidationOption } from '../../utils/projectValidation.js';
 
@@ -89,6 +89,17 @@ export const screensetCreateCommand: CommandDefinition<
     const { logger, projectRoot } = ctx;
     const screensetId = args.name;
     const category = args.category ?? 'drafts';
+
+    // Check if UIKit is configured - screensets require a UI kit
+    const config = await loadConfig(projectRoot!);
+    if (!config?.uikit || config.uikit === 'none') {
+      throw new Error(
+        'Cannot create screenset: No UI kit configured.\n' +
+        'Screensets require UI components (Button, Card, etc.) from a UI kit.\n' +
+        'Please install a UI kit first, then update hai3.config.json with your uikit identifier.\n' +
+        'Example: { "hai3": true, "layer": "app", "uikit": "@hai3/uikit" }'
+      );
+    }
 
     // Check if screenset already exists
     if (await screensetExists(projectRoot!, screensetId)) {

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -16,6 +16,8 @@ export interface Hai3Config {
   hai3: true;
   /** Project layer (SDK architecture tier) */
   layer?: LayerType;
+  /** UI Kit selection: 'none' means no UIKit, any other string is the UIKit identifier */
+  uikit?: string;
 }
 
 /**


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#151](https://github.com/cyberfabric/cyberware-frontx/pull/151) | **Author:** dAlcaSan | **Opened:** 2026-01-27T13:16:41Z | **Status:** merged on 2026-01-28T11:01:00Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Fixes the CLI "None" UIKit option to generate truly clean projects without &#219;hai3/uikit-specific styling infrastructure.

## Problem

When selecting "None (implement your own)" for UIKit during `hai3 create`, the generated project still included:
- `tailwind.config.ts` with &#219;hai3/uikit CSS variable mappings
- `postcss.config.ts`
- `scripts/generate-colors.ts`
- `generate:colors` script in package.json

This coupling made it difficult for users to bring their own UIKit since the configurations assumed &#219;hai3/uikit.

## Solution

### Files modified:
- [packages/cli/src/core/types.ts](cci:7://file:///Users/david/Development/Dev-HAI3/packages/cli/src/core/types.ts:0:0-0:0) - Added `uikit` field to [Hai3Config](cci:2://file:///Users/david/Development/Dev-HAI3/packages/cli/src/core/types.ts:13:0-20:1) interface
- [packages/cli/src/generators/project.ts](cci:7://file:///Users/david/Development/Dev-HAI3/packages/cli/src/generators/project.ts:0:0-0:0) - Skip UIKit-dependent files when `uikit=none`
- [packages/cli/src/commands/screenset/create.ts](cci:7://file:///Users/david/Development/Dev-HAI3/packages/cli/src/commands/screenset/create.ts:0:0-0:0) - Block creation when no UIKit configured
- [packages/cli/src/commands/screenset/copy.ts](cci:7://file:///Users/david/Development/Dev-HAI3/packages/cli/src/commands/screenset/copy.ts:0:0-0:0) - Block copy when no UIKit configured

### When `uikit=none`:
- ❌ `tailwind.config.ts` - not generated
- ❌ `postcss.config.ts` - not generated
- ❌ `scripts/generate-colors.ts` - not generated
- ❌ `generate:colors` script - not in package.json
- ❌ Demo screenset - not generated
- ✅ [hai3.config.json](cci:7://file:///Users/david/Development/testlib2/patata/hai3.config.json:0:0-0:0) - includes `"uikit": "none"`

### package.json scripts (clean):
```json
"dev": "vite",
"build": "vite build",
"type-check": "tsc --noEmit"

---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#151 -->