### PR TITLE
fix: correct empty-state guidance for removed screenset command

### DIFF
--- a/packages/cyber-pilot-kit-frontx/AGENTS.md
+++ b/packages/cyber-pilot-kit-frontx/AGENTS.md
@@ -16,7 +16,8 @@
 
 - CLI resolves templates by source-spec at runtime; it bundles no template content
 - Source-spec format: `protocol://host/path#ref`
-- Scaffolding commands live under two namespaces: `project` and `mfe`
+- The CLI has no scaffolding commands; supported commands are `install`, `list`, `update-local`, `validate`, `seed`, `add`, `upgrade`, and `help`
+- To add an MFE package, copy the `_blank-mfe` reference scaffold in `mfe_packages/` (see its `README.md`)
 
 ## When working with MFEs
 

--- a/template-standard/src-app/app/layout/Menu.tsx
+++ b/template-standard/src-app/app/layout/Menu.tsx
@@ -96,7 +96,7 @@ export const Menu: React.FC<MenuProps> = ({ children }) => {
         <SidebarMenu>
           {extensions.length === 0 ? (
             <div className="px-3 py-4 text-sm text-muted-foreground">
-              No screens yet. Create a screenset with <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">frontx screenset create</code> or add MFE packages.
+              No screens yet. Add an MFE package by copying the <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">_blank-mfe</code> reference scaffold in <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">mfe_packages/</code>.
             </div>
           ) : (
             extensions.map((ext) => {


### PR DESCRIPTION
## Summary

Fixes #475.

The menu empty state directed users to `frontx screenset create`, a command removed when the `screenset` namespace was dropped from the CLI (#456). This PR replaces the stale guidance in both locations flagged by the issue:

- **`template-standard/src-app/app/layout/Menu.tsx`** — empty state now points at copying the `_blank-mfe` reference scaffold in `mfe_packages/`, the supported path for adding an MFE package.
- **`packages/cyber-pilot-kit-frontx/AGENTS.md`** — the claim that "scaffolding commands live under two namespaces: `project` and `mfe`" is replaced with the actual CLI command list (`install`, `list`, `update-local`, `validate`, `seed`, `add`, `upgrade`, `help`) plus a pointer to the `_blank-mfe` scaffold.

## Test plan

- `grep -rn "screenset create"` over both files returns no hits
- Verified the command list matches `node packages/cli/dist/cli.js help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)