### PR TITLE
feat(ui-kit): forms batch on Base UI, AI docs layer, token polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -381,7 +381,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -484,6 +483,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1309,6 +1368,44 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@gears-frontx/api": {
       "resolved": "packages/api",
@@ -2456,7 +2553,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3331,7 +3428,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5360,7 +5457,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5370,7 +5466,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -5429,6 +5524,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -5613,7 +5714,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/secure-json-parse": {
@@ -6683,6 +6783,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -7145,6 +7254,7 @@
       "version": "0.3.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@base-ui/react": "1.6.0",
         "class-variance-authority": "0.7.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7259,6 +7259,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "16.3.2",
+        "@types/node": "^25.5.0",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "4.1.4",
@@ -7273,6 +7274,23 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
+    },
+    "packages/ui-kit/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "packages/ui-kit/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -79,11 +79,16 @@ internal react-kit (gitlab.constr.dev/frontend/react-kit): per-component
 directories, colocated tests and docs, `render`-prop polymorphism. A composite
 `data-table` is deliberately deferred.
 
-## AI layer (planned)
+## AI layer
 
-`llms.txt` + a short usage doc per component (when to use, anti-patterns,
-composition examples) shipped in the package; three composition recipes (CRUD
-page, settings form, confirmation dialog).
+Shipped in the package so agents read it from `node_modules`: `llms.txt` at
+the package root (entry point: setup rules + component index) and a short
+usage doc per component (when to use, kit-level props, examples,
+anti-patterns) colocated as `src/components/<name>/<name>.md` and copied to
+`dist/docs/` at build. A unit test enforces that every component has a doc,
+is indexed in `llms.txt`, and documents every variant/size its CSS module
+defines. Still planned: three composition recipes (CRUD page, settings form,
+confirmation dialog) once the components they compose exist.
 
 ## Testing and acceptance
 

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -33,6 +33,10 @@ Rules for generated code:
 - [RadioGroup](dist/docs/radio-group.md): mutually exclusive options
   (RadioGroup + RadioGroupItem); `value`/`onValueChange` on the group;
   arrow-key navigation built in.
+- [Select](dist/docs/select.md): dropdown picking one value from a
+  list (Select/SelectTrigger/SelectValue/SelectContent/SelectGroup/
+  SelectItem); trigger sizes default|sm; keyboard and typeahead built
+  in.
 - [Switch](dist/docs/switch.md): immediate on/off toggle;
   `checked`/`onCheckedChange`, sizes default|sm; use checkbox for
   submit-time options.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -22,6 +22,9 @@ Rules for generated code:
 - [Button](dist/docs/button.md): action button; variants
   default|destructive|outline|secondary|ghost|link, sizes
   default|sm|lg|icon; render-prop polymorphism for rendering as a link.
+- [Input](dist/docs/input.md): single-line text field; `onValueChange`
+  for the string value, `aria-invalid` for the error state; wires into
+  Field automatically.
 
 ## Optional
 

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -11,9 +11,10 @@ Rules for generated code:
   `import '@gears-frontx/ui-kit/theme.css';`
   `import '@gears-frontx/ui-kit/styles.css';`
 - Import components from the package root: `import { Button } from '@gears-frontx/ui-kit';`
-- Set the app font on `<body>` (or `<html>`), not on an inner container:
-  overlay components (Select) portal their popup to `<body>` and inherit
-  the font from there.
+- Set the app font AND `data-theme` on `<html>`/`<body>`, not on an inner
+  container: overlay components (Select) portal their popup to `<body>`
+  and inherit theme tokens and font from there. If a subtree must carry
+  its own theme, pass that element as `container` to `SelectContent`.
 - Brand/appearance changes go through theme tokens (CSS variables in
   `theme.css`, light/dark via `data-theme`), never through inline styles or
   overriding kit class names.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -11,6 +11,9 @@ Rules for generated code:
   `import '@gears-frontx/ui-kit/theme.css';`
   `import '@gears-frontx/ui-kit/styles.css';`
 - Import components from the package root: `import { Button } from '@gears-frontx/ui-kit';`
+- Set the app font on `<body>` (or `<html>`), not on an inner container:
+  overlay components (Select) portal their popup to `<body>` and inherit
+  the font from there.
 - Brand/appearance changes go through theme tokens (CSS variables in
   `theme.css`, light/dark via `data-theme`), never through inline styles or
   overriding kit class names.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -14,6 +14,8 @@ Rules for generated code:
 - Brand/appearance changes go through theme tokens (CSS variables in
   `theme.css`, light/dark via `data-theme`), never through inline styles or
   overriding kit class names.
+- Rounding is a scale derived from `--radius` (`--radius-sm|md|lg|xl`);
+  override `--radius` alone and every component follows.
 - Per-component docs below list the kit-level props; everything else is the
   underlying native element's props.
 

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -1,0 +1,28 @@
+# @gears-frontx/ui-kit
+
+> Standard React component base for FrontX templates. Behavior comes from
+> Base UI primitives, styling is compiled CSS on semantic design tokens,
+> variants via a `variant`/`size` prop pair. Consumers need no CSS framework
+> or build plugins.
+
+Rules for generated code:
+
+- Import styles exactly once at the app entry, theme first:
+  `import '@gears-frontx/ui-kit/theme.css';`
+  `import '@gears-frontx/ui-kit/styles.css';`
+- Import components from the package root: `import { Button } from '@gears-frontx/ui-kit';`
+- Brand/appearance changes go through theme tokens (CSS variables in
+  `theme.css`, light/dark via `data-theme`), never through inline styles or
+  overriding kit class names.
+- Per-component docs below list the kit-level props; everything else is the
+  underlying native element's props.
+
+## Components
+
+- [Button](dist/docs/button.md): action button; variants
+  default|destructive|outline|secondary|ghost|link, sizes
+  default|sm|lg|icon; render-prop polymorphism for rendering as a link.
+
+## Optional
+
+- [README](README.md): installation, setup, package layout.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -25,6 +25,8 @@ Rules for generated code:
 - [Input](dist/docs/input.md): single-line text field; `onValueChange`
   for the string value, `aria-invalid` for the error state; wires into
   Field automatically.
+- [Label](dist/docs/label.md): caption for a form control; native
+  `<label>` props; associate via `htmlFor` or by nesting the control.
 - [Textarea](dist/docs/textarea.md): multi-line text field; native
   `<textarea>` props; grows with content; `aria-invalid` for the error
   state.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -22,6 +22,9 @@ Rules for generated code:
 - [Button](dist/docs/button.md): action button; variants
   default|destructive|outline|secondary|ghost|link, sizes
   default|sm|lg|icon; render-prop polymorphism for rendering as a link.
+- [Checkbox](dist/docs/checkbox.md): on/off tick box for independent
+  options; `checked`/`onCheckedChange`; nest inside Label for one click
+  target.
 - [Input](dist/docs/input.md): single-line text field; `onValueChange`
   for the string value, `aria-invalid` for the error state; wires into
   Field automatically.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -25,6 +25,10 @@ Rules for generated code:
 - [Checkbox](dist/docs/checkbox.md): on/off tick box for independent
   options; `checked`/`onCheckedChange`; nest inside Label for one click
   target.
+- [Field](dist/docs/field.md): labelled form field composition
+  (Field/FieldLabel/FieldDescription/FieldError); wires ids, htmlFor,
+  aria-describedby, and validation display automatically — the default
+  way to build forms.
 - [Input](dist/docs/input.md): single-line text field; `onValueChange`
   for the string value, `aria-invalid` for the error state; wires into
   Field automatically.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -25,6 +25,9 @@ Rules for generated code:
 - [Input](dist/docs/input.md): single-line text field; `onValueChange`
   for the string value, `aria-invalid` for the error state; wires into
   Field automatically.
+- [Textarea](dist/docs/textarea.md): multi-line text field; native
+  `<textarea>` props; grows with content; `aria-invalid` for the error
+  state.
 
 ## Optional
 

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -30,6 +30,9 @@ Rules for generated code:
   Field automatically.
 - [Label](dist/docs/label.md): caption for a form control; native
   `<label>` props; associate via `htmlFor` or by nesting the control.
+- [Switch](dist/docs/switch.md): immediate on/off toggle;
+  `checked`/`onCheckedChange`, sizes default|sm; use checkbox for
+  submit-time options.
 - [Textarea](dist/docs/textarea.md): multi-line text field; native
   `<textarea>` props; grows with content; `aria-invalid` for the error
   state.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -18,7 +18,7 @@ Rules for generated code:
 - Brand/appearance changes go through theme tokens (CSS variables in
   `theme.css`, light/dark via `data-theme`), never through inline styles or
   overriding kit class names.
-- Rounding is a scale derived from `--radius` (`--radius-sm|md|lg|xl`);
+- Rounding is a scale derived from `--radius` (`--radius-xs|sm|md|lg|xl`);
   override `--radius` alone and every component follows.
 - Per-component docs below list the kit-level props; everything else is the
   underlying native element's props.
@@ -27,7 +27,8 @@ Rules for generated code:
 
 - [Button](dist/docs/button.md): action button; variants
   default|destructive|outline|secondary|ghost|link, sizes
-  default|sm|lg|icon; render-prop polymorphism for rendering as a link.
+  default|sm|lg|icon; render prop for button-semantic actions over a
+  real anchor (not a link substitute).
 - [Checkbox](dist/docs/checkbox.md): on/off tick box for independent
   options; `checked`/`onCheckedChange`; nest inside Label for one click
   target.

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -30,6 +30,9 @@ Rules for generated code:
   Field automatically.
 - [Label](dist/docs/label.md): caption for a form control; native
   `<label>` props; associate via `htmlFor` or by nesting the control.
+- [RadioGroup](dist/docs/radio-group.md): mutually exclusive options
+  (RadioGroup + RadioGroupItem); `value`/`onValueChange` on the group;
+  arrow-key navigation built in.
 - [Switch](dist/docs/switch.md): immediate on/off toggle;
   `checked`/`onCheckedChange`, sizes default|sm; use checkbox for
   submit-time options.

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -31,6 +31,7 @@
     "test:consumer": "bash scripts/verify-consumer.sh"
   },
   "dependencies": {
+    "@base-ui/react": "1.6.0",
     "class-variance-authority": "0.7.1"
   },
   "peerDependencies": {
@@ -39,12 +40,12 @@
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "4.1.4",
     "jsdom": "26.1.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3",
     "tsup": "^8.0.0",
     "typescript": "^5.4.2",
     "vitest": "4.1.4"

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist",
+    "llms.txt",
     "README.md",
     "LICENSE",
     "NOTICE"
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",
+    "@types/node": "^25.5.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "4.1.4",

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -81,4 +81,9 @@ grep -rq -- '--primary' dist/assets/*.css || { echo 'FAIL: theme variables missi
 grep -rqE 'button_button' dist/assets/*.css || { echo 'FAIL: component styles missing from bundle'; exit 1; }
 grep -rqE 'button_variantOutline' dist/assets/*.js || { echo 'FAIL: CSS-module class map missing from JS bundle'; exit 1; }
 
+echo "==> Asserting the AI docs layer ships with the package"
+KIT="node_modules/@gears-frontx/ui-kit"
+[ -f "$KIT/llms.txt" ] || { echo 'FAIL: llms.txt missing from the package'; exit 1; }
+[ -f "$KIT/dist/docs/button.md" ] || { echo 'FAIL: per-component docs missing from dist/docs'; exit 1; }
+
 echo "OK: consumer check passed"

--- a/packages/ui-kit/src/__test-utils__/setup.ts
+++ b/packages/ui-kit/src/__test-utils__/setup.ts
@@ -1,0 +1,22 @@
+/*
+ * jsdom has no PointerEvent constructor; Base UI dispatches one onto the
+ * hidden native input when a checkbox/radio/switch is clicked. A MouseEvent
+ * subclass is enough for those code paths.
+ */
+if (typeof window !== 'undefined' && typeof window.PointerEvent === 'undefined') {
+  class PointerEventPolyfill extends MouseEvent {
+    readonly pointerId: number;
+    readonly pointerType: string;
+
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? '';
+    }
+  }
+  Object.defineProperty(window, 'PointerEvent', {
+    value: PointerEventPolyfill,
+    writable: true,
+    configurable: true,
+  });
+}

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -1,0 +1,63 @@
+# Button
+
+An action button. Wraps the Base UI Button primitive: render-prop
+polymorphism, correct disabled/focus behavior, `type="button"` by default
+(pass `type="submit"` explicitly for form submission).
+
+## When to use
+
+- Any click-triggered action: submit, delete, open a dialog, toggle a panel.
+- Navigation styled as a button: `<Button render={<a href="..." />}>` so the
+  element is a real link (crawlable, cmd-clickable).
+
+## When not to use
+
+- Plain in-text navigation — use the consumer app's link component, not
+  `variant="link"`; that variant exists for actions that visually read as
+  links.
+- Toggling on/off state — use `switch` or `checkbox` (planned) instead.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `variant` | `default` \| `destructive` \| `outline` \| `secondary` \| `ghost` \| `link` | `default` |
+| `size` | `default` \| `sm` \| `lg` \| `icon` | `default` |
+| `render` | `ReactElement` — replaces the root element, button semantics are applied to it | — |
+| `focusableWhenDisabled` | `boolean` — keep the button in tab order when disabled | `false` |
+| `className` | `string` — merged after variant classes | — |
+
+All other props are native `<button>` props (`onClick`, `disabled`, `type`,
+`aria-*`, ...) and are forwarded as-is.
+
+## Examples
+
+```tsx
+import { Button } from '@gears-frontx/ui-kit';
+
+// Primary action
+<Button onClick={save}>Save</Button>
+
+// Dangerous action
+<Button variant="destructive" onClick={remove}>Delete</Button>
+
+// Secondary action next to a primary one
+<Button variant="outline" onClick={cancel}>Cancel</Button>
+
+// Icon-only: always label it
+<Button size="icon" aria-label="Close">✕</Button>
+
+// Real link that looks like a button
+<Button render={<a href="/reports" />} variant="outline">Open reports</Button>
+
+// Form submit (explicit type)
+<Button type="submit">Create account</Button>
+```
+
+## Anti-patterns
+
+- Do not restyle via inline `style` or ad-hoc CSS — brand changes belong in
+  the theme tokens (`theme.css` CSS variables).
+- Do not use `size="icon"` without `aria-label`.
+- Do not emulate disabled with CSS/`onClick` guards — pass `disabled`
+  (add `focusableWhenDisabled` if it must stay discoverable by keyboard).

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -18,7 +18,7 @@ polymorphism, correct disabled/focus behavior, `type="button"` by default
 - Plain in-text navigation — use the consumer app's link component, not
   `variant="link"`; that variant exists for actions that visually read as
   links.
-- Toggling on/off state — use `switch` or `checkbox` (planned) instead.
+- Toggling on/off state — use `switch` or `checkbox` instead.
 
 ## Props (kit level)
 

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -7,9 +7,11 @@ polymorphism, correct disabled/focus behavior, `type="button"` by default
 ## When to use
 
 - Any click-triggered action: submit, delete, open a dialog, toggle a panel.
-- Navigation styled as a button:
-  `<Button render={<a href="..." />} nativeButton={false}>` — a real anchor
-  underneath (crawlable, cmd-clickable) with button semantics on top.
+- An action that also navigates (e.g. "Open reports"):
+  `<Button render={<a href="..." />} nativeButton={false}>`. It is announced
+  as a button (`role="button"`), while the real anchor underneath keeps
+  cmd-click/middle-click and crawlability. Not a substitute for a link: for
+  plain navigation use the consumer app's link component.
 
 ## When not to use
 
@@ -49,7 +51,8 @@ import { Button } from '@gears-frontx/ui-kit';
 // Icon-only: always label it
 <Button size="icon" aria-label="Close">✕</Button>
 
-// Real link that looks like a button
+// Button-semantic action over a real anchor (announced as a button,
+// cmd-clickable) — not for plain navigation
 <Button render={<a href="/reports" />} nativeButton={false} variant="outline">
   Open reports
 </Button>

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -7,8 +7,9 @@ polymorphism, correct disabled/focus behavior, `type="button"` by default
 ## When to use
 
 - Any click-triggered action: submit, delete, open a dialog, toggle a panel.
-- Navigation styled as a button: `<Button render={<a href="..." />}>` so the
-  element is a real link (crawlable, cmd-clickable).
+- Navigation styled as a button:
+  `<Button render={<a href="..." />} nativeButton={false}>` — a real anchor
+  underneath (crawlable, cmd-clickable) with button semantics on top.
 
 ## When not to use
 
@@ -24,6 +25,7 @@ polymorphism, correct disabled/focus behavior, `type="button"` by default
 | `variant` | `default` \| `destructive` \| `outline` \| `secondary` \| `ghost` \| `link` | `default` |
 | `size` | `default` \| `sm` \| `lg` \| `icon` | `default` |
 | `render` | `ReactElement` — replaces the root element, button semantics are applied to it | — |
+| `nativeButton` | `boolean` — set to `false` whenever `render` is not a native `<button>` | `true` |
 | `focusableWhenDisabled` | `boolean` — keep the button in tab order when disabled | `false` |
 | `className` | `string` — merged after variant classes | — |
 
@@ -48,7 +50,9 @@ import { Button } from '@gears-frontx/ui-kit';
 <Button size="icon" aria-label="Close">✕</Button>
 
 // Real link that looks like a button
-<Button render={<a href="/reports" />} variant="outline">Open reports</Button>
+<Button render={<a href="/reports" />} nativeButton={false} variant="outline">
+  Open reports
+</Button>
 
 // Form submit (explicit type)
 <Button type="submit">Create account</Button>

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -10,7 +10,7 @@
   gap: 0.5rem;
   white-space: nowrap;
   border: 1px solid transparent;
-  border-radius: calc(var(--radius) - 2px);
+  border-radius: var(--radius-md);
   font-family: inherit;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -113,7 +113,7 @@
 .sizeSm {
   height: 2rem;
   padding: 0 0.75rem;
-  border-radius: calc(var(--radius) - 4px);
+  border-radius: var(--radius-sm);
 }
 
 .sizeLg {

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -45,6 +45,18 @@ describe('Button', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('renders a custom element via the render prop', () => {
+    render(
+      <Button render={<a href="/docs" />} variant="link">
+        Docs
+      </Button>,
+    );
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).toHaveProperty('tagName', 'A');
+    expect(link.className).toContain(styles.button);
+    expect(link.className).toContain(styles.variantLink);
+  });
+
   it('does not fire clicks when disabled', () => {
     const onClick = vi.fn();
     render(

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -46,15 +46,21 @@ describe('Button', () => {
   });
 
   it('renders a custom element via the render prop', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(
-      <Button render={<a href="/docs" />} variant="link">
+      <Button render={<a href="/docs" />} nativeButton={false} variant="link">
         Docs
       </Button>,
     );
-    const link = screen.getByRole('link', { name: 'Docs' });
+    // Base UI applies button semantics to the anchor: role="button", real href.
+    const link = screen.getByRole('button', { name: 'Docs' });
     expect(link).toHaveProperty('tagName', 'A');
+    expect(link).toHaveProperty('href', expect.stringContaining('/docs'));
     expect(link.className).toContain(styles.button);
     expect(link.className).toContain(styles.variantLink);
+    // nativeButton={false} keeps Base UI's non-native-button warning silent.
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it('does not fire clicks when disabled', () => {

--- a/packages/ui-kit/src/components/button/button.tsx
+++ b/packages/ui-kit/src/components/button/button.tsx
@@ -1,5 +1,5 @@
+import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ComponentProps } from 'react';
 
 import styles from './button.module.css';
 
@@ -27,8 +27,10 @@ const buttonVariants = cva(styles.button, {
 });
 
 export interface ButtonProps
-  extends ComponentProps<'button'>, VariantProps<typeof buttonVariants> {}
+  extends Omit<ButtonPrimitive.Props, 'className'>, VariantProps<typeof buttonVariants> {
+  className?: string;
+}
 
-export function Button({ className, variant, size, type = 'button', ...props }: ButtonProps) {
-  return <button type={type} className={buttonVariants({ variant, size, className })} {...props} />;
+export function Button({ className, variant, size, ...props }: ButtonProps) {
+  return <ButtonPrimitive className={buttonVariants({ variant, size, className })} {...props} />;
 }

--- a/packages/ui-kit/src/components/checkbox/checkbox.md
+++ b/packages/ui-kit/src/components/checkbox/checkbox.md
@@ -1,0 +1,55 @@
+# Checkbox
+
+An on/off tick box. Wraps the Base UI Checkbox primitive: renders a
+`role="checkbox"` button with a hidden native input for forms, toggles via
+mouse and keyboard, exposes state through `data-checked`/`data-unchecked`.
+
+## When to use
+
+- Opting in/out of independent options (multiple can be on at once).
+- Accepting terms, selecting rows, toggling settings that apply on submit.
+
+## When not to use
+
+- An immediate on/off with instant effect — use `switch`.
+- Mutually exclusive options — use `radio-group`.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `checked` / `defaultChecked` | controlled / uncontrolled state | `false` |
+| `onCheckedChange` | `(checked: boolean, eventDetails) => void` | — |
+| `name` / `value` | form submission via the hidden native input | — |
+| `className` | `string` — merged after the kit class | — |
+
+Other props follow Base UI Checkbox.Root (`disabled`, `required`,
+`readOnly`, ...). `aria-invalid` switches the border and ring to the
+destructive color. The `indeterminate` prop is not visually distinguished
+from checked yet — avoid it for now.
+
+## Examples
+
+```tsx
+import { Checkbox, Label } from '@gears-frontx/ui-kit';
+
+// Labelled checkbox — nesting gives one click target
+<Label>
+  <Checkbox name="terms" required /> I agree to the terms
+</Label>
+
+// Controlled
+<Checkbox checked={selected} onCheckedChange={setSelected} />
+
+// Disabled
+<Label data-disabled="">
+  <Checkbox disabled defaultChecked /> Locked option
+</Label>
+```
+
+## Anti-patterns
+
+- Do not render a checkbox without a visible label — `aria-label` alone is
+  a last resort for dense tables.
+- Do not use it as an instant toggle for a running process — that is
+  `switch` semantics.

--- a/packages/ui-kit/src/components/checkbox/checkbox.md
+++ b/packages/ui-kit/src/components/checkbox/checkbox.md
@@ -25,8 +25,8 @@ mouse and keyboard, exposes state through `data-checked`/`data-unchecked`.
 
 Other props follow Base UI Checkbox.Root (`disabled`, `required`,
 `readOnly`, ...). `aria-invalid` switches the border and ring to the
-destructive color. The `indeterminate` prop is not visually distinguished
-from checked yet — avoid it for now.
+destructive color. `indeterminate` renders a minus mark in an unfilled box
+(`aria-checked="mixed"`) — use it for "some children selected" parents.
 
 ## Examples
 

--- a/packages/ui-kit/src/components/checkbox/checkbox.module.css
+++ b/packages/ui-kit/src/components/checkbox/checkbox.module.css
@@ -13,7 +13,7 @@
   height: 1rem;
   padding: 0;
   border: 1px solid var(--input);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background-color: transparent;
   outline: none;
   transition:

--- a/packages/ui-kit/src/components/checkbox/checkbox.module.css
+++ b/packages/ui-kit/src/components/checkbox/checkbox.module.css
@@ -48,7 +48,9 @@
   }
 }
 
-.checkbox:disabled {
+/* Base UI renders the root as a <span role="checkbox">, so :disabled can
+ * never match — the stamped data-disabled attribute is the disabled state. */
+.checkbox[data-disabled] {
   cursor: not-allowed;
   opacity: 0.5;
 }
@@ -73,4 +75,18 @@
 .icon {
   width: 0.875rem;
   height: 0.875rem;
+}
+
+/* Indeterminate shows a minus in an unfilled box (the root gets
+ * data-indeterminate, not data-checked, so it keeps the outline look). */
+.iconIndeterminate {
+  display: none;
+}
+
+.indicator[data-indeterminate] .iconCheck {
+  display: none;
+}
+
+.indicator[data-indeterminate] .iconIndeterminate {
+  display: block;
 }

--- a/packages/ui-kit/src/components/checkbox/checkbox.module.css
+++ b/packages/ui-kit/src/components/checkbox/checkbox.module.css
@@ -1,0 +1,76 @@
+/*
+ * Checkbox styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.checkbox {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: 1px solid var(--input);
+  border-radius: 4px;
+  background-color: transparent;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+/* Enlarged touch target beyond the 1rem box. */
+.checkbox::after {
+  content: '';
+  position: absolute;
+  inset: -0.5rem -0.75rem;
+}
+
+.checkbox[data-checked] {
+  border-color: var(--primary);
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.checkbox:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .checkbox:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.checkbox:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.checkbox[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}
+
+/* Invalid but checked: the filled box keeps its primary border. */
+.checkbox[aria-invalid='true'][data-checked] {
+  border-color: var(--primary);
+}
+
+.indicator {
+  display: grid;
+  place-content: center;
+  color: currentcolor;
+}
+
+.icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}

--- a/packages/ui-kit/src/components/checkbox/checkbox.test.tsx
+++ b/packages/ui-kit/src/components/checkbox/checkbox.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Checkbox } from './checkbox';
+import styles from './checkbox.module.css';
+
+afterEach(cleanup);
+
+describe('Checkbox', () => {
+  it('renders an unchecked checkbox with the base class', () => {
+    render(<Checkbox aria-label="Terms" />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Terms' });
+    expect(checkbox.className).toContain(styles.checkbox);
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(checkbox.hasAttribute('data-unchecked')).toBe(true);
+  });
+
+  it('toggles on click and reports through onCheckedChange', () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox aria-label="Terms" onCheckedChange={onCheckedChange} />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Terms' });
+    fireEvent.click(checkbox);
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange.mock.calls[0]?.[0]).toBe(true);
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+    expect(checkbox.hasAttribute('data-checked')).toBe(true);
+  });
+
+  it('respects defaultChecked and merges a consumer className', () => {
+    render(<Checkbox aria-label="Terms" defaultChecked className="consumer" />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Terms' });
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+    expect(checkbox.className).toContain(styles.checkbox);
+    expect(checkbox.className).toContain('consumer');
+  });
+
+  it('does not toggle when disabled', () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox aria-label="Terms" disabled onCheckedChange={onCheckedChange} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Terms' }));
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-kit/src/components/checkbox/checkbox.test.tsx
+++ b/packages/ui-kit/src/components/checkbox/checkbox.test.tsx
@@ -34,10 +34,22 @@ describe('Checkbox', () => {
     expect(checkbox.className).toContain('consumer');
   });
 
+  it('renders a distinct indeterminate state', () => {
+    render(<Checkbox aria-label="Partial" indeterminate />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Partial' });
+    expect(checkbox.getAttribute('aria-checked')).toBe('mixed');
+    const indicator = checkbox.querySelector(`.${styles.indicator}`);
+    expect(indicator?.hasAttribute('data-indeterminate')).toBe(true);
+    expect(indicator?.querySelector(`.${styles.iconIndeterminate}`)).toBeTruthy();
+  });
+
   it('does not toggle when disabled', () => {
     const onCheckedChange = vi.fn();
     render(<Checkbox aria-label="Terms" disabled onCheckedChange={onCheckedChange} />);
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Terms' }));
+    const checkbox = screen.getByRole('checkbox', { name: 'Terms' });
+    fireEvent.click(checkbox);
     expect(onCheckedChange).not.toHaveBeenCalled();
+    // The root is a <span>, so the disabled style hangs off data-disabled.
+    expect(checkbox.hasAttribute('data-disabled')).toBe(true);
   });
 });

--- a/packages/ui-kit/src/components/checkbox/checkbox.tsx
+++ b/packages/ui-kit/src/components/checkbox/checkbox.tsx
@@ -1,0 +1,30 @@
+import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
+import { cx } from 'class-variance-authority';
+
+import styles from './checkbox.module.css';
+
+export interface CheckboxProps extends Omit<CheckboxPrimitive.Root.Props, 'className'> {
+  className?: string;
+}
+
+export function Checkbox({ className, ...props }: CheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root className={cx(styles.checkbox, className)} {...props}>
+      <CheckboxPrimitive.Indicator className={styles.indicator}>
+        {/* Inline check mark (lucide "check" path, ISC) — the kit carries no icon dependency. */}
+        <svg
+          className={styles.icon}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}

--- a/packages/ui-kit/src/components/checkbox/checkbox.tsx
+++ b/packages/ui-kit/src/components/checkbox/checkbox.tsx
@@ -11,9 +11,11 @@ export function Checkbox({ className, ...props }: CheckboxProps) {
   return (
     <CheckboxPrimitive.Root className={cx(styles.checkbox, className)} {...props}>
       <CheckboxPrimitive.Indicator className={styles.indicator}>
-        {/* Inline check mark (lucide "check" path, ISC) — the kit carries no icon dependency. */}
+        {/* Inline check/minus marks (lucide paths, ISC) — the kit carries no
+         * icon dependency. CSS swaps them on the indicator's
+         * data-indeterminate state. */}
         <svg
-          className={styles.icon}
+          className={cx(styles.icon, styles.iconCheck)}
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -23,6 +25,18 @@ export function Checkbox({ className, ...props }: CheckboxProps) {
           aria-hidden="true"
         >
           <path d="M20 6 9 17l-5-5" />
+        </svg>
+        <svg
+          className={cx(styles.icon, styles.iconIndeterminate)}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M5 12h14" />
         </svg>
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>

--- a/packages/ui-kit/src/components/field/field.md
+++ b/packages/ui-kit/src/components/field/field.md
@@ -6,9 +6,9 @@ control inside it automatically — ids, `htmlFor`, and `aria-describedby`
 are wired for you, and validation state flows to every part via
 `data-invalid`/`data-disabled`.
 
-Kit controls (`Input`, and Base UI-based controls like `Checkbox`,
-`Switch`, `RadioGroup`, `Select`) register themselves with the surrounding
-Field — no extra props needed.
+Kit controls (`Input`, `Textarea`, and Base UI-based controls like
+`Checkbox`, `Switch`, `RadioGroup`, `Select`) register themselves with the
+surrounding Field — no extra props needed.
 
 ## When to use
 

--- a/packages/ui-kit/src/components/field/field.md
+++ b/packages/ui-kit/src/components/field/field.md
@@ -1,0 +1,68 @@
+# Field
+
+A labelled form field. Wraps the Base UI Field primitives: `Field` (root)
+associates its `FieldLabel`, `FieldDescription`, `FieldError`, and the
+control inside it automatically — ids, `htmlFor`, and `aria-describedby`
+are wired for you, and validation state flows to every part via
+`data-invalid`/`data-disabled`.
+
+Kit controls (`Input`, and Base UI-based controls like `Checkbox`,
+`Switch`, `RadioGroup`, `Select`) register themselves with the surrounding
+Field — no extra props needed.
+
+## When to use
+
+- Every labelled control in a form. This is the default way to compose
+  forms from the kit.
+
+## When not to use
+
+- Purely decorative text next to a control that is not its label or
+  description.
+
+## Props (kit level)
+
+`Field` (root):
+
+| Prop | Type | Default |
+|------|------|---------|
+| `name` | field name, also used by form-level validation | — |
+| `disabled` | disables the control and dims the label | `false` |
+| `invalid` | force the invalid state (external validation libraries) | — |
+| `validate` | custom validation: `(value) => string \| string[] \| null` | — |
+| `className` | `string` — merged after the kit class | — |
+
+`FieldError` accepts `match`: `true` to always show (external validation),
+or a native `ValidityState` key (`"valueMissing"`, `"typeMismatch"`, ...)
+to show only for that failure. Without `match` it shows whenever the field
+is invalid.
+
+## Examples
+
+```tsx
+import { Field, FieldDescription, FieldError, FieldLabel, Input } from '@gears-frontx/ui-kit';
+
+// Label + description + native validation
+<Field name="email">
+  <FieldLabel>Email</FieldLabel>
+  <Input type="email" required placeholder="you@company.com" />
+  <FieldDescription>We only use it for the invoice.</FieldDescription>
+  <FieldError match="valueMissing">Email is required.</FieldError>
+  <FieldError match="typeMismatch">That does not look like an email.</FieldError>
+</Field>
+
+// External validation (e.g. server errors)
+<Field name="slug" invalid={Boolean(serverError)}>
+  <FieldLabel>Slug</FieldLabel>
+  <Input value={slug} onValueChange={setSlug} />
+  <FieldError match={true}>{serverError}</FieldError>
+</Field>
+```
+
+## Anti-patterns
+
+- Do not wire `htmlFor`/`id`/`aria-describedby` by hand inside a Field —
+  the point of the composition is that it does this for you.
+- Do not put two controls in one Field — one field, one control.
+- Do not render validation text outside `FieldError` — screen readers
+  lose the association.

--- a/packages/ui-kit/src/components/field/field.module.css
+++ b/packages/ui-kit/src/components/field/field.module.css
@@ -1,0 +1,28 @@
+/*
+ * Field styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.field {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Base UI stamps data-invalid on the root when validation fails. */
+.field[data-invalid] {
+  color: var(--destructive);
+}
+
+.description {
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.375;
+}
+
+.error {
+  color: var(--destructive);
+  font-size: 0.875rem;
+  line-height: 1.375;
+}

--- a/packages/ui-kit/src/components/field/field.test.tsx
+++ b/packages/ui-kit/src/components/field/field.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Input } from '../input/input';
+import { Field, FieldDescription, FieldError, FieldLabel } from './field';
+import styles from './field.module.css';
+
+afterEach(cleanup);
+
+describe('Field', () => {
+  it('associates the label with the control automatically', () => {
+    render(
+      <Field name="email">
+        <FieldLabel>Email</FieldLabel>
+        <Input type="email" />
+      </Field>,
+    );
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveProperty('tagName', 'INPUT');
+  });
+
+  it('links the description via aria-describedby', () => {
+    render(
+      <Field name="email">
+        <FieldLabel>Email</FieldLabel>
+        <Input type="email" />
+        <FieldDescription>Used for the invoice only.</FieldDescription>
+      </Field>,
+    );
+    const input = screen.getByLabelText('Email');
+    const description = screen.getByText('Used for the invoice only.');
+    expect(description.className).toContain(styles.description);
+    expect(input.getAttribute('aria-describedby')).toContain(description.id);
+  });
+
+  it('shows a forced error and marks the field invalid', () => {
+    render(
+      <Field name="slug" invalid>
+        <FieldLabel>Slug</FieldLabel>
+        <Input defaultValue="taken" />
+        <FieldError match={true}>Already taken.</FieldError>
+      </Field>,
+    );
+    const error = screen.getByText('Already taken.');
+    expect(error.className).toContain(styles.error);
+    expect(screen.getByLabelText('Slug').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('dims and disables through the field root', () => {
+    render(
+      <Field name="locked" disabled>
+        <FieldLabel>Locked</FieldLabel>
+        <Input />
+      </Field>,
+    );
+    expect(screen.getByLabelText('Locked')).toHaveProperty('disabled', true);
+  });
+});

--- a/packages/ui-kit/src/components/field/field.tsx
+++ b/packages/ui-kit/src/components/field/field.tsx
@@ -1,0 +1,39 @@
+import { Field as FieldPrimitive } from '@base-ui/react/field';
+import { cx } from 'class-variance-authority';
+
+import { Label } from '../label/label';
+import styles from './field.module.css';
+
+export interface FieldProps extends Omit<FieldPrimitive.Root.Props, 'className'> {
+  className?: string;
+}
+
+export function Field({ className, ...props }: FieldProps) {
+  return <FieldPrimitive.Root className={cx(styles.field, className)} {...props} />;
+}
+
+export interface FieldLabelProps extends Omit<FieldPrimitive.Label.Props, 'className'> {
+  className?: string;
+}
+
+/* Renders the kit Label through Base UI Field.Label, which wires htmlFor /
+ * id to the field's control automatically. */
+export function FieldLabel({ className, ...props }: FieldLabelProps) {
+  return <FieldPrimitive.Label render={<Label />} className={className} {...props} />;
+}
+
+export interface FieldDescriptionProps extends Omit<FieldPrimitive.Description.Props, 'className'> {
+  className?: string;
+}
+
+export function FieldDescription({ className, ...props }: FieldDescriptionProps) {
+  return <FieldPrimitive.Description className={cx(styles.description, className)} {...props} />;
+}
+
+export interface FieldErrorProps extends Omit<FieldPrimitive.Error.Props, 'className'> {
+  className?: string;
+}
+
+export function FieldError({ className, ...props }: FieldErrorProps) {
+  return <FieldPrimitive.Error className={cx(styles.error, className)} {...props} />;
+}

--- a/packages/ui-kit/src/components/input/input.md
+++ b/packages/ui-kit/src/components/input/input.md
@@ -1,0 +1,57 @@
+# Input
+
+A single-line text field. Wraps the Base UI Input primitive: a native
+`<input>` that automatically wires itself to `Field` (label, description,
+error, validation state) when rendered inside one.
+
+## When to use
+
+- Any single-line free-text value: names, emails, search queries, numbers,
+  file uploads (`type="file"`).
+- Inside a `Field` (planned) to get label association and validation display
+  for free.
+
+## When not to use
+
+- Multi-line text — use `textarea`.
+- Picking from a fixed set of options — use `select`, `radio-group`, or
+  `checkbox`.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `value` / `defaultValue` | controlled / uncontrolled value | — |
+| `onValueChange` | `(value: string, eventDetails) => void` — fires on every change | — |
+| `className` | `string` — merged after the kit class | — |
+
+All other props are native `<input>` props (`type`, `placeholder`,
+`disabled`, `required`, `aria-invalid`, ...) and are forwarded as-is.
+`aria-invalid` switches the border and ring to the destructive color.
+
+## Examples
+
+```tsx
+import { Input } from '@gears-frontx/ui-kit';
+
+// Uncontrolled with placeholder
+<Input placeholder="Search projects…" />
+
+// Controlled
+<Input value={email} onValueChange={setEmail} type="email" />
+
+// Invalid state (set automatically when used inside a Field with an error)
+<Input aria-invalid={true} defaultValue="not-an-email" />
+
+// Disabled
+<Input disabled value="read only for now" />
+```
+
+## Anti-patterns
+
+- Do not use `onChange` + `event.target.value` when `onValueChange` is
+  enough — it hands you the string directly.
+- Do not restyle via inline `style` — sizing/spacing tweaks belong to layout
+  containers, colors to theme tokens.
+- Do not build a labelled input by hand once `field` lands — the Field
+  composition handles label/error/description wiring.

--- a/packages/ui-kit/src/components/input/input.md
+++ b/packages/ui-kit/src/components/input/input.md
@@ -8,8 +8,8 @@ error, validation state) when rendered inside one.
 
 - Any single-line free-text value: names, emails, search queries, numbers,
   file uploads (`type="file"`).
-- Inside a `Field` (planned) to get label association and validation display
-  for free.
+- Inside a `Field` to get label association and validation display for
+  free.
 
 ## When not to use
 
@@ -53,5 +53,5 @@ import { Input } from '@gears-frontx/ui-kit';
   enough — it hands you the string directly.
 - Do not restyle via inline `style` — sizing/spacing tweaks belong to layout
   containers, colors to theme tokens.
-- Do not build a labelled input by hand once `field` lands — the Field
-  composition handles label/error/description wiring.
+- Do not build a labelled input by hand — the `Field` composition handles
+  label/error/description wiring.

--- a/packages/ui-kit/src/components/input/input.module.css
+++ b/packages/ui-kit/src/components/input/input.module.css
@@ -10,7 +10,7 @@
   height: 2.25rem;
   padding: 0.25rem 0.625rem;
   border: 1px solid var(--input);
-  border-radius: calc(var(--radius) - 2px);
+  border-radius: var(--radius-md);
   background-color: transparent;
   color: var(--foreground);
   font-family: inherit;

--- a/packages/ui-kit/src/components/input/input.module.css
+++ b/packages/ui-kit/src/components/input/input.module.css
@@ -1,0 +1,72 @@
+/*
+ * Input styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.input {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  height: 2.25rem;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid var(--input);
+  border-radius: calc(var(--radius) - 2px);
+  background-color: transparent;
+  color: var(--foreground);
+  font-family: inherit;
+  /* text-base on small screens so iOS Safari does not zoom on focus */
+  font-size: 1rem;
+  line-height: 1.5rem;
+  outline: none;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+@media (min-width: 768px) {
+  .input {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+}
+
+.input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.input::file-selector-button {
+  display: inline-flex;
+  height: 1.75rem;
+  border: 0;
+  background-color: transparent;
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.input:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .input:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.input:disabled {
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.input[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}

--- a/packages/ui-kit/src/components/input/input.test.tsx
+++ b/packages/ui-kit/src/components/input/input.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Input } from './input';
+import styles from './input.module.css';
+
+afterEach(cleanup);
+
+describe('Input', () => {
+  it('renders a native input with the base class', () => {
+    render(<Input placeholder="Search" />);
+    const input = screen.getByPlaceholderText('Search');
+    expect(input).toHaveProperty('tagName', 'INPUT');
+    expect(input.className).toContain(styles.input);
+  });
+
+  it('reports value changes through onValueChange', () => {
+    const onValueChange = vi.fn();
+    render(<Input onValueChange={onValueChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'gears' } });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0]?.[0]).toBe('gears');
+  });
+
+  it('merges a consumer className and forwards native props', () => {
+    render(<Input className="consumer" type="email" defaultValue="a@b.c" required />);
+    const input = screen.getByRole('textbox');
+    expect(input.className).toContain(styles.input);
+    expect(input.className).toContain('consumer');
+    expect(input).toHaveProperty('type', 'email');
+    expect(input).toHaveProperty('value', 'a@b.c');
+    expect(input).toHaveProperty('required', true);
+  });
+
+  it('forwards the invalid state', () => {
+    render(<Input aria-invalid={true} />);
+    expect(screen.getByRole('textbox').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('does not accept input when disabled', () => {
+    const onValueChange = vi.fn();
+    render(<Input disabled onValueChange={onValueChange} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveProperty('disabled', true);
+  });
+});

--- a/packages/ui-kit/src/components/input/input.tsx
+++ b/packages/ui-kit/src/components/input/input.tsx
@@ -1,0 +1,12 @@
+import { Input as InputPrimitive } from '@base-ui/react/input';
+import { cx } from 'class-variance-authority';
+
+import styles from './input.module.css';
+
+export interface InputProps extends Omit<InputPrimitive.Props, 'className'> {
+  className?: string;
+}
+
+export function Input({ className, ...props }: InputProps) {
+  return <InputPrimitive className={cx(styles.input, className)} {...props} />;
+}

--- a/packages/ui-kit/src/components/label/label.md
+++ b/packages/ui-kit/src/components/label/label.md
@@ -1,0 +1,50 @@
+# Label
+
+A caption for a form control. A styled native `<label>` — associate it with
+a control via `htmlFor`, or by nesting the control inside it.
+
+## When to use
+
+- Naming any form control: `input`, `textarea`, `select`, `checkbox`,
+  `switch`, `radio-group` items.
+- Inline labels next to a checkbox/switch (nest the control, get the click
+  target for free).
+
+## When not to use
+
+- Headings or free-standing text — labels are for controls; use regular
+  markup styled by the consumer app.
+- Once `field` lands, prefer the Field composition — it wires the label,
+  control, description, and error together automatically.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `className` | `string` — merged after the kit class | — |
+
+All other props are native `<label>` props (`htmlFor`, ...) and are
+forwarded as-is. A `data-disabled` attribute dims the label (set
+automatically inside a Field whose control is disabled).
+
+## Examples
+
+```tsx
+import { Input, Label } from '@gears-frontx/ui-kit';
+
+// Explicit association
+<Label htmlFor="email">Email</Label>
+<Input id="email" type="email" />
+
+// Nested control (single click target)
+<Label>
+  <input type="checkbox" /> Remember me
+</Label>
+```
+
+## Anti-patterns
+
+- Do not render a label without associating it with a control — screen
+  readers get nothing from an orphan label.
+- Do not use placeholders instead of labels — placeholders disappear on
+  input.

--- a/packages/ui-kit/src/components/label/label.md
+++ b/packages/ui-kit/src/components/label/label.md
@@ -14,7 +14,7 @@ a control via `htmlFor`, or by nesting the control inside it.
 
 - Headings or free-standing text — labels are for controls; use regular
   markup styled by the consumer app.
-- Once `field` lands, prefer the Field composition — it wires the label,
+- Inside a form, prefer the `Field` composition — it wires the label,
   control, description, and error together automatically.
 
 ## Props (kit level)

--- a/packages/ui-kit/src/components/label/label.module.css
+++ b/packages/ui-kit/src/components/label/label.module.css
@@ -1,0 +1,22 @@
+/*
+ * Label styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--foreground);
+  font-size: 0.875rem;
+  line-height: 1;
+  font-weight: 500;
+  user-select: none;
+}
+
+/* Base UI Field.Label stamps data-disabled when its control is disabled;
+ * the same attribute can be set manually outside a Field. */
+.label[data-disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/packages/ui-kit/src/components/label/label.module.css
+++ b/packages/ui-kit/src/components/label/label.module.css
@@ -3,11 +3,14 @@
  * Consumes only theme.css variables — no raw colors.
  */
 
+/*
+ * No color declaration on purpose: the label inherits from its context so
+ * Field can tint it destructive via .field[data-invalid].
+ */
 .label {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--foreground);
   font-size: 0.875rem;
   line-height: 1;
   font-weight: 500;

--- a/packages/ui-kit/src/components/label/label.test.tsx
+++ b/packages/ui-kit/src/components/label/label.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Input } from '../input/input';
+import { Label } from './label';
+import styles from './label.module.css';
+
+afterEach(cleanup);
+
+describe('Label', () => {
+  it('renders a native label with the base class', () => {
+    render(<Label>Email</Label>);
+    const label = screen.getByText('Email');
+    expect(label).toHaveProperty('tagName', 'LABEL');
+    expect(label.className).toContain(styles.label);
+  });
+
+  it('associates with a control via htmlFor', () => {
+    render(
+      <>
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" />
+      </>,
+    );
+    expect(screen.getByLabelText('Email')).toHaveProperty('id', 'email');
+  });
+
+  it('merges a consumer className and forwards data attributes', () => {
+    render(
+      <Label className="consumer" data-disabled="">
+        Name
+      </Label>,
+    );
+    const label = screen.getByText('Name');
+    expect(label.className).toContain(styles.label);
+    expect(label.className).toContain('consumer');
+    expect(label.hasAttribute('data-disabled')).toBe(true);
+  });
+});

--- a/packages/ui-kit/src/components/label/label.tsx
+++ b/packages/ui-kit/src/components/label/label.tsx
@@ -1,0 +1,10 @@
+import { cx } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
+
+import styles from './label.module.css';
+
+export type LabelProps = ComponentProps<'label'>;
+
+export function Label({ className, ...props }: LabelProps) {
+  return <label className={cx(styles.label, className)} {...props} />;
+}

--- a/packages/ui-kit/src/components/radio-group/radio-group.md
+++ b/packages/ui-kit/src/components/radio-group/radio-group.md
@@ -1,0 +1,59 @@
+# RadioGroup
+
+A set of mutually exclusive options. Wraps the Base UI RadioGroup/Radio
+primitives: `role="radiogroup"` container, `role="radio"` items with a
+hidden native input, arrow-key navigation between items, state via
+`data-checked`/`data-unchecked`.
+
+## When to use
+
+- Choosing exactly one of 2–6 visible options: plan tier, delivery method,
+  sort order.
+
+## When not to use
+
+- More than ~6 options or constrained space — use `select`.
+- Independent on/off options — use `checkbox`.
+- Instant toggles — use `switch`.
+
+## Props (kit level)
+
+`RadioGroup`:
+
+| Prop | Type | Default |
+|------|------|---------|
+| `value` / `defaultValue` | controlled / uncontrolled selected value | — |
+| `onValueChange` | `(value, eventDetails) => void` | — |
+| `name` | form submission via the hidden native input | — |
+| `disabled` | disables the whole group | `false` |
+| `className` | `string` — merged after the kit class | — |
+
+`RadioGroupItem`: `value` (required), `disabled`, `className`; other props
+follow Base UI Radio.Root. `aria-invalid` on an item switches its border
+and ring to the destructive color.
+
+## Examples
+
+```tsx
+import { Label, RadioGroup, RadioGroupItem } from '@gears-frontx/ui-kit';
+
+<RadioGroup value={tier} onValueChange={setTier} aria-label="Plan tier">
+  <Label>
+    <RadioGroupItem value="free" /> Free
+  </Label>
+  <Label>
+    <RadioGroupItem value="pro" /> Pro
+  </Label>
+  <Label>
+    <RadioGroupItem value="enterprise" disabled /> Enterprise (contact us)
+  </Label>
+</RadioGroup>
+```
+
+## Anti-patterns
+
+- Do not use radio items outside a `RadioGroup` — keyboard navigation and
+  the single-selection contract live on the group.
+- Do not preselect nothing when a default makes sense — an all-unchecked
+  radio group is hard to keyboard-focus predictably.
+- Do not use it for yes/no — a single `checkbox` or `switch` reads better.

--- a/packages/ui-kit/src/components/radio-group/radio-group.module.css
+++ b/packages/ui-kit/src/components/radio-group/radio-group.module.css
@@ -1,0 +1,88 @@
+/*
+ * Radio group styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.group {
+  display: grid;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+.item {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: 1px solid var(--input);
+  border-radius: 9999px;
+  background-color: transparent;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+/* Enlarged touch target beyond the 1rem circle. */
+.item::after {
+  content: '';
+  position: absolute;
+  inset: -0.5rem -0.75rem;
+}
+
+.item[data-checked] {
+  border-color: var(--primary);
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.item:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .item:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.item:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.item[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}
+
+/* Invalid but checked: the filled circle keeps its primary border. */
+.item[aria-invalid='true'][data-checked] {
+  border-color: var(--primary);
+}
+
+.indicator {
+  display: flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  transform: translate(-50%, -50%);
+  border-radius: 9999px;
+  background-color: var(--primary-foreground);
+}

--- a/packages/ui-kit/src/components/radio-group/radio-group.module.css
+++ b/packages/ui-kit/src/components/radio-group/radio-group.module.css
@@ -52,7 +52,9 @@
   }
 }
 
-.item:disabled {
+/* Base UI renders the item as a <span role="radio">, so :disabled can
+ * never match — the stamped data-disabled attribute is the disabled state. */
+.item[data-disabled] {
   cursor: not-allowed;
   opacity: 0.5;
 }

--- a/packages/ui-kit/src/components/radio-group/radio-group.test.tsx
+++ b/packages/ui-kit/src/components/radio-group/radio-group.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { RadioGroup, RadioGroupItem } from './radio-group';
+import styles from './radio-group.module.css';
+
+afterEach(cleanup);
+
+function renderGroup(props: Parameters<typeof RadioGroup>[0] = {}) {
+  return render(
+    <RadioGroup aria-label="Tier" {...props}>
+      <RadioGroupItem value="free" aria-label="Free" />
+      <RadioGroupItem value="pro" aria-label="Pro" />
+      <RadioGroupItem value="enterprise" aria-label="Enterprise" disabled />
+    </RadioGroup>,
+  );
+}
+
+describe('RadioGroup', () => {
+  it('renders a radiogroup with radio items and kit classes', () => {
+    renderGroup();
+    const group = screen.getByRole('radiogroup', { name: 'Tier' });
+    expect(group.className).toContain(styles.group);
+    const items = screen.getAllByRole('radio');
+    expect(items).toHaveLength(3);
+    expect(items[0]?.className).toContain(styles.item);
+  });
+
+  it('selects an item on click and reports through onValueChange', () => {
+    const onValueChange = vi.fn();
+    renderGroup({ onValueChange });
+    const pro = screen.getByRole('radio', { name: 'Pro' });
+    fireEvent.click(pro);
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0]?.[0]).toBe('pro');
+    expect(pro.getAttribute('aria-checked')).toBe('true');
+    expect(pro.hasAttribute('data-checked')).toBe(true);
+  });
+
+  it('keeps selection exclusive', () => {
+    renderGroup({ defaultValue: 'free' });
+    const free = screen.getByRole('radio', { name: 'Free' });
+    const pro = screen.getByRole('radio', { name: 'Pro' });
+    expect(free.getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(pro);
+    expect(free.getAttribute('aria-checked')).toBe('false');
+    expect(pro.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('ignores clicks on a disabled item', () => {
+    const onValueChange = vi.fn();
+    renderGroup({ onValueChange });
+    fireEvent.click(screen.getByRole('radio', { name: 'Enterprise' }));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-kit/src/components/radio-group/radio-group.test.tsx
+++ b/packages/ui-kit/src/components/radio-group/radio-group.test.tsx
@@ -50,7 +50,10 @@ describe('RadioGroup', () => {
   it('ignores clicks on a disabled item', () => {
     const onValueChange = vi.fn();
     renderGroup({ onValueChange });
-    fireEvent.click(screen.getByRole('radio', { name: 'Enterprise' }));
+    const disabledItem = screen.getByRole('radio', { name: 'Enterprise' });
+    fireEvent.click(disabledItem);
     expect(onValueChange).not.toHaveBeenCalled();
+    // The item is a <span>, so the disabled style hangs off data-disabled.
+    expect(disabledItem.hasAttribute('data-disabled')).toBe(true);
   });
 });

--- a/packages/ui-kit/src/components/radio-group/radio-group.tsx
+++ b/packages/ui-kit/src/components/radio-group/radio-group.tsx
@@ -1,0 +1,27 @@
+import { Radio as RadioPrimitive } from '@base-ui/react/radio';
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group';
+import { cx } from 'class-variance-authority';
+
+import styles from './radio-group.module.css';
+
+export interface RadioGroupProps extends Omit<RadioGroupPrimitive.Props, 'className'> {
+  className?: string;
+}
+
+export function RadioGroup({ className, ...props }: RadioGroupProps) {
+  return <RadioGroupPrimitive className={cx(styles.group, className)} {...props} />;
+}
+
+export interface RadioGroupItemProps extends Omit<RadioPrimitive.Root.Props, 'className'> {
+  className?: string;
+}
+
+export function RadioGroupItem({ className, ...props }: RadioGroupItemProps) {
+  return (
+    <RadioPrimitive.Root className={cx(styles.item, className)} {...props}>
+      <RadioPrimitive.Indicator className={styles.indicator}>
+        <span className={styles.dot} />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
+  );
+}

--- a/packages/ui-kit/src/components/select/select.md
+++ b/packages/ui-kit/src/components/select/select.md
@@ -36,7 +36,10 @@ raw value instead of the label until the popup has been opened once.
 `SelectValue`: renders the selected item's label; pass `placeholder` via
 the root's `items`/children contract (see example). `SelectContent`
 accepts positioning props (`side`, `sideOffset`, `align`, `alignOffset`,
-`alignItemWithTrigger`). `SelectItem` takes `value` (required) and
+`alignItemWithTrigger`) and `container` — the popup portals to `<body>`
+by default, so if your theme lives on a subtree (`data-theme` on a
+section instead of `<html>`), pass that section as `container` or the
+popup renders with the root theme. `SelectItem` takes `value` (required) and
 `disabled`. `aria-invalid` on the trigger switches its border and ring to
 the destructive color.
 

--- a/packages/ui-kit/src/components/select/select.md
+++ b/packages/ui-kit/src/components/select/select.md
@@ -33,8 +33,8 @@ raw value instead of the label until the popup has been opened once.
 | `size` | `default` \| `sm` | `default` |
 | `className` | `string` — merged after the kit class | — |
 
-`SelectValue`: renders the selected item's label; pass `placeholder` via
-the root's `items`/children contract (see example). `SelectContent`
+`SelectValue`: renders the selected item's label. Pass `placeholder`
+directly to `SelectValue` (see example). `SelectContent`
 accepts positioning props (`side`, `sideOffset`, `align`, `alignOffset`,
 `alignItemWithTrigger`) and `container` — the popup portals to `<body>`
 by default, so if your theme lives on a subtree (`data-theme` on a

--- a/packages/ui-kit/src/components/select/select.md
+++ b/packages/ui-kit/src/components/select/select.md
@@ -1,0 +1,92 @@
+# Select
+
+A dropdown for picking one value from a list. Wraps the Base UI Select
+primitives; the popup is portalled, keyboard navigation, typeahead, and
+form submission (hidden native input on the root) come from Base UI.
+
+Composition: `Select` (root, holds the value) → `SelectTrigger` (+
+`SelectValue` for the current label) → `SelectContent` → `SelectGroup` /
+`SelectLabel` / `SelectItem` / `SelectSeparator`.
+
+## When to use
+
+- Picking one option from ~7 or more, or when space is tight.
+- Option lists with groups and separators.
+
+## When not to use
+
+- 2–6 always-visible options — use `radio-group`.
+- Multi-select or search over options — out of MVP scope; compose from
+  primitives in the consumer app.
+
+## Props (kit level)
+
+`Select` (root): `value` / `defaultValue`, `onValueChange`, `name`,
+`disabled`, `required` — see Base UI Select.Root. Always pass `items`
+(`{ value, label }[]`) as well: without it the closed trigger renders the
+raw value instead of the label until the popup has been opened once.
+
+`SelectTrigger`:
+
+| Prop | Type | Default |
+|------|------|---------|
+| `size` | `default` \| `sm` | `default` |
+| `className` | `string` — merged after the kit class | — |
+
+`SelectValue`: renders the selected item's label; pass `placeholder` via
+the root's `items`/children contract (see example). `SelectContent`
+accepts positioning props (`side`, `sideOffset`, `align`, `alignOffset`,
+`alignItemWithTrigger`). `SelectItem` takes `value` (required) and
+`disabled`. `aria-invalid` on the trigger switches its border and ring to
+the destructive color.
+
+## Examples
+
+```tsx
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@gears-frontx/ui-kit';
+
+const REGIONS = [
+  { value: 'eu-central', label: 'Frankfurt' },
+  { value: 'eu-west', label: 'Dublin' },
+  { value: 'us-east', label: 'Virginia' },
+  { value: 'us-west', label: 'Oregon (soon)' },
+];
+
+<Select value={region} onValueChange={setRegion} items={REGIONS}>
+  <SelectTrigger aria-label="Region">
+    <SelectValue placeholder="Pick a region" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>Europe</SelectLabel>
+      <SelectItem value="eu-central">Frankfurt</SelectItem>
+      <SelectItem value="eu-west">Dublin</SelectItem>
+    </SelectGroup>
+    <SelectSeparator />
+    <SelectGroup>
+      <SelectLabel>Americas</SelectLabel>
+      <SelectItem value="us-east">Virginia</SelectItem>
+      <SelectItem value="us-west" disabled>
+        Oregon (soon)
+      </SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>
+```
+
+## Anti-patterns
+
+- Do not put items directly under `SelectContent` without a `SelectGroup`
+  — the group carries the list padding.
+- Do not use a select for navigation — that is a menu/link pattern.
+- Do not omit a placeholder or default value — an empty trigger gives the
+  user (and the agent) nothing to read.

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -11,7 +11,7 @@
   gap: 0.375rem;
   padding: 0.5rem 0.5rem 0.5rem 0.625rem;
   border: 1px solid var(--input);
-  border-radius: calc(var(--radius) - 2px);
+  border-radius: var(--radius-md);
   background-color: transparent;
   color: var(--foreground);
   font-family: inherit;
@@ -91,7 +91,7 @@
   min-width: 9rem;
   overflow-x: hidden;
   overflow-y: auto;
-  border-radius: calc(var(--radius) - 2px);
+  border-radius: var(--radius-md);
   border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
   background-color: var(--popover);
   color: var(--popover-foreground);
@@ -135,7 +135,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.375rem 2rem 0.375rem 0.5rem;
-  border-radius: calc(var(--radius) - 4px);
+  border-radius: var(--radius-sm);
   cursor: default;
   user-select: none;
   font-size: 0.875rem;

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -1,0 +1,207 @@
+/*
+ * Select styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.trigger {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.375rem;
+  padding: 0.5rem 0.5rem 0.5rem 0.625rem;
+  border: 1px solid var(--input);
+  border-radius: calc(var(--radius) - 2px);
+  background-color: transparent;
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  outline: none;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.trigger[data-placeholder] {
+  color: var(--muted-foreground);
+}
+
+.trigger:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .trigger:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.trigger[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}
+
+.sizeDefault {
+  height: 2.25rem;
+}
+
+.sizeSm {
+  height: 2rem;
+}
+
+.triggerIcon {
+  pointer-events: none;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.value {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 0.375rem;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+}
+
+.positioner {
+  isolation: isolate;
+  z-index: 50;
+}
+
+.popup {
+  position: relative;
+  isolation: isolate;
+  z-index: 50;
+  max-height: var(--available-height);
+  width: var(--anchor-width);
+  min-width: 9rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-radius: calc(var(--radius) - 2px);
+  border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow:
+    0 4px 6px -1px color-mix(in oklab, var(--foreground) 10%, transparent),
+    0 2px 4px -2px color-mix(in oklab, var(--foreground) 10%, transparent);
+  transform-origin: var(--transform-origin);
+  transition:
+    opacity 100ms ease,
+    transform 100ms ease;
+}
+
+.popup[data-starting-style],
+.popup[data-ending-style] {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+/* When the popup aligns an item over the trigger (native-select feel),
+ * entering with a scale animation would visibly shift it — skip it. */
+.popup[data-align-trigger='true'] {
+  transition: none;
+}
+
+.group {
+  padding: 0.25rem;
+  scroll-margin: 0.25rem 0;
+}
+
+.groupLabel {
+  padding: 0.375rem 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.item {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 2rem 0.375rem 0.5rem;
+  border-radius: calc(var(--radius) - 4px);
+  cursor: default;
+  user-select: none;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  outline: none;
+}
+
+.item:focus,
+.item[data-highlighted] {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.item[data-disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.itemText {
+  display: flex;
+  flex: 1;
+  flex-shrink: 0;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.itemIndicator {
+  pointer-events: none;
+  position: absolute;
+  right: 0.5rem;
+  display: flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.separator {
+  pointer-events: none;
+  margin: 0.25rem -0.25rem;
+  height: 1px;
+  background-color: var(--border);
+}
+
+.scrollArrow {
+  z-index: 10;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0;
+  cursor: default;
+  background-color: var(--popover);
+}
+
+.scrollArrowUp {
+  top: 0;
+}
+
+.scrollArrowDown {
+  bottom: 0;
+}
+
+.svgIcon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  pointer-events: none;
+}

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -69,6 +69,27 @@ describe('Select', () => {
     expect(screen.getByRole('combobox', { name: 'Region' }).textContent).toContain('Americas');
   });
 
+  it('portals the popup into a provided container', () => {
+    const container = document.createElement('div');
+    container.id = 'themed-section';
+    document.body.appendChild(container);
+    render(
+      <Select items={ITEMS} defaultOpen>
+        <SelectTrigger aria-label="Region">
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent container={container}>
+          <SelectGroup>
+            <SelectItem value="eu">Europe</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+    const listbox = screen.getByRole('listbox');
+    expect(container.contains(listbox)).toBe(true);
+    container.remove();
+  });
+
   it('applies the sm trigger size', () => {
     render(
       <Select>

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './select';
+import styles from './select.module.css';
+
+afterEach(cleanup);
+
+const ITEMS = [
+  { value: 'eu', label: 'Europe' },
+  { value: 'us', label: 'Americas' },
+];
+
+function renderSelect(rootProps: Parameters<typeof Select>[0] = {}) {
+  return render(
+    <Select items={ITEMS} {...rootProps}>
+      <SelectTrigger aria-label="Region">
+        <SelectValue placeholder="Pick a region" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="eu">Europe</SelectItem>
+          <SelectItem value="us">Americas</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>,
+  );
+}
+
+describe('Select', () => {
+  it('renders a closed trigger with the placeholder and kit classes', () => {
+    renderSelect();
+    const trigger = screen.getByRole('combobox', { name: 'Region' });
+    expect(trigger.className).toContain(styles.trigger);
+    expect(trigger.className).toContain(styles.sizeDefault);
+    expect(trigger.textContent).toContain('Pick a region');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('shows options when open and marks items with kit classes', () => {
+    renderSelect({ defaultOpen: true });
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    const option = screen.getByRole('option', { name: 'Europe' });
+    expect(option.className).toContain(styles.item);
+  });
+
+  it('selects an option and reports through onValueChange', () => {
+    const onValueChange = vi.fn();
+    renderSelect({ defaultOpen: true, onValueChange });
+    const option = screen.getByRole('option', { name: 'Europe' });
+    // Base UI commits a mouse selection only when the click started on the
+    // item (guards against alignItemWithTrigger placing an item under the
+    // cursor), so the pointerdown must precede the click.
+    fireEvent.pointerDown(option);
+    fireEvent.click(option);
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0]?.[0]).toBe('eu');
+  });
+
+  it('renders the selected value in the trigger', () => {
+    renderSelect({ defaultValue: 'us' });
+    expect(screen.getByRole('combobox', { name: 'Region' }).textContent).toContain('Americas');
+  });
+
+  it('applies the sm trigger size', () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="Compact" size="sm">
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="a">A</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+    expect(screen.getByRole('combobox', { name: 'Compact' }).className).toContain(styles.sizeSm);
+  });
+});

--- a/packages/ui-kit/src/components/select/select.tsx
+++ b/packages/ui-kit/src/components/select/select.tsx
@@ -65,11 +65,18 @@ export interface SelectContentProps
       'align' | 'alignOffset' | 'side' | 'sideOffset' | 'alignItemWithTrigger'
     > {
   className?: string;
+  /**
+   * Where to portal the popup. Defaults to <body>. Pass a themed container
+   * when the theme is scoped to a subtree (data-theme on a section rather
+   * than <html>) so the popup inherits its tokens and font.
+   */
+  container?: SelectPrimitive.Portal.Props['container'];
 }
 
 export function SelectContent({
   className,
   children,
+  container,
   side = 'bottom',
   sideOffset = 4,
   align = 'center',
@@ -78,7 +85,7 @@ export function SelectContent({
   ...props
 }: SelectContentProps) {
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container}>
       <SelectPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/packages/ui-kit/src/components/select/select.tsx
+++ b/packages/ui-kit/src/components/select/select.tsx
@@ -1,0 +1,185 @@
+import { Select as SelectPrimitive } from '@base-ui/react/select';
+import { cva, cx, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
+
+import styles from './select.module.css';
+
+/* Inline lucide paths (ISC) — the kit carries no icon dependency. */
+function Chevron({ direction, className }: { direction: 'up' | 'down'; className?: string }) {
+  return (
+    <svg
+      className={cx(styles.svgIcon, className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={direction === 'down' ? 'm6 9 6 6 6-6' : 'm18 15-6-6-6 6'} />
+    </svg>
+  );
+}
+
+export const Select = SelectPrimitive.Root;
+
+export interface SelectValueProps extends Omit<SelectPrimitive.Value.Props, 'className'> {
+  className?: string;
+}
+
+export function SelectValue({ className, ...props }: SelectValueProps) {
+  return <SelectPrimitive.Value className={cx(styles.value, className)} {...props} />;
+}
+
+const triggerVariants = cva(styles.trigger, {
+  variants: {
+    size: {
+      default: styles.sizeDefault,
+      sm: styles.sizeSm,
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+export interface SelectTriggerProps
+  extends Omit<SelectPrimitive.Trigger.Props, 'className'>, VariantProps<typeof triggerVariants> {
+  className?: string;
+}
+
+export function SelectTrigger({ className, size, children, ...props }: SelectTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger className={triggerVariants({ size, className })} {...props}>
+      {children}
+      <SelectPrimitive.Icon render={<Chevron direction="down" className={styles.triggerIcon} />} />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+export interface SelectContentProps
+  extends Omit<SelectPrimitive.Popup.Props, 'className'>,
+    Pick<
+      SelectPrimitive.Positioner.Props,
+      'align' | 'alignOffset' | 'side' | 'sideOffset' | 'alignItemWithTrigger'
+    > {
+  className?: string;
+}
+
+export function SelectContent({
+  className,
+  children,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectContentProps) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className={styles.positioner}
+      >
+        <SelectPrimitive.Popup
+          data-align-trigger={alignItemWithTrigger}
+          className={cx(styles.popup, className)}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+export interface SelectGroupProps extends Omit<SelectPrimitive.Group.Props, 'className'> {
+  className?: string;
+}
+
+export function SelectGroup({ className, ...props }: SelectGroupProps) {
+  return <SelectPrimitive.Group className={cx(styles.group, className)} {...props} />;
+}
+
+export interface SelectLabelProps extends Omit<SelectPrimitive.GroupLabel.Props, 'className'> {
+  className?: string;
+}
+
+export function SelectLabel({ className, ...props }: SelectLabelProps) {
+  return <SelectPrimitive.GroupLabel className={cx(styles.groupLabel, className)} {...props} />;
+}
+
+export interface SelectItemProps extends Omit<SelectPrimitive.Item.Props, 'className'> {
+  className?: string;
+  children?: ReactNode;
+}
+
+export function SelectItem({ className, children, ...props }: SelectItemProps) {
+  return (
+    <SelectPrimitive.Item className={cx(styles.item, className)} {...props}>
+      <SelectPrimitive.ItemText className={styles.itemText}>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator render={<span className={styles.itemIndicator} />}>
+        <svg
+          className={styles.svgIcon}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+export interface SelectSeparatorProps extends Omit<SelectPrimitive.Separator.Props, 'className'> {
+  className?: string;
+}
+
+export function SelectSeparator({ className, ...props }: SelectSeparatorProps) {
+  return <SelectPrimitive.Separator className={cx(styles.separator, className)} {...props} />;
+}
+
+export function SelectScrollUpButton({
+  className,
+  ...props
+}: Omit<ComponentProps<typeof SelectPrimitive.ScrollUpArrow>, 'className'> & {
+  className?: string;
+}) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      className={cx(styles.scrollArrow, styles.scrollArrowUp, className)}
+      {...props}
+    >
+      <Chevron direction="up" />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+export function SelectScrollDownButton({
+  className,
+  ...props
+}: Omit<ComponentProps<typeof SelectPrimitive.ScrollDownArrow>, 'className'> & {
+  className?: string;
+}) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      className={cx(styles.scrollArrow, styles.scrollArrowDown, className)}
+      {...props}
+    >
+      <Chevron direction="down" />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}

--- a/packages/ui-kit/src/components/switch/switch.md
+++ b/packages/ui-kit/src/components/switch/switch.md
@@ -1,0 +1,51 @@
+# Switch
+
+An on/off toggle with immediate effect. Wraps the Base UI Switch primitive
+(Root + Thumb): renders a `role="switch"` button with a hidden native input
+for forms, state via `data-checked`/`data-unchecked`.
+
+## When to use
+
+- Settings that apply the moment they change: enable notifications, dark
+  mode, feature flags.
+
+## When not to use
+
+- Options that only apply on form submit — use `checkbox`.
+- Mutually exclusive choices — use `radio-group`.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `checked` / `defaultChecked` | controlled / uncontrolled state | `false` |
+| `onCheckedChange` | `(checked: boolean, eventDetails) => void` | — |
+| `size` | `default` \| `sm` | `default` |
+| `name` / `value` | form submission via the hidden native input | — |
+| `className` | `string` — merged after the kit class | — |
+
+Other props follow Base UI Switch.Root (`disabled`, `readOnly`, ...).
+`aria-invalid` switches the border and ring to the destructive color.
+
+## Examples
+
+```tsx
+import { Label, Switch } from '@gears-frontx/ui-kit';
+
+// Labelled toggle — nesting gives one click target
+<Label>
+  <Switch checked={notify} onCheckedChange={setNotify} /> Email notifications
+</Label>
+
+// Compact rows
+<Switch size="sm" defaultChecked aria-label="Enable rule" />
+
+// Disabled
+<Switch disabled aria-label="Locked setting" />
+```
+
+## Anti-patterns
+
+- Do not use a switch when the change needs a confirm/submit step — that is
+  `checkbox` semantics.
+- Do not render one without a visible label or `aria-label`.

--- a/packages/ui-kit/src/components/switch/switch.module.css
+++ b/packages/ui-kit/src/components/switch/switch.module.css
@@ -1,0 +1,94 @@
+/*
+ * Switch styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  outline: none;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+/* Enlarged touch target beyond the track. */
+.switch::after {
+  content: '';
+  position: absolute;
+  inset: -0.5rem -0.75rem;
+}
+
+.switch[data-checked] {
+  background-color: var(--primary);
+}
+
+.switch[data-unchecked] {
+  background-color: var(--input);
+}
+
+.switch:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .switch:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.switch[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.switch[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}
+
+.sizeDefault {
+  height: 1.15rem;
+  width: 2rem;
+}
+
+.sizeSm {
+  height: 0.875rem;
+  width: 1.5rem;
+}
+
+.thumb {
+  pointer-events: none;
+  display: block;
+  border-radius: 9999px;
+  background-color: var(--background);
+  transition: transform 150ms ease;
+}
+
+.sizeDefault .thumb {
+  width: 1rem;
+  height: 1rem;
+}
+
+.sizeSm .thumb {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.thumb[data-checked] {
+  transform: translateX(calc(100% - 2px));
+}
+
+.thumb[data-unchecked] {
+  transform: translateX(0);
+}

--- a/packages/ui-kit/src/components/switch/switch.test.tsx
+++ b/packages/ui-kit/src/components/switch/switch.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Switch } from './switch';
+import styles from './switch.module.css';
+
+afterEach(cleanup);
+
+describe('Switch', () => {
+  it('renders an unchecked switch with base and default size classes', () => {
+    render(<Switch aria-label="Notifications" />);
+    const toggle = screen.getByRole('switch', { name: 'Notifications' });
+    expect(toggle.className).toContain(styles.switch);
+    expect(toggle.className).toContain(styles.sizeDefault);
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('toggles on click and reports through onCheckedChange', () => {
+    const onCheckedChange = vi.fn();
+    render(<Switch aria-label="Notifications" onCheckedChange={onCheckedChange} />);
+    const toggle = screen.getByRole('switch', { name: 'Notifications' });
+    fireEvent.click(toggle);
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange.mock.calls[0]?.[0]).toBe(true);
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    expect(toggle.hasAttribute('data-checked')).toBe(true);
+  });
+
+  it('applies the sm size and merges a consumer className', () => {
+    render(<Switch aria-label="Rule" size="sm" className="consumer" />);
+    const toggle = screen.getByRole('switch', { name: 'Rule' });
+    expect(toggle.className).toContain(styles.sizeSm);
+    expect(toggle.className).toContain('consumer');
+  });
+
+  it('does not toggle when disabled', () => {
+    const onCheckedChange = vi.fn();
+    render(<Switch aria-label="Locked" disabled onCheckedChange={onCheckedChange} />);
+    fireEvent.click(screen.getByRole('switch', { name: 'Locked' }));
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-kit/src/components/switch/switch.tsx
+++ b/packages/ui-kit/src/components/switch/switch.tsx
@@ -1,0 +1,29 @@
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import styles from './switch.module.css';
+
+const switchVariants = cva(styles.switch, {
+  variants: {
+    size: {
+      default: styles.sizeDefault,
+      sm: styles.sizeSm,
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+export interface SwitchProps
+  extends Omit<SwitchPrimitive.Root.Props, 'className'>, VariantProps<typeof switchVariants> {
+  className?: string;
+}
+
+export function Switch({ className, size, ...props }: SwitchProps) {
+  return (
+    <SwitchPrimitive.Root className={switchVariants({ size, className })} {...props}>
+      <SwitchPrimitive.Thumb className={styles.thumb} />
+    </SwitchPrimitive.Root>
+  );
+}

--- a/packages/ui-kit/src/components/textarea/textarea.md
+++ b/packages/ui-kit/src/components/textarea/textarea.md
@@ -1,0 +1,50 @@
+# Textarea
+
+A multi-line text field. A styled native `<textarea>` — no primitive is
+needed. Grows with its content in browsers that support `field-sizing`;
+elsewhere it keeps the native resize handle.
+
+## When to use
+
+- Multi-line free text: descriptions, comments, messages.
+
+## When not to use
+
+- Single-line values — use `input`.
+- Rich text — out of the kit's scope; bring an editor and style it with
+  theme tokens.
+
+## Props (kit level)
+
+| Prop | Type | Default |
+|------|------|---------|
+| `className` | `string` — merged after the kit class | — |
+
+All other props are native `<textarea>` props (`value`, `onChange`,
+`placeholder`, `disabled`, `rows`, `aria-invalid`, ...) and are forwarded
+as-is. `aria-invalid` switches the border and ring to the destructive color.
+
+## Examples
+
+```tsx
+import { Textarea } from '@gears-frontx/ui-kit';
+
+// Uncontrolled
+<Textarea placeholder="Describe the issue…" />
+
+// Controlled
+<Textarea value={notes} onChange={(e) => setNotes(e.target.value)} />
+
+// Fixed starting height via rows
+<Textarea rows={6} defaultValue={draft} />
+
+// Invalid state
+<Textarea aria-invalid={true} defaultValue={tooLong} />
+```
+
+## Anti-patterns
+
+- Do not fix the height with inline styles — pass `rows` or set a
+  `max-height` in the consumer layout; the field sizes itself to content.
+- Do not use it for single-line values just to get a bigger hit target —
+  use `input`; sizing belongs to layout.

--- a/packages/ui-kit/src/components/textarea/textarea.md
+++ b/packages/ui-kit/src/components/textarea/textarea.md
@@ -7,6 +7,8 @@ elsewhere it keeps the native resize handle.
 ## When to use
 
 - Multi-line free text: descriptions, comments, messages.
+- Inside a `Field` to get label association and validation display for
+  free — it registers with the surrounding Field like `Input` does.
 
 ## When not to use
 

--- a/packages/ui-kit/src/components/textarea/textarea.module.css
+++ b/packages/ui-kit/src/components/textarea/textarea.module.css
@@ -12,7 +12,7 @@
   width: 100%;
   padding: 0.5rem 0.625rem;
   border: 1px solid var(--input);
-  border-radius: calc(var(--radius) - 2px);
+  border-radius: var(--radius-md);
   background-color: transparent;
   color: var(--foreground);
   font-family: inherit;

--- a/packages/ui-kit/src/components/textarea/textarea.module.css
+++ b/packages/ui-kit/src/components/textarea/textarea.module.css
@@ -1,0 +1,62 @@
+/*
+ * Textarea styles, translated from shadcn/ui (MIT) to CSS Modules.
+ * Consumes only theme.css variables — no raw colors.
+ */
+
+.textarea {
+  display: flex;
+  /* Grows with content where supported (Chromium 123+); a fixed min-height
+   * plus the native resize handle everywhere else. */
+  field-sizing: content;
+  min-height: 4rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--input);
+  border-radius: calc(var(--radius) - 2px);
+  background-color: transparent;
+  color: var(--foreground);
+  font-family: inherit;
+  /* text-base on small screens so iOS Safari does not zoom on focus */
+  font-size: 1rem;
+  line-height: 1.5rem;
+  outline: none;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+@media (min-width: 768px) {
+  .textarea {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+}
+
+.textarea::placeholder {
+  color: var(--muted-foreground);
+}
+
+.textarea:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+@media (forced-colors: active) {
+  .textarea:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+.textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Declared after :focus-visible so the invalid ring wins while focused. */
+.textarea[aria-invalid='true'] {
+  border-color: var(--destructive);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--destructive) 20%, transparent);
+}

--- a/packages/ui-kit/src/components/textarea/textarea.test.tsx
+++ b/packages/ui-kit/src/components/textarea/textarea.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Textarea } from './textarea';
+import styles from './textarea.module.css';
+
+afterEach(cleanup);
+
+describe('Textarea', () => {
+  it('renders a native textarea with the base class', () => {
+    render(<Textarea placeholder="Notes" />);
+    const textarea = screen.getByPlaceholderText('Notes');
+    expect(textarea).toHaveProperty('tagName', 'TEXTAREA');
+    expect(textarea.className).toContain(styles.textarea);
+  });
+
+  it('forwards value changes', () => {
+    const onChange = vi.fn();
+    render(<Textarea onChange={onChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'line one' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('textbox')).toHaveProperty('value', 'line one');
+  });
+
+  it('merges a consumer className and forwards native props', () => {
+    render(<Textarea className="consumer" rows={6} disabled />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.className).toContain(styles.textarea);
+    expect(textarea.className).toContain('consumer');
+    expect(textarea).toHaveProperty('rows', 6);
+    expect(textarea).toHaveProperty('disabled', true);
+  });
+
+  it('forwards the invalid state', () => {
+    render(<Textarea aria-invalid={true} />);
+    expect(screen.getByRole('textbox').getAttribute('aria-invalid')).toBe('true');
+  });
+});

--- a/packages/ui-kit/src/components/textarea/textarea.test.tsx
+++ b/packages/ui-kit/src/components/textarea/textarea.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { Field, FieldDescription, FieldLabel } from '../field/field';
 import { Textarea } from './textarea';
 import styles from './textarea.module.css';
 
@@ -34,5 +35,20 @@ describe('Textarea', () => {
   it('forwards the invalid state', () => {
     render(<Textarea aria-invalid={true} />);
     expect(screen.getByRole('textbox').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('wires into a surrounding Field like Input does', () => {
+    render(
+      <Field name="notes" disabled>
+        <FieldLabel>Notes</FieldLabel>
+        <Textarea />
+        <FieldDescription>Optional context.</FieldDescription>
+      </Field>,
+    );
+    const textarea = screen.getByLabelText('Notes');
+    expect(textarea).toHaveProperty('tagName', 'TEXTAREA');
+    expect(textarea).toHaveProperty('disabled', true);
+    const description = screen.getByText('Optional context.');
+    expect(textarea.getAttribute('aria-describedby')).toContain(description.id);
   });
 });

--- a/packages/ui-kit/src/components/textarea/textarea.tsx
+++ b/packages/ui-kit/src/components/textarea/textarea.tsx
@@ -1,0 +1,10 @@
+import { cx } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
+
+import styles from './textarea.module.css';
+
+export type TextareaProps = ComponentProps<'textarea'>;
+
+export function Textarea({ className, ...props }: TextareaProps) {
+  return <textarea className={cx(styles.textarea, className)} {...props} />;
+}

--- a/packages/ui-kit/src/components/textarea/textarea.tsx
+++ b/packages/ui-kit/src/components/textarea/textarea.tsx
@@ -1,3 +1,4 @@
+import { Field as FieldPrimitive } from '@base-ui/react/field';
 import { cx } from 'class-variance-authority';
 import type { ComponentProps } from 'react';
 
@@ -5,6 +6,11 @@ import styles from './textarea.module.css';
 
 export type TextareaProps = ComponentProps<'textarea'>;
 
+/* Rendered through Field.Control so a surrounding Field wires the label,
+ * aria-describedby, and validation state — same as Input. Outside a Field
+ * the control falls back to Base UI's no-op context. */
 export function Textarea({ className, ...props }: TextareaProps) {
-  return <textarea className={cx(styles.textarea, className)} {...props} />;
+  return (
+    <FieldPrimitive.Control render={<textarea className={cx(styles.textarea, className)} {...props} />} />
+  );
 }

--- a/packages/ui-kit/src/docs.test.ts
+++ b/packages/ui-kit/src/docs.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// Guards the AI docs layer: every component ships a colocated usage doc,
+// is indexed in llms.txt, and the doc mentions every variant/size the
+// component's CSS module actually defines (naming convention:
+// `.variantXxx` / `.sizeXxx` classes).
+
+const srcDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(srcDir, '..');
+const componentsDir = join(srcDir, 'components');
+const components = readdirSync(componentsDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const llms = readFileSync(join(packageRoot, 'llms.txt'), 'utf8');
+
+const lowerFirst = (value: string) => value.charAt(0).toLowerCase() + value.slice(1);
+
+describe.each(components)('%s docs', (name) => {
+  const dir = join(componentsDir, name);
+
+  it('has a colocated usage doc', () => {
+    expect(() => readFileSync(join(dir, `${name}.md`), 'utf8')).not.toThrow();
+  });
+
+  it('is indexed in llms.txt', () => {
+    expect(llms).toContain(`dist/docs/${name}.md`);
+  });
+
+  it('documents every variant and size from the CSS module', () => {
+    const doc = readFileSync(join(dir, `${name}.md`), 'utf8');
+    const css = readFileSync(join(dir, `${name}.module.css`), 'utf8');
+    const tokens = Array.from(css.matchAll(/\.(?:variant|size)([A-Z][A-Za-z0-9]*)/g), (match) =>
+      lowerFirst(match[1] ?? ''),
+    );
+    for (const token of Array.from(new Set(tokens))) {
+      expect(doc, `"${token}" is missing from ${name}.md`).toContain(token);
+    }
+  });
+});

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -16,5 +16,24 @@ export {
   RadioGroupItem,
   type RadioGroupItemProps,
 } from './components/radio-group/radio-group';
+export {
+  Select,
+  SelectContent,
+  type SelectContentProps,
+  SelectGroup,
+  type SelectGroupProps,
+  SelectItem,
+  type SelectItemProps,
+  SelectLabel,
+  type SelectLabelProps,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  type SelectSeparatorProps,
+  SelectTrigger,
+  type SelectTriggerProps,
+  SelectValue,
+  type SelectValueProps,
+} from './components/select/select';
 export { Switch, type SwitchProps } from './components/switch/switch';
 export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -7,3 +7,4 @@
  * once in the consumer entry module.
  */
 export { Button, type ButtonProps } from './components/button/button';
+export { Input, type InputProps } from './components/input/input';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -8,6 +8,16 @@
  */
 export { Button, type ButtonProps } from './components/button/button';
 export { Checkbox, type CheckboxProps } from './components/checkbox/checkbox';
+export {
+  Field,
+  type FieldProps,
+  FieldDescription,
+  type FieldDescriptionProps,
+  FieldError,
+  type FieldErrorProps,
+  FieldLabel,
+  type FieldLabelProps,
+} from './components/field/field';
 export { Input, type InputProps } from './components/input/input';
 export { Label, type LabelProps } from './components/label/label';
 export {

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -10,4 +10,5 @@ export { Button, type ButtonProps } from './components/button/button';
 export { Checkbox, type CheckboxProps } from './components/checkbox/checkbox';
 export { Input, type InputProps } from './components/input/input';
 export { Label, type LabelProps } from './components/label/label';
+export { Switch, type SwitchProps } from './components/switch/switch';
 export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -8,3 +8,4 @@
  */
 export { Button, type ButtonProps } from './components/button/button';
 export { Input, type InputProps } from './components/input/input';
+export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -8,4 +8,5 @@
  */
 export { Button, type ButtonProps } from './components/button/button';
 export { Input, type InputProps } from './components/input/input';
+export { Label, type LabelProps } from './components/label/label';
 export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -10,5 +10,11 @@ export { Button, type ButtonProps } from './components/button/button';
 export { Checkbox, type CheckboxProps } from './components/checkbox/checkbox';
 export { Input, type InputProps } from './components/input/input';
 export { Label, type LabelProps } from './components/label/label';
+export {
+  RadioGroup,
+  type RadioGroupProps,
+  RadioGroupItem,
+  type RadioGroupItemProps,
+} from './components/radio-group/radio-group';
 export { Switch, type SwitchProps } from './components/switch/switch';
 export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -7,6 +7,7 @@
  * once in the consumer entry module.
  */
 export { Button, type ButtonProps } from './components/button/button';
+export { Checkbox, type CheckboxProps } from './components/checkbox/checkbox';
 export { Input, type InputProps } from './components/input/input';
 export { Label, type LabelProps } from './components/label/label';
 export { Textarea, type TextareaProps } from './components/textarea/textarea';

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -30,7 +30,17 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+
+  /*
+   * Radius scale (shadcn v4 convention). Components consume only the
+   * derived steps; consumers rebrand by overriding --radius alone and
+   * the whole scale follows.
+   */
   --radius: 0.625rem;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
 }
 
 [data-theme='dark'] {

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -37,6 +37,7 @@
    * the whole scale follows.
    */
   --radius: 0.625rem;
+  --radius-xs: calc(var(--radius) - 6px);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// Guards the theme seam: every CSS variable a component module consumes must
+// be defined by theme.css (the single branding surface), except the vars the
+// Base UI positioner provides at runtime.
+
+const srcDir = dirname(fileURLToPath(import.meta.url));
+const themeCss = readFileSync(join(srcDir, 'styles', 'theme.css'), 'utf8');
+
+const BASE_UI_RUNTIME_VARS = new Set([
+  '--anchor-width',
+  '--anchor-height',
+  '--available-width',
+  '--available-height',
+  '--transform-origin',
+]);
+
+const definedTokens = new Set(
+  Array.from(themeCss.matchAll(/(--[a-z0-9-]+)\s*:/g), (match) => match[1]),
+);
+
+const componentsDir = join(srcDir, 'components');
+const moduleFiles = readdirSync(componentsDir, { recursive: true, encoding: 'utf8' })
+  .filter((file) => file.endsWith('.module.css'))
+  .map((file) => join(componentsDir, file));
+
+describe('theme tokens', () => {
+  it('defines the radius scale derived from --radius', () => {
+    for (const token of ['--radius', '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl']) {
+      expect(definedTokens.has(token), `${token} is missing from theme.css`).toBe(true);
+    }
+  });
+
+  it.each(moduleFiles)('%s consumes only theme-defined variables', (file) => {
+    const css = readFileSync(file, 'utf8');
+    const used = Array.from(css.matchAll(/var\((--[a-z0-9-]+)/g), (match) => match[1] ?? '');
+    expect(used.length).toBeGreaterThan(0);
+    for (const token of Array.from(new Set(used))) {
+      if (BASE_UI_RUNTIME_VARS.has(token)) {
+        continue;
+      }
+      expect(definedTokens.has(token), `${token} is not defined in theme.css`).toBe(true);
+    }
+  });
+
+  it('keeps raw colors out of component modules', () => {
+    for (const file of moduleFiles) {
+      const css = readFileSync(file, 'utf8');
+      const raw = css.match(/#[0-9a-f]{3,8}\b|rgb\(|rgba\(|hsl\(|oklch\(/i);
+      expect(raw, `raw color "${raw?.[0]}" in ${file}`).toBeNull();
+    }
+  });
+});

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -37,8 +37,9 @@ describe('theme tokens', () => {
 
   it.each(moduleFiles)('%s consumes only theme-defined variables', (file) => {
     const css = readFileSync(file, 'utf8');
+    // A module may consume no tokens at all (label inherits everything);
+    // what it does consume must come from the theme.
     const used = Array.from(css.matchAll(/var\((--[a-z0-9-]+)/g), (match) => match[1] ?? '');
-    expect(used.length).toBeGreaterThan(0);
     for (const token of Array.from(new Set(used))) {
       if (BASE_UI_RUNTIME_VARS.has(token)) {
         continue;

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -30,7 +30,14 @@ const moduleFiles = readdirSync(componentsDir, { recursive: true, encoding: 'utf
 
 describe('theme tokens', () => {
   it('defines the radius scale derived from --radius', () => {
-    for (const token of ['--radius', '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl']) {
+    for (const token of [
+      '--radius',
+      '--radius-xs',
+      '--radius-sm',
+      '--radius-md',
+      '--radius-lg',
+      '--radius-xl',
+    ]) {
       expect(definedTokens.has(token), `${token} is missing from theme.css`).toBe(true);
     }
   });

--- a/packages/ui-kit/tsconfig.test.json
+++ b/packages/ui-kit/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/ui-kit/tsup.config.ts
+++ b/packages/ui-kit/tsup.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
     '.css': 'local-css',
   },
   // Design tokens are plain CSS (not a module) and must survive as a separate
-  // consumer-importable file — tsup only emits CSS that JS imports.
-  onSuccess: 'cp src/styles/theme.css dist/theme.css',
+  // consumer-importable file — tsup only emits CSS that JS imports. The
+  // per-component usage docs ship under dist/docs/ so agents can read them
+  // from node_modules via llms.txt.
+  onSuccess: 'cp src/styles/theme.css dist/theme.css && mkdir -p dist/docs && cp src/components/*/*.md dist/docs/',
 });

--- a/packages/ui-kit/vitest.config.ts
+++ b/packages/ui-kit/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['./src/__test-utils__/setup.ts'],
     execArgv: nodeMajor >= 25 ? ['--no-experimental-webstorage'] : [],
     include: [
       '__tests__/**/*.test.{ts,tsx}',


### PR DESCRIPTION
## What

Stage 2 of the UI Kit delivery plan (`packages/ui-kit/design-notes.md`): the forms component batch on `@base-ui/react`, the AI docs layer, and the theme-token polish. This is the work #499 announced in its "Next (separate PRs)" section. Related: #495 (the package remains under the interim `artifacts.toml` ignore, unchanged here).

One commit per component; each ships the component, its CSS Module, a colocated usage doc, an `llms.txt` entry, and render/interaction tests.

## Demo

All components exercised in the sandbox (packed tarball in a clean Vite app), light and dark:

https://github.com/user-attachments/assets/aba29629-1269-4347-b4d6-47112d6cc89b

## Contents

- **Button moves onto the Base UI primitive** (`@base-ui/react/button`, new dependency, pinned `1.6.0`): `render`-prop polymorphism per the kit's wrapping convention, `type="button"` default now comes from the primitive. Visuals untouched — same CSS Module and CVA map. Browser verification caught that non-`<button>` render targets need `nativeButton={false}`; the doc and tests pin that contract.
- **8 new form components** — `Input`, `Textarea`, `Label`, `Checkbox`, `Switch` (sizes `default|sm`), `RadioGroup`, `Select` (9 parts, portalled popup), `Field` (Base UI Field composition: automatic `htmlFor`/`aria-describedby` wiring and validation display; deliberately not shadcn's div-based `field.tsx`, which has no such wiring). Styles are base-vega translations to CSS Modules following the Button precedent: theme tokens only, no raw colors, shadows and `dark:`-only refinements dropped (the Select popup keeps a `color-mix`-derived border/shadow so it separates from the page). Check/chevron icons are inline lucide paths — the kit carries no icon dependency.
- **AI docs layer**: `llms.txt` at the package root (setup rules + component index) and a per-component usage doc (when to use, kit-level props, examples, anti-patterns) copied to `dist/docs/` at build. A docs test enforces that every component has a doc, is indexed, and documents every variant/size its CSS module defines; the consumer acceptance script asserts the docs ship inside the tarball.
- **Tokens polish**: `theme.css` exposes the shadcn v4 radius scale (`--radius-sm|md|lg|xl` derived from `--radius`); component modules consume the scale, so overriding `--radius` alone rebrands every corner. A tokens test guards the seam: modules may consume only theme-defined variables (Base UI runtime vars excepted) and no raw colors.
- **Select contracts documented and tested**: pass `items` on the root so the closed trigger renders labels; mouse selection commits on pointerdown-then-click (Base UI's `alignItemWithTrigger` guard); `SelectContent` forwards Base UI's `container` prop so subtree-scoped themes (`data-theme` on a section rather than `<html>`) reach the portalled popup.
- **Test infra**: `PointerEvent` polyfill as the vitest setup file (jsdom lacks the constructor; Base UI re-dispatches clicks through it), node types return to `tsconfig.test.json` (`@types/node`, pinned like telemetry) because the docs/tokens tests read files.

## Verified

Green on node 25.1.0: `type-check:all`, `lint` (incl. `lint:deps`), `test:unit` (78 tests / 11 files), `arch:check` 12/12, and `test:consumer` (tarball → clean Vite project → build → assert styles, class maps, and the AI docs in the package).

Beyond CI: every component was exercised in a real browser against the packed tarball (all states, light/dark). That run produced three fixes included here: the `nativeButton` contract for render-prop links, the Label color declaration that broke Field's invalid tinting via inheritance, and the portal container escape hatch for subtree themes.

## Next (separate PRs)

Structure batch (`card`, `tabs`, `badge`, `separator`, `skeleton`), overlays (`dialog`, `dropdown-menu`, `tooltip`, `toast`), `table`, composition recipes for the AI layer, kitchen-sink example app, then the #495 publication gates before `private` is lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Checkbox, Field, Input, Label, Radio Group, Select, Switch, and Textarea components.
  * Added accessible form interactions, validation and disabled states, sizing options, and theme-based styling.
  * Enhanced Button support for accessible link-style usage.
* **Documentation**
  * Added comprehensive component usage guidance and published package documentation with an AI-friendly index.
* **Bug Fixes**
  * Standardized corner-radius styling with theme tokens.
* **Tests**
  * Expanded coverage for behavior, accessibility, styling, and documentation completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
