### PR TITLE
docs(react): document useApiStream status lifecycle at code altitude (#516)

### DIFF
--- a/.cf-studio/config/AGENTS.md
+++ b/.cf-studio/config/AGENTS.md
@@ -59,14 +59,16 @@ WHEN:
 DO:
   - LOAD `architecture/DESIGN.md` §1.3 (Architecture Layers) and §2.2 (Constraints) before editing any code
   - LOAD `packages/cyber-pilot-kit-frontx/guidelines/ecosystem-boundaries.md` and apply the boundary constraints for every touched package
-  - LOAD the governing FEATURE.md — each lives with the package it describes, under `packages/*/architecture/features/` — before changing code that carries its `@cpt-` markers
-  - RUN keep `@cpt-` traceability markers intact and aligned with the FEATURE instructions they cite
+  - LOAD `architecture/ADR/0033-template-territory-traceability.md` before changing template territory (any top-level directory carrying a `frontx-template.json` manifest)
+  - LOAD the governing FEATURE.md — each lives with the package it describes, under `packages/*/architecture/features/` — before changing ecosystem code that carries its `@cpt-` markers
+  - RUN keep `@cpt-` traceability markers intact and aligned with the FEATURE instructions they cite — in ecosystem code only
+  - RUN apply the template-territory marker policy from `cpt-frontx-adr-template-territory-traceability` to template code changes
 
 RULES:
   - ALWAYS read the named DESIGN constraint (MFES-*, GTS-PLUGIN-*, API-*, CLI-*, KIT-*) before editing code it governs; NEVER code from assumed rules
   - ALWAYS stop and ask when a change would cross a DESIGN §2.2 constraint or a package boundary from `ecosystem-boundaries.md`
-  - ALWAYS stop and ask when no FEATURE covers behaviour the change introduces
-  - NEVER restate architecture rules in artifacts or prompts; reference `architecture/DESIGN.md` and the kit guideline instead
+  - ALWAYS stop and ask when no FEATURE covers behaviour the change introduces in ecosystem code; no ecosystem FEATURE covers template territory by decision, so template consumer-visible behaviour is governed by `cpt-frontx-adr-template-territory-traceability`
+  - NEVER restate architecture rules in artifacts or prompts; reference `architecture/DESIGN.md`, ADRs, and the kit guideline instead
 ```
 
 ```pdsl
@@ -81,9 +83,9 @@ WHEN:
   - REQUIRE reviewing code changes in this repository
 
 DO:
-  - LOAD `architecture/DESIGN.md` §2.2 and `packages/cyber-pilot-kit-frontx/guidelines/ecosystem-boundaries.md`; NEVER review from memory of their rules
+  - LOAD `architecture/DESIGN.md` §2.2, `packages/cyber-pilot-kit-frontx/guidelines/ecosystem-boundaries.md`, and `architecture/ADR/0033-template-territory-traceability.md`; NEVER review from memory of their rules
   - RUN FX-001 Constraints: every changed package complies with its named DESIGN §2.2 constraints and its package boundary in `ecosystem-boundaries.md`; ambiguous ownership was raised, not guessed
-  - RUN FX-002 Traceability: changed code keeps `@cpt-` markers consistent with the governing FEATURE, and `cfs validate` passes
+  - RUN FX-002 Traceability: changed ecosystem code keeps `@cpt-` markers consistent with the governing FEATURE, and `cfs validate` passes; changed template territory (any top-level directory carrying a `frontx-template.json` manifest) follows the marker policy in `cpt-frontx-adr-template-territory-traceability`
   - RUN FX-003 Architecture checks: `npm run arch:check` passes for the changed packages
 
 RULES:

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -21,7 +21,7 @@ reason = "In-package demos exercise a package's public surface rather than imple
 patterns = ["*/demo/*"]
 
 [[ignore]]
-reason = "template-shell/template-mfe are template territory (Phase 11 template-move, split in issue #470); code carries pre-redesign markers that reference archived IDs — no active FEATURE artifact backs these packages"
+reason = "These globs cover template territory — top-level directories carrying a frontx-template.json manifest — outside the ecosystem artifact universe (cpt-frontx-adr-template-territory-traceability); residue markers bind nothing and are removed as files are touched — no active FEATURE artifact backs these packages"
 patterns = ["template-shell/**", "template-mfe/**"]
 
 [[ignore]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,6 @@ ALWAYS resolve and enforce prerequisites of skills/workflows/commands BEFORE app
 
 AI tooling and FrontX development guidelines are provided by the Constructor Studio kit under `.cf-studio/`.
 
-Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds.
+Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Ecosystem code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds. Template territory — any top-level directory carrying a `frontx-template.json` manifest (how `scripts/template-discovery.mjs` finds templates) — sits outside this chain: markers found there are non-authoritative residue being retired as files change (`cpt-frontx-adr-template-territory-traceability`).
 
 ALL user requests MUST be handled by the Orchestrator agent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,6 @@ ALWAYS resolve and enforce prerequisites of skills/workflows/commands BEFORE app
 
 AI tooling and FrontX development guidelines are provided by the Constructor Studio kit under `.cf-studio/`.
 
-Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds.
+Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Ecosystem code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds. Template territory — any top-level directory carrying a `frontx-template.json` manifest (how `scripts/template-discovery.mjs` finds templates) — sits outside this chain: markers found there are non-authoritative residue being retired as files change (`cpt-frontx-adr-template-territory-traceability`).
 
 ALL user requests MUST be handled by the Orchestrator agent.

--- a/architecture/ADR/0033-template-territory-traceability.md
+++ b/architecture/ADR/0033-template-territory-traceability.md
@@ -1,0 +1,126 @@
+---
+status: accepted
+date: 2026-08-04
+---
+
+# Which Artifact Tree Specifies Template-Territory Code, and What Its Traceability Markers Mean
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Template territory is outside the ecosystem artifact universe; markers there are non-authoritative residue, removed as files are touched](#template-territory-is-outside-the-ecosystem-artifact-universe-markers-there-are-non-authoritative-residue-removed-as-files-are-touched)
+  - [Extend the ecosystem artifact tree to cover template internals](#extend-the-ecosystem-artifact-tree-to-cover-template-internals)
+  - [Keep the residue markers and rely on the scan exclusion alone](#keep-the-residue-markers-and-rely-on-the-scan-exclusion-alone)
+  - [Give template territory its own artifact tree now](#give-template-territory-its-own-artifact-tree-now)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-frontx-adr-template-territory-traceability`
+
+## Context and Problem Statement
+
+The repository's architecture artifacts describe the FrontX ecosystem — the published packages, the CLI, and the AI tooling kit — while the template subtrees — the top-level directories carrying a `frontx-template.json` manifest, which is how the repository defines a template — hold template payload the CLI resolves and applies into a developer's repository, not ecosystem contract. That payload still carries `@cpt-` traceability markers from the pre-ecosystem-redesign artifact generation, whose FEATUREs (`feature-request-lifecycle`, `feature-react-bindings`, `feature-state-management` and their peers) were archived and then deleted, so the markers name instruction IDs no artifact defines. Reviewers reading a marked template file reasonably infer a specified contract behind it and open a gap report when they cannot find one. Which artifact tree, if any, specifies template-territory code, and what status do the `@cpt-` markers already sitting in it have?
+
+## Decision Drivers
+
+* **One universe per artifact tree** — the ecosystem's PRD, DESIGN, and DECOMPOSITION describe the ecosystem's own artifacts; admitting template payload into that same tree would give one artifact set two unrelated subjects and two reasons to change.
+* **Template content is not ecosystem content** — the ecosystem's tooling deliberately carries no bundled template or solution content (`cpt-frontx-principle-template-agnostic-tooling`); its specification should draw the same line, or the decoupling holds in code but not in the artifacts.
+* **A marker is a claim** — a `@cpt-` marker asserts that a numbered instruction specifies the marked region; a marker that names nothing is a false claim to every reader, whether or not any validator reads it.
+* **Silence must be legible** — that template internals are unspecified is a deliberate position, and it must be discoverable from the artifacts rather than inferred from a validator's exclusion list.
+* **No premature specification** — writing FEATUREs for template internals now would fix contracts for code whose ownership is still moving (the template split), and it is the larger, harder-to-undo commitment of the available options.
+
+## Considered Options
+
+* **Template territory is outside the ecosystem artifact universe; markers there are non-authoritative residue, removed as files are touched** — the ecosystem artifact tree's subject is the ecosystem's own artifacts; template subtrees are payload it does not specify. Existing `@cpt-` markers in those subtrees are declared residue of the archived generation: they bind nothing, no new ones are added, and the ones present are removed from a file when that file is otherwise modified. Behaviour of template code is documented at code altitude, where the code lives.
+* **Extend the ecosystem artifact tree to cover template internals** — add DECOMPOSITION entries and FEATUREs (starting with a revived request-lifecycle feature) so every existing marker in template territory resolves to a live instruction.
+* **Keep the residue markers and rely on the scan exclusion alone** — change nothing in the artifacts or the payload; the registry's exclusion of the template subtrees is the whole answer.
+* **Give template territory its own artifact tree now** — author a separate, nested artifact tree owned by the template, and re-point every marker in the payload at IDs from that tree.
+
+## Decision Outcome
+
+Chosen option: **Template territory is outside the ecosystem artifact universe; markers there are non-authoritative residue, removed as files are touched**, because it is the only option that keeps one subject per artifact tree, retires the false claims the stale markers make, and commits to no specification the template's ownership is not yet settled enough to support.
+
+The **ecosystem artifact tree specifies the ecosystem's own artifacts** — the published packages, the CLI, and the AI tooling kit. Template subtrees are payload the CLI resolves, applies, and upgrades through the uniform mechanism (`cpt-frontx-adr-uniform-template-mechanism`); what they contain internally is the template's own business, bounded by the ownership declaration it publishes (`cpt-frontx-adr-template-ownership-boundary-declaration`), not an ecosystem contract. Consequently **no ecosystem FEATURE is authored to back template-internal code**, and no artifact in this tree is extended to cover it.
+
+The `@cpt-` markers presently in template territory are **residue of the archived pre-redesign generation and bind nothing**: they are not authoritative, they are not evidence that a contract was specified, and they must not be read as traceability. **No new markers are added to template territory**, and when a template file is otherwise modified, **every residue marker that file carries is removed** — the rule is uniform, needs no separate sweep, and leaves no half-covered file behind. The strip is mechanical, and review should keep marker-only deletion easy to distinguish from substantive change. Where template code has behaviour a consumer depends on — a hook's observable status lifecycle, for instance — that behaviour is documented **at code altitude, in the code and its package documentation**, which is the reader's location and carries no claim of upstream specification.
+
+The scope of this decision is which artifact tree specifies template-territory code and the standing of `@cpt-` markers found there. It does not decide the boundary a template declares (`cpt-frontx-adr-template-ownership-boundary-declaration`), how the CLI applies or upgrades a template (`cpt-frontx-adr-uniform-template-mechanism`, `cpt-frontx-adr-project-upgrade-mechanism`), nor whether the template will eventually carry an artifact tree of its own — that is deliberately deferred (see More Information).
+
+### Consequences
+
+* Good, because each artifact tree keeps one subject: the ecosystem's artifacts are described by the ecosystem's artifacts, and template payload is not smuggled into them.
+* Good, because a `@cpt-` marker recovers its meaning inside the specified universe: there it names a live instruction; residue in paths the registry ignores is retired by the rule above.
+* Good, because the position is now stated in the artifacts, so the next reviewer who finds a marked-but-unspecified template file reads a decision instead of filing a gap.
+* Good, because it commits to no specification of code whose ownership is still moving, leaving the template's own artifact tree available as a later, deliberate step.
+* Bad, because template territory keeps residue markers until each file is otherwise touched, so the payload stays in a mixed state for as long as that takes.
+* Bad, because behaviour documented only at code altitude is easier to change without review than behaviour fixed by a numbered instruction, so a consumer-visible change in template payload rests on code review alone.
+
+### Confirmation
+
+Compliance is confirmed by the artifact registry and by review. The registry admits only the ecosystem's own source paths to traceability scanning and excludes the template subtrees, so no template file is scanned for markers and no marker there is validated; `cfs validate` passing therefore never depends on template payload. Review confirms that no FEATURE in this tree names a path under a template subtree, that a change adding a `@cpt-` marker to template territory is refused, and that a change modifying an already-marked template file removes every residue marker that file carries while keeping the mechanical marker deletion easy to distinguish from substantive change and documenting any consumer-visible behaviour at code altitude in the same change.
+
+## Pros and Cons of the Options
+
+### Template territory is outside the ecosystem artifact universe; markers there are non-authoritative residue, removed as files are touched
+
+The ecosystem tree specifies ecosystem artifacts only; template payload is unspecified by it, residue markers bind nothing and are removed as files are modified, and template behaviour is documented in the code.
+
+* Good, because one artifact tree keeps one subject, matching the tooling's own template-agnostic separation.
+* Good, because it retires false traceability claims rather than preserving them.
+* Good, because the removal rule is uniform and needs no repository-wide sweep to be consistent.
+* Neutral, because it leaves the template's own artifact tree as an open, deferred option.
+* Bad, because the payload stays mixed until files are touched, and code-altitude documentation is weaker protection than a numbered instruction.
+
+### Extend the ecosystem artifact tree to cover template internals
+
+Revive the archived feature areas as live FEATUREs, with DECOMPOSITION entries and DESIGN components, so every existing marker resolves.
+
+* Good, because every marker in the repository would resolve to a live instruction.
+* Good, because consumer-visible template behaviour would be fixed by numbered instructions.
+* Bad, because it re-imports template payload into an artifact tree whose subject is the ecosystem, giving one tree two subjects and two reasons to change.
+* Bad, because it is the largest and least reversible option, fixing contracts for code whose ownership is still in motion.
+* Bad, because doing it for one hook, rather than for every archived feature area at once, produces an arbitrary island of specified code inside unspecified payload.
+
+### Keep the residue markers and rely on the scan exclusion alone
+
+Change nothing; the registry's exclusion of the template subtrees is the whole answer.
+
+* Good, because it costs nothing and breaks no validation, which already ignores those paths.
+* Bad, because the false claims stay in the payload and keep misleading readers — the exclusion is invisible from the file a reviewer is reading.
+* Bad, because it leaves the position recorded only in tool configuration, where an architectural decision is not discoverable.
+
+### Give template territory its own artifact tree now
+
+Author a separate nested artifact tree owned by the template and re-point the payload's markers at its IDs.
+
+* Good, because it would specify template behaviour without mixing subjects, and would give the markers a legitimate home.
+* Neutral, because it is the natural destination if template internals ever need specified contracts.
+* Bad, because it is premature while template ownership is still moving, and it is a large authoring commitment ahead of any demonstrated need.
+
+## More Information
+
+**Deferred deliberately**: whether template territory gets an artifact tree of its own is **not decided here**. It is deferred until template ownership has settled and template internals present a contract a consumer depends on across versions — at which point this decision must be revisited through the repository's ADR lifecycle, markers may be reintroduced against IDs from that tree, and the registry's scanning scope is revisited in the same step. Deciding it now would fix contracts for code whose ownership is in motion.
+
+The uniform mechanism by which the CLI treats any template is decided in `cpt-frontx-adr-uniform-template-mechanism`; the boundary a template declares over what it owns in `cpt-frontx-adr-template-ownership-boundary-declaration`. These are non-binding pointers and do not form part of this decision's durable identity.
+
+Applicability of the remaining checklist categories: **REL** — Not applicable, because this decision changes no runtime behaviour and introduces no failure mode; it fixes what the artifacts specify and what a marker asserts. **PERF** — Not applicable, because no latency or throughput budget is bound to artifact scope. **SEC** — Not applicable, because no secret material or authentication surface is introduced. **DATA** — Not applicable, because no schema is fixed. **INT** — addressed: the integration surface a consumer relies on is the template's declared ownership boundary and its published payload, not an ecosystem instruction for template internals. **OPS** — Not applicable, because there is no running service. **MAINT** — addressed: markers regain a single meaning, and the touch-it-remove-it rule keeps residue retirement uniform without a repository-wide sweep. **COMPL** — Not applicable. **UX** — addressed for the developer-as-reader: a marked file inside the specified universe resolves to a live instruction, and template payload no longer implies specification it does not have. **BIZ** — Not applicable, because product requirements live in the PRD and are cited here by ID.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements and design elements:
+
+* `cpt-frontx-principle-template-agnostic-tooling` — The ecosystem's tooling bundles no template or solution content; this decision draws the same line through the artifacts, keeping template payload outside the specification of the ecosystem's own artifacts.
+* `cpt-frontx-principle-ownership-bounded-composition` — What a template contains internally falls inside the boundary that template declares and owns; this decision keeps that content out of the ecosystem tree rather than specifying it from outside the owner.
+* `cpt-frontx-adr-uniform-template-mechanism` — Templates are payload the tooling resolves, applies, and upgrades uniformly without branching on type; this decision is the artifact-side consequence: the ecosystem specifies the mechanism, not any template's internals.
+* `cpt-frontx-nfr-evolvability` — Retiring markers that bind nothing, and declining to fix contracts for code whose ownership is still moving, keeps the artifacts an accurate description of what is specified and leaves the template free to evolve on its own cadence.

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -82,6 +82,7 @@ Foundational:
 * `cpt-frontx-adr-artifact-versioning-and-distribution` — Distributes the ecosystem as independently published, per-concern, independently versioned artifacts.
 * `cpt-frontx-adr-core-package-boundaries` — Partitions the published libraries into boundary-governed concerns (runtime, type-system provider, protocol surface).
 * `cpt-frontx-adr-contract-schema-ownership` — Ends the circular DESIGN↔ADR schema deferral by assigning each owned contract's role to DESIGN, its decision rationale to the ADR, and its concrete field-level schema to the owning FEATURE.
+* `cpt-frontx-adr-template-territory-traceability` — Fixes this artifact tree's subject as the ecosystem's own artifacts, leaves template payload unspecified by it, and declares the `@cpt-` markers surviving in template territory to be non-authoritative residue removed as files are touched.
 
 Published libraries:
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -442,7 +442,6 @@ export interface RestRequestContext {
   readonly signal?: AbortSignal;
 }
 
-// @cpt-FEATURE:cpt-frontx-dod-request-lifecycle-abort-signal:p1
 /**
  * REST Request Options
  * Per-request options for REST protocol HTTP methods.
@@ -925,7 +924,6 @@ export interface MutationDescriptor<TData, TVariables> {
 // Stream Descriptor Types
 // ============================================================================
 
-// @cpt-FEATURE:cpt-frontx-fr-sse-stream-descriptors:p2
 /**
  * Stream connection status.
  */

--- a/scripts/template-discovery.test.mjs
+++ b/scripts/template-discovery.test.mjs
@@ -95,3 +95,28 @@ describe('MANIFEST_FILENAME sync guard', () => {
     expect(MANIFEST_FILENAME).toBe(match[1]);
   });
 });
+
+// Same drift class, different surface: template territory is defined by
+// manifest presence (ADR-0018, cpt-frontx-adr-template-territory-traceability),
+// but the artifact registry's ignore entry can only hold literal globs. A
+// manifest-backed template directory added without updating those globs would
+// be outside the marker policy in prose while `cfs validate` still scans it.
+describe('artifacts.toml template-territory ignore sync guard', () => {
+  it('ignore globs cover exactly the manifest-discovered template directories', () => {
+    const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+    const toml = readFileSync(path.join(repoRoot, '.cf-studio', 'config', 'artifacts.toml'), 'utf8');
+    const entry = toml
+      .split('[[ignore]]')
+      .find((block) => block.includes('cpt-frontx-adr-template-territory-traceability'));
+
+    expect(entry, 'template-territory ignore entry not found - did artifacts.toml drop its ADR citation?').toBeDefined();
+
+    const patternsLine = /patterns\s*=\s*\[([^\]]*)\]/.exec(entry);
+    expect(patternsLine, 'template-territory ignore entry carries no patterns array').not.toBeNull();
+
+    const globbed = [...patternsLine[1].matchAll(/"([^"]+)\/\*\*"/g)].map((m) => m[1]).sort();
+    const discovered = findTemplateDirs(repoRoot).map((d) => path.basename(d)).sort();
+
+    expect(globbed).toEqual(discovered);
+  });
+});

--- a/template-shell/packages/react/CLAUDE.md
+++ b/template-shell/packages/react/CLAUDE.md
@@ -98,7 +98,7 @@ endpoint descriptors directly (e.g., `queryCache.get(service.getCurrentUser)`).
 
 ### SSE Streaming with Stream Descriptors
 
-Services declare SSE endpoints as stream descriptors. Components consume them via `useApiStream`, which manages the EventSource lifecycle automatically (connect on mount, disconnect on unmount).
+Services declare SSE endpoints as stream descriptors. Components consume them via `useApiStream`, which manages the connection lifecycle automatically (connect on mount, disconnect on unmount).
 
 ```tsx
 import { useApiStream, apiRegistry } from '@gears-frontx/react';
@@ -124,18 +124,38 @@ function ChatStream() {
   );
 
   if (status === 'connecting') return <Loading />;
-  if (error) return <Error error={error} />;
+  if (status === 'error') return <Error error={error} />;
 
   return <div>{data?.text}</div>;
 }
 ```
 
 `useApiStream` returns `{ data, events, status, error, disconnect }`:
-- `data` — latest event payload (always set in both modes)
+- `data` — latest event payload (set in both modes)
 - `events` — all received events when `mode: 'accumulate'`; empty array in `'latest'` mode
-- `status` — `'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'`
-- `error` — connection error if any
-- `disconnect()` — manually close the connection
+- `status` — connection lifecycle state, `StreamStatus` (see below)
+- `error` — the last connect attempt's error; retained until the next connect attempt resets it, so check `status` rather than `error` truthiness
+- `disconnect()` — close the connection manually
+
+#### Status lifecycle
+
+`status` is a `StreamStatus`: `'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'`.
+
+The TSDoc block on `useApiStream` in `src/hooks/useApiStream.ts` is the detailed and authoritative state-machine reference, including teardown edge cases. This guide summarizes consumer-facing usage and gating.
+
+`disconnect()` closes the connection and does not reconnect. There is no reconnect function: to open a new connection, change the descriptor key, change `mode`, or toggle `enabled` back to true.
+
+#### The `enabled` option
+
+`enabled` (default `true`) gates whether the hook connects at all. While it is false the hook never calls the descriptor's `connect()` and ordinarily holds `status: 'idle'` (calling `disconnect()` while disabled is the one exception — see the TSDoc). Flipping it to true re-runs the connect effect and starts a fresh connection; flipping it back to false tears the connection down and returns `status` to `'idle'`.
+
+Tearing down via `enabled` does not clear `data` or `events` — a descriptor-key or `mode` change, or re-enabling, does. A component reading `data` while the stream is disabled still sees the last event from the previous connection.
+
+Gating advice, since `'idle'` covers both "not started yet" and "deferred by `enabled`":
+
+- Gate the loading state on `'connecting'` alone. Treating `'idle'` as loading renders a permanent spinner for a stream deliberately held at `enabled: false`.
+- Handle `'idle'` as "not started / deferred". A component that both defers and shows loading should key its spinner off its own active flag, not off `'idle'`.
+- Check `status === 'error'` rather than the truthiness of `error` to render failures.
 
 ### Available Hooks
 

--- a/template-shell/packages/react/__tests__/useApiStream.test.tsx
+++ b/template-shell/packages/react/__tests__/useApiStream.test.tsx
@@ -8,9 +8,6 @@
  * @packageDocumentation
  */
 
-// @cpt-FEATURE:implement-endpoint-descriptors:p3
-// @cpt-FEATURE:cpt-frontx-dod-request-lifecycle-use-api-stream:p2
-
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import {
@@ -414,7 +411,6 @@ describe('useApiStream', () => {
     expect(result.current.events).toEqual(['b1']);
   });
 
-  // @cpt-begin:cpt-frontx-dod-request-lifecycle-use-api-stream:p2:inst-test-same-key-no-reconnect
   it('does not call connect again when a new descriptor object shares the same key', async () => {
     const client = buildTestQueryClient();
     const wrapper = makeQueryWrapper(client);
@@ -448,5 +444,4 @@ describe('useApiStream', () => {
     await waitFor(() => expect(connectSecond).not.toHaveBeenCalled());
     expect(connectFirst).toHaveBeenCalledTimes(1);
   });
-  // @cpt-end:cpt-frontx-dod-request-lifecycle-use-api-stream:p2:inst-test-same-key-no-reconnect
 });

--- a/template-shell/packages/react/src/hooks/useApiStream.ts
+++ b/template-shell/packages/react/src/hooks/useApiStream.ts
@@ -1,10 +1,9 @@
 /**
  * useApiStream - Declarative SSE streaming hook
  *
- * Accepts a StreamDescriptor from @gears-frontx/api and manages the EventSource
- * lifecycle: connects on mount, disconnects on unmount/descriptor change.
- * Returns the latest event, accumulated events, connection status, and
- * a manual disconnect function.
+ * Accepts a StreamDescriptor from @gears-frontx/api and returns the latest
+ * event, accumulated events, connection status, and a manual disconnect
+ * function.
  *
  * @example
  * ```tsx
@@ -17,10 +16,6 @@
  * const { events, status } = useApiStream(service.messageStream, { mode: 'accumulate' });
  * ```
  */
-
-// @cpt-dod:cpt-frontx-dod-request-lifecycle-use-api-stream:p2
-// @cpt-flow:cpt-frontx-flow-request-lifecycle-use-api-stream:p2
-// @cpt-FEATURE:cpt-frontx-fr-sse-stream-descriptors:p3
 
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import type { StreamDescriptor, StreamStatus } from '@gears-frontx/framework';
@@ -39,19 +34,76 @@ export interface ApiStreamOptions {
 
 /** Return type of useApiStream. */
 export interface ApiStreamResult<TEvent> {
-  /** Latest event payload (always set in both modes). */
+  /** Latest event payload, set in both modes — `undefined` until the first event and after each connect attempt resets it. */
   data: TEvent | undefined;
   /** All received events when `mode: 'accumulate'`; empty array in `'latest'` mode. */
   events: TEvent[];
   /** Connection lifecycle status. */
   status: StreamStatus;
-  /** Error if the connection failed. */
+  /** Last connect error — set when a connect attempt rejects, cleared when the next attempt starts. */
   error: Error | null;
   /** Manually close the connection. */
   disconnect: () => void;
 }
 
-// @cpt-begin:cpt-frontx-flow-request-lifecycle-use-api-stream:p2:inst-use-api-stream
+/**
+ * Manages the status lifecycle for a single SSE stream connection.
+ *
+ * **Status values**
+ * - `'idle'` — no connection is being attempted. This is the initial status
+ *   before the first connect effect runs, and it is ordinarily the status
+ *   while `enabled` is `false`. Consumers must not assume `'idle'` means "never
+ *   connected" — a stream that is disabled after having connected returns to
+ *   `'idle'` too, and `data`/`events` from the earlier connection are not
+ *   cleared by that transition alone (they are cleared by mode/key changes,
+ *   see below).
+ * - `'connecting'` — `descriptor.connect()` has been called and its promise
+ *   has not yet settled.
+ * - `'connected'` — set both when `connect()` resolves (unless a disconnect
+ *   was requested while it was pending) and, independently, whenever the
+ *   `onEvent` callback delivers a new event. Because every event re-asserts
+ *   `'connected'`, this status also serves as "still receiving events."
+ * - `'disconnected'` — reached via any of: the descriptor's `onComplete`
+ *   callback firing (the stream ended normally), `connect()` rejecting while
+ *   a disconnect was requested concurrently, or the manual `disconnect()`
+ *   function being called. `disconnect()` has no `enabled` guard: called
+ *   while the stream is disabled it still sets `'disconnected'`, which
+ *   persists until the next connect-effect run.
+ * - `'error'` — `connect()` rejected and no disconnect was requested while it
+ *   was pending. `error` holds the rejection, coerced to an `Error` if it
+ *   wasn't one already.
+ *
+ * **Transitions**
+ * - Mount / `enabled` becomes `true` / `descriptor.key` or `mode` changes:
+ *   `data`, `events`, and `error` are reset, then status goes to
+ *   `'connecting'` and `connect()` is called.
+ * - `enabled` becomes `false` (or starts `false`): status is forced to
+ *   `'idle'` and `connect()` is never called; no other field is reset by
+ *   this transition alone.
+ * - Unmount, `descriptor.key` change, `mode` change, or `enabled` flipping to
+ *   `false` while connected or connecting: the previous connection is torn
+ *   down via `descriptor.disconnect()` once its `connect()` promise settles
+ *   (or immediately skipped if it rejected). All four share the same cleanup
+ *   path: the effect's cleanup runs on every dependency change and on unmount.
+ * - Calling `disconnect()`: if a connection id is already resolved, it is
+ *   disconnected immediately and status becomes `'disconnected'`. If
+ *   `connect()` is still pending, the request is recorded and honored when
+ *   the promise settles — the newly resolved connection is torn down instead
+ *   of being adopted, and status is `'disconnected'`. One caveat:
+ *   `disconnect()` does not cancel the event callback, so a buffered or
+ *   in-flight event landing after the call re-asserts `'connected'` — and in
+ *   the pending-connect case the settle handler tears the connection down
+ *   without touching status, so that stray `'connected'` persists.
+ * - Stream completion while `connect()` is still pending: the current
+ *   implementation lets `onComplete` set `'disconnected'`, then the settle
+ *   handler adopts the connection id and re-asserts `'connected'` anyway.
+ *   This is known current behavior, not a durable guarantee: a pending
+ *   upstream derived-status rewrite is expected to remove this transition.
+ *
+ * `enabled` (default `true`) is the only way to defer connecting past mount;
+ * flipping it back to `true` re-runs the same connect sequence as a fresh
+ * mount would.
+ */
 export function useApiStream<TEvent>(
   descriptor: StreamDescriptor<TEvent>,
   options?: ApiStreamOptions,
@@ -169,4 +221,3 @@ export function useApiStream<TEvent>(
 
   return { data, events, status, error, disconnect };
 }
-// @cpt-end:cpt-frontx-flow-request-lifecycle-use-api-stream:p2:inst-use-api-stream


### PR DESCRIPTION
Closes #516.

## The decision (ADR-0033)

Issue #516 asked whether `useApiStream`'s status lifecycle should get a FEATURE spec or whether its `@cpt-` markers should be walked back. Investigation showed the markers are **residue from the archived pre-redesign `feature-request-lifecycle` FEATURE** (moved to `.archive-pre-ecosystem-redesign/`, then deleted) — and `template-shell/**` is already deliberately excluded from `cfs validate`'s universe in `.cf-studio/config/artifacts.toml`. Reviving one archived feature for one hook would create a specified island inside otherwise-unspecified template payload.

So this PR records **ADR-0033 (template-territory traceability)**: the ecosystem artifact tree does not specify template payload; residue `@cpt-` markers there bind nothing, are removed when a file is otherwise modified, and no new ones are added; consumer-visible template behaviour is documented **at code altitude**. A template-owned artifact tree is explicitly deferred, not rejected. (Originally numbered 0034 while the #495 branch carried an ADR-0033; that branch archived its ADR, so this one took the freed number.)

## Changes

- `architecture/ADR/0033-template-territory-traceability.md` — the decision; `architecture/DESIGN.md` — one line in the §1.2 ADR inventory
- `useApiStream.ts` — residue `@cpt-dod`/`@cpt-flow`/`@cpt-FEATURE`/`@cpt-begin/end` markers removed; full status-lifecycle TSDoc added (per-value semantics, all transitions, `enabled` gating, data/events persistence across a disable); header corrected from "EventSource lifecycle" to "connection lifecycle" (the transport is the descriptor's detail)
- `useApiStream.test.tsx` — residue markers removed, tests untouched
- `template-shell/packages/react/CLAUDE.md` — returns list, `enabled` subsection, gating advice, and a pointer to the TSDoc, which is the single owner of the state machine (see the review response)
- `.cf-studio/config/artifacts.toml` — template ignore reason now cites `cpt-frontx-adr-template-territory-traceability`
- `.cf-studio/config/AGENTS.md`, root `CLAUDE.md` — the marker-preservation instructions gained the template-territory carve-out so agents and FX-002 review enforce the ADR instead of contradicting it
- `packages/api/src/types.ts` — the last two archived-generation markers in the scanned universe removed (comment-only)
- `scripts/template-discovery.test.mjs` — sync guard: the artifacts.toml template-territory ignore globs must cover exactly the manifest-discovered template directories, so the literal config cannot drift from the manifest rule the prose surfaces state

## Response to the review (squashed into the single head commit)

All 13 threads addressed:

- **ADR renumbered 0034 → 0033** — the skip rationale went stale when #517 archived its ADR (references use the ID slug, so only the filename moved)
- **The removal rule is stated once**: whole file — when a template file is otherwise modified, every residue marker it carries leaves; the ADR asks only that marker-only deletions remain easy to distinguish from substantive changes in review, without prescribing a commit topology
- **Instruction surfaces taught the carve-out** (AGENTS.md ×2, root CLAUDE.md) — an agent following them no longer preserves what the ADR retires
- **Mechanism-agnostic deferral, not "superseded"** — the decision is revisited through the repository's ADR lifecycle once template ownership settles, preserving ADR-0027's immutability premise; the prompting-instance narration dropped (the Decision Outcome keeps the example in timeless form)
- **The scanned universe is actually clean now** — `packages/api/src/types.ts` carried the last two dead markers; a sweep found no others, so the ADR's consequence holds
- **The TSDoc owns the state machine**; CLAUDE.md's duplicate table/transitions (already drifted within this PR) replaced by a pointer plus gating advice
- **The example models the gating advice** (`status === 'connecting'` alone) instead of contradicting it behind two caveats
- **TSDoc truth fixes**: cleanup-path rationale corrected (dep array is `[descriptorKey, enabled, mode]`; unmount arrives via unmount semantics); disconnect-while-disabled exception to the `'idle'` invariant recorded; the completion-during-connect adoption quirk documented (a short-lived stream can show `'disconnected'` → `'connected'` with no consumer action — behavioural fix left to #491's derived-status rewrite); `data` no longer claims "always set"

## Verification

- Stripping comments and blank lines, all three touched TS files are **identical to develop** — zero logic change (verified at the rebased head)
- `cfs validate` at the rebased head: 0 errors, 0 warnings, coverage 124/124; `validate-toc` / `check-language` pass
- react package: type-check clean, 135/135 tests pass (17/17 in `useApiStream.test.tsx`) — unchanged since only comments and docs moved
- Every documented lifecycle claim was verified line-by-line against the hook implementation (QA + architect review)

## ⚠️ Coordination with #491

These docs are grounded in **develop's** `useState<StreamStatus>('idle')` initializer. The unmerged #491 changes initialization to `enabled ? 'connecting' : 'idle'` and derives the returned status. The in-file reminder was removed in round 3 (maintainer-only text does not belong in shipped template payload), so **this section is the coordination record**: whichever PR lands second must update the TSDoc's initial-state claims. CLAUDE.md no longer carries initial-state claims at all. #491's derived-status rewrite is also the right home for fixing the completion-during-connect adoption quirk and the stray-`'connected'`-after-`disconnect()` sibling documented in the TSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified streaming connection lifecycles, status transitions, loading and error states, disconnect behavior, and enabling or disabling streams.
  - Added guidance distinguishing product code from reusable template content and documenting template maintenance practices.

- **Maintenance**
  - Added a formal architecture decision record for template traceability.
  - Removed obsolete internal annotations and updated configuration and review guidance to reflect template boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

