### PR TITLE
[PR #48] fix: missing dependency added to project generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7963,7 +7963,7 @@
     },
     "packages/cli": {
       "name": "@hai3/cli",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hai3/cli",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "HAI3 CLI - Project scaffolding and screenset management tools",
   "bin": {
     "hai3": "./dist/index.cjs"

--- a/packages/cli/src/generators/project.ts
+++ b/packages/cli/src/generators/project.ts
@@ -145,6 +145,8 @@ export async function generateProject(
     'lucide-react': '^0.344.0',
     react: '^18.3.1',
     'react-dom': '^18.3.1',
+    'react-markdown': '^9.0.1',
+    'remark-gfm': '^4.0.0',
     'tailwindcss-animate': '^1.0.7',
   };
 


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-frontx#48](https://github.com/cyberfabric/cyberware-frontx/pull/48) | **Author:** beyond-event-horizon | **Opened:** 2025-11-26T13:41:25Z | **Status:** merged on 2025-11-26T13:43:18Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



---
<!-- cf-mirror-pr: cyberfabric/cyberware-frontx#48 -->