### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
-# Only the last matching pattern applies — ownership does not accumulate, so a
-# path listed below is owned by those names alone, not additionally by @GeraBart.
-
 *                        @GeraBart
 
 /packages/ui-kit/        @SysoevAndrey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 /packages/ui-kit/        @SysoevAndrey
 /packages/telemetry/     @hello1101n
 
-/template-shell/         @gs-layer @itechmeat
-/template-mfe/           @gs-layer @itechmeat
+/template-shell/         @gs-layer @itechmeat @tscbmstubp
+/template-mfe/           @gs-layer @itechmeat @tscbmstubp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Only the last matching pattern applies — ownership does not accumulate, so a
+# path listed below is owned by those names alone, not additionally by @GeraBart.
+
+*                        @GeraBart
+
+/packages/ui-kit/        @SysoevAndrey
+/packages/telemetry/     @hello1101n
+
+/template-shell/         @gs-layer @itechmeat
+/template-mfe/           @gs-layer @itechmeat


### PR DESCRIPTION
The repo has no CODEOWNERS, so nothing auto-requests a reviewer — PRs sit unassigned until someone is asked by hand.

`@GeraBart` is the default owner. Three paths with a clear specialist name them instead:

| path | owner |
|---|---|
| `/packages/ui-kit/` | @SysoevAndrey |
| `/packages/telemetry/` | @hello1101n |
| `/template-shell/`, `/template-mfe/` | @gs-layer @itechmeat @tscbmstubp |

Derived from commit history on `develop` and approvals on merged PRs. Deliberately minimal — a starting point to extend as ownership settles, not a full map of the repo.

Note that only the **last** matching pattern applies; ownership does not accumulate, so the paths above are owned by those names alone and not additionally by `@GeraBart`.

## Blocker: only @GeraBart has write access

GitHub's CODEOWNERS validation rejects every other owner in this file:

```
flagged: @SysoevAndrey  @hello1101n  @gs-layer  @itechmeat  @tscbmstubp
clean:   @GeraBart
```

Code owners need **explicit write access** — a stricter bar than being requestable as a reviewer, which only needs read. All five accounts exist, so it is the write-access half failing.

The practical effect is that every path-specific rule is inert and the file behaves as `* @GeraBart` until access is granted. It is harmless as-is — CODEOWNERS only auto-requests reviewers and gates nothing unless *Require review from Code Owners* is enabled in branch protection — and each line starts working the moment access lands, with no follow-up PR needed.

Happy to strip the inert lines instead if this PR should only contain what works today.
