### PR TITLE
ci: guard the template lockfile self-link entry npm reconciliation drops (#524)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,17 @@ jobs:
     - name: Check template ecosystem pin-drift
       run: npm run policy:template-pin-drift
 
+    # #524: `npm install` reconciling an out-of-sync template lockfile drops
+    # the template's `file:.` self-link entry, writing a lockfile its own
+    # `npm ci` then rejects ("Missing: ... from lock file") — and reconciling
+    # is exactly what `npm ci`'s out-of-sync error tells the developer to do.
+    # This asserts every self-link a template's manifest declares still has
+    # its lockfile entry, so the failure names the vanished entry at commit
+    # time instead of surfacing as a generic `npm ci` red in template CI.
+    # No build-order dependency: reads the JSON files directly.
+    - name: Check template lockfile self-link entries
+      run: npm run policy:template-lockfile-selflink
+
   studio-validate:
     name: Studio Validate Artifacts
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "npm run lint:deps && eslint . --max-warnings 0",
     "policy:version-check": "node scripts/ecosystem-version-policy.mjs",
     "policy:template-pin-drift": "node scripts/template-pin-drift-check.mjs",
+    "policy:template-lockfile-selflink": "node scripts/template-lockfile-selflink-check.mjs",
     "validate:templates": "node scripts/validate-templates.mjs",
     "type-check": "npm run type-check:all",
     "type-check:host": "tsc --noEmit",

--- a/scripts/template-lockfile-selflink-check.mjs
+++ b/scripts/template-lockfile-selflink-check.mjs
@@ -1,0 +1,323 @@
+/**
+ * Template Lockfile Self-Link Guard (#524).
+ *
+ * A self-contained template depends on itself: the workspace packages depend
+ * on the template by name (`packages/framework` declares
+ * `"@gears-frontx/frontx-template-shell": "file:../.."`), and the template's
+ * root manifest pins that name's resolution to its own directory via
+ * `"overrides": { "@gears-frontx/frontx-template-shell": "file:." }`, so the
+ * template's own library build is resolvable through `node_modules`. npm
+ * records that resolution in the lockfile as
+ *
+ *   "node_modules/@gears-frontx/frontx-template-shell": {
+ *     "resolved": "",
+ *     "link": true
+ *   }
+ *
+ * and `npm ci` refuses to install without it ("Missing: <name>@<version> from
+ * lock file").
+ *
+ * The trap (#524): when `npm install` has to RECONCILE a manifest change — a
+ * lockfile out of sync with `package.json`, exactly the state a pin bump that
+ * skipped the lockfile leaves behind — the lockfile it writes back omits this
+ * entry. And reconciling with `npm install` is what `npm ci`'s own out-of-sync
+ * error message tells the developer to do, so the documented remediation
+ * produces a second broken lockfile, red in every job that runs `npm ci` in
+ * the template, with nothing naming the entry that vanished. This guard is
+ * that name: it fails on the exact missing lockfile entry, before the commit
+ * lands (observed on npm 11.7.0 / node 25.4.0, the pair CI's `25.x` jobs get).
+ *
+ * Discovery mirrors the sibling guards (`template-pin-drift-check.mjs`,
+ * `validate-templates.mjs`): a template is a top-level directory carrying
+ * `frontx-template.json` (ADR-0018 manifest presence, never a `template-*`
+ * name guess), and zero templates found — or zero templates actually checked —
+ * is a hard failure, never a vacuous pass. WHAT to assert is read from each
+ * template's own root manifest — every
+ * dependency declared at the `file:.` self-path — so a renamed template or a
+ * second self-linking template is covered with no change here. An overlay
+ * template (no root `package.json`, e.g. `template-mfe/`) or one without a
+ * lockfile has no `npm ci` contract to protect and is skipped.
+ *
+ * CLI entry: `node scripts/template-lockfile-selflink-check.mjs` (exit 0 on
+ * success). Core logic is exported for unit tests in
+ * `scripts/template-lockfile-selflink-check.test.mjs`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { MANIFEST_FILENAME, findTemplateDirs } from './template-discovery.mjs';
+
+// Re-exported for the zero-templates failure message, same as the pin-drift
+// guard: the filename is owned by `template-discovery.mjs`.
+export { MANIFEST_FILENAME };
+
+/**
+ * The dependency fields npm materialises into the install tree. `peerDependencies`
+ * is deliberately absent: a peer declaration alone produces no `node_modules`
+ * entry of its own to lose. `overrides` is scanned separately
+ * (`selfLinkDependenciesOf`) because its values can be nested objects, and it
+ * is where the real tree declares its self-link today: `template-shell`'s root
+ * manifest carries `"overrides": { "@gears-frontx/frontx-template-shell": "file:." }`,
+ * redirecting the workspace packages' dependency on that name
+ * (`packages/framework` declares it at `file:../..`) to the template root.
+ */
+const INSTALLED_DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies'];
+
+/**
+ * A `file:` specifier that resolves to the manifest's own directory — the
+ * self-link shape npm's reconciliation drops from the lockfile (#524).
+ * `file:.` is what the repo declares; the normalised variants are accepted so
+ * a formatting change in the manifest cannot silently take the dependency out
+ * of the guard's view.
+ *
+ * @param {string} spec
+ * @returns {boolean}
+ */
+export function isSelfLinkSpec(spec) {
+  if (typeof spec !== 'string' || !spec.startsWith('file:')) return false;
+  const target = spec.slice('file:'.length);
+  return target === '.' || target === './' || target === '';
+}
+
+/**
+ * @typedef {{ name: string; field: string; spec: string }} SelfLinkDependency
+ */
+
+/**
+ * Every dependency the manifest declares at its own directory.
+ *
+ * @param {unknown} manifest parsed root `package.json` of a template
+ * @returns {SelfLinkDependency[]}
+ */
+export function selfLinkDependenciesOf(manifest) {
+  if (typeof manifest !== 'object' || manifest === null) return [];
+
+  /** @type {SelfLinkDependency[]} */
+  const found = [];
+  for (const field of INSTALLED_DEPENDENCY_FIELDS) {
+    const section = /** @type {Record<string, unknown>} */ (manifest)[field];
+    if (typeof section !== 'object' || section === null) continue;
+    for (const [name, spec] of Object.entries(section)) {
+      if (typeof spec === 'string' && isSelfLinkSpec(spec)) {
+        found.push({ name, field, spec });
+      }
+    }
+  }
+
+  // An `overrides` self-link produces the same lockfile entry as a direct
+  // dependency once anything in the tree depends on the name - which is the
+  // point of declaring it there (the workspace packages depend on the template
+  // by name; the override pins the resolution to the template root). A nested
+  // override object carries its own spec under the "." key.
+  const overrides = /** @type {Record<string, unknown>} */ (manifest).overrides;
+  if (typeof overrides === 'object' && overrides !== null) {
+    for (const [name, value] of Object.entries(overrides)) {
+      const spec =
+        typeof value === 'string'
+          ? value
+          : typeof value === 'object' && value !== null
+            ? /** @type {Record<string, unknown>} */ (value)['.']
+            : undefined;
+      if (typeof spec === 'string' && isSelfLinkSpec(spec)) {
+        found.push({ name, field: 'overrides', spec });
+      }
+    }
+  }
+
+  return found;
+}
+
+/**
+ * @typedef {{
+ *   templateName: string;
+ *   dependency: SelfLinkDependency;
+ *   lockfilePath: string;
+ *   problem: 'entry-missing' | 'entry-not-link';
+ * }} SelfLinkFinding
+ */
+
+/**
+ * Checks one template's lockfile against the self-link dependencies its
+ * manifest declares.
+ *
+ * @param {{ manifest: unknown; lockfile: unknown; templateName: string; lockfilePath: string }} input
+ * @returns {SelfLinkFinding[]}
+ */
+export function findMissingSelfLinks({ manifest, lockfile, templateName, lockfilePath }) {
+  const declared = selfLinkDependenciesOf(manifest);
+  if (declared.length === 0) return [];
+
+  const packages =
+    typeof lockfile === 'object' && lockfile !== null
+      ? /** @type {Record<string, unknown>} */ (lockfile).packages
+      : undefined;
+
+  /** @type {SelfLinkFinding[]} */
+  const findings = [];
+  for (const dependency of declared) {
+    const entry =
+      typeof packages === 'object' && packages !== null
+        ? /** @type {Record<string, unknown>} */ (packages)[`node_modules/${dependency.name}`]
+        : undefined;
+
+    if (entry === undefined) {
+      findings.push({ templateName, dependency, lockfilePath, problem: 'entry-missing' });
+    } else if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      /** @type {Record<string, unknown>} */ (entry).link !== true
+    ) {
+      // An entry that exists but is not a link would make npm install the name
+      // from the registry over the template's own build — a different corruption
+      // of the same contract, reported distinctly so the fix is obvious.
+      findings.push({ templateName, dependency, lockfilePath, problem: 'entry-not-link' });
+    }
+  }
+  return findings;
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} description named in the fail-closed error
+ * @returns {unknown}
+ */
+function readJsonFailClosed(filePath, description) {
+  /** @type {string} */
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(`${description} ${filePath} is unreadable (${error instanceof Error ? error.message : String(error)})`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${description} ${filePath} is not valid JSON (${error instanceof Error ? error.message : String(error)})`);
+  }
+}
+
+/**
+ * @param {{ rootDir: string; log: (line: string) => void; logError: (line: string) => void }} context
+ * @returns {number}
+ */
+function check({ rootDir, log, logError }) {
+  const templateDirs = findTemplateDirs(rootDir);
+
+  // Same rule as the sibling guards: zero templates found means discovery is
+  // broken or the repo lost its templates, and either needs a human — a
+  // vacuous pass would hide both.
+  if (templateDirs.length === 0) {
+    logError(
+      `[template-lockfile-selflink-check] FAIL: no template found under ${rootDir} (looked for a top-level directory carrying ${MANIFEST_FILENAME}).`,
+    );
+    return 1;
+  }
+
+  /** @type {SelfLinkFinding[]} */
+  const findings = [];
+  let checkedCount = 0;
+
+  for (const templateDir of templateDirs) {
+    const templateName = path.basename(templateDir);
+    const manifestPath = path.join(templateDir, 'package.json');
+    const lockfilePath = path.join(templateDir, 'package-lock.json');
+
+    // No root package.json: an add-only overlay (template-mfe) — nothing is
+    // ever `npm ci`-installed at its root, so there is no lockfile contract
+    // to protect. No lockfile: same conclusion from the other side.
+    if (!fs.existsSync(manifestPath) || !fs.existsSync(lockfilePath)) continue;
+
+    const manifest = readJsonFailClosed(manifestPath, 'template manifest');
+    const lockfile = readJsonFailClosed(lockfilePath, 'template lockfile');
+    findings.push(
+      ...findMissingSelfLinks({
+        manifest,
+        lockfile,
+        templateName,
+        lockfilePath: path.relative(rootDir, lockfilePath),
+      }),
+    );
+    checkedCount += 1;
+  }
+
+  // Same rule extended to "zero templates CHECKED": every discovered template
+  // being skipped (no root package.json or no lockfile) leaves nothing
+  // asserted, and a lockfile rename or move would otherwise disarm the guard
+  // while it still reports success.
+  if (checkedCount === 0) {
+    logError(
+      `[template-lockfile-selflink-check] FAIL: ${templateDirs.length} template(s) discovered under ${rootDir}, ` +
+        'but none carries both a root package.json and a package-lock.json, so nothing was checked. ' +
+        'If a template intentionally lost its lockfile contract, update this guard alongside it.',
+    );
+    return 1;
+  }
+
+  if (findings.length > 0) {
+    logError(`[template-lockfile-selflink-check] FAIL: ${findings.length} self-link lockfile entr(y/ies) broken:`);
+    for (const { templateName, dependency, lockfilePath, problem } of findings) {
+      logError(
+        problem === 'entry-missing'
+          ? `  ${lockfilePath}: packages["node_modules/${dependency.name}"] is missing, but ${templateName}/package.json ${dependency.field} declares "${dependency.name}": "${dependency.spec}"`
+          : `  ${lockfilePath}: packages["node_modules/${dependency.name}"] exists but is not a link entry ("link": true), so npm would install a registry copy over the template's own build`,
+      );
+    }
+    logError(
+      '\nThis is the #524 npm quirk: `npm install` reconciling an out-of-sync lockfile drops the\n' +
+        'file:. self-link entry, producing a lockfile its own `npm ci` rejects ("Missing: <name> from\n' +
+        'lock file"). Restore the entry —\n' +
+        '\n' +
+        '  "node_modules/<name>": { "resolved": "", "link": true }\n' +
+        '\n' +
+        '— or make the intended lockfile change surgically instead of regenerating (see\n' +
+        'https://github.com/constructorfabric/gears-frontx/issues/524). Do NOT re-run `npm install`\n' +
+        'to fix this: it is what removed the entry.',
+    );
+    return 1;
+  }
+
+  log(
+    `Template lockfile self-link check passed: ${checkedCount} installable template(s) of ${templateDirs.length} ` +
+      'discovered carry every self-link entry their manifest requires.',
+  );
+  return 0;
+}
+
+/**
+ * CI entry point. Wired into `npm run policy:template-lockfile-selflink` and
+ * `.github/workflows/main.yml`.
+ *
+ * Fail-closed throws (unreadable or malformed JSON) are caught here and turned
+ * into an exit code with the message naming the offending file, same as the
+ * sibling guards: a guard whose own crash looks different from its own failure
+ * teaches developers to read a red build as "the script is broken".
+ *
+ * @param {{
+ *   rootDir?: string;
+ *   log?: (line: string) => void;
+ *   logError?: (line: string) => void;
+ * }} [options]
+ * @returns {number} 0 on success, 1 on failure.
+ */
+export function runCli(options = {}) {
+  const rootDir = options.rootDir ?? process.cwd();
+  const log = options.log ?? console.log;
+  const logError = options.logError ?? console.error;
+
+  try {
+    return check({ rootDir, log, logError });
+  } catch (error) {
+    logError(`[template-lockfile-selflink-check] FAIL: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+const isEntryPoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntryPoint) {
+  // `process.exitCode` rather than `process.exit()`: the latter can truncate
+  // buffered output on some platforms, and there is nothing here that needs a
+  // hard stop.
+  process.exitCode = runCli();
+}

--- a/scripts/template-lockfile-selflink-check.test.mjs
+++ b/scripts/template-lockfile-selflink-check.test.mjs
@@ -1,0 +1,265 @@
+// @cpt-dod:cpt-frontx-dod-unit-test-generation-and-agent-verification-standard-test-convention:p1
+import path from 'node:path';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  findMissingSelfLinks,
+  isSelfLinkSpec,
+  runCli,
+  selfLinkDependenciesOf,
+} from './template-lockfile-selflink-check.mjs';
+
+let rootDir;
+
+afterEach(async () => {
+  if (rootDir) await rm(rootDir, { recursive: true, force: true });
+});
+
+async function makeRoot() {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'frontx-selflink-'));
+  return rootDir;
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(value));
+}
+
+// A minimal marker manifest - discovery only checks for the file's presence
+// (`findTemplateDirs`), never its content.
+async function writeManifest(templateDir) {
+  await writeJson(path.join(templateDir, 'frontx-template.json'), {});
+}
+
+/** Runs the guard with its output captured, so a case can assert what it named. */
+function run(root) {
+  const lines = [];
+  const record = (line) => lines.push(line);
+  const exitCode = runCli({ rootDir: root, log: record, logError: record });
+  return { exitCode, output: lines.join('\n') };
+}
+
+// The exact shapes from the tree this guard protects: template-shell's root
+// manifest declares its self-link in `overrides` (the workspace packages
+// depend on the name; the override pins it to the template root), and the
+// lockfile entry below is what npm's reconciliation drops (#524).
+const SELF_NAME = '@gears-frontx/frontx-template-shell';
+const manifestWithSelfLink = {
+  name: SELF_NAME,
+  version: '0.1.0-alpha.2',
+  overrides: { [SELF_NAME]: 'file:.' },
+};
+const lockfileWithSelfLink = {
+  lockfileVersion: 3,
+  packages: {
+    '': { name: SELF_NAME, version: '0.1.0-alpha.2' },
+    [`node_modules/${SELF_NAME}`]: { resolved: '', link: true },
+  },
+};
+
+describe('isSelfLinkSpec', () => {
+  it('accepts the declared shape and its normalised variants', () => {
+    expect(isSelfLinkSpec('file:.')).toBe(true);
+    expect(isSelfLinkSpec('file:./')).toBe(true);
+    expect(isSelfLinkSpec('file:')).toBe(true);
+  });
+
+  it('rejects file: paths that leave the directory and non-file specs', () => {
+    expect(isSelfLinkSpec('file:../..')).toBe(false);
+    expect(isSelfLinkSpec('file:./packages/framework')).toBe(false);
+    expect(isSelfLinkSpec('0.3.0-alpha.1')).toBe(false);
+    expect(isSelfLinkSpec('workspace:*')).toBe(false);
+  });
+});
+
+describe('selfLinkDependenciesOf', () => {
+  it('finds a self-link in any installed-dependency field, with its field named', () => {
+    const manifest = {
+      dependencies: { a: 'file:.' },
+      devDependencies: { b: 'file:./' },
+      optionalDependencies: { c: 'file:.' },
+    };
+    expect(selfLinkDependenciesOf(manifest)).toEqual([
+      { name: 'a', field: 'dependencies', spec: 'file:.' },
+      { name: 'b', field: 'devDependencies', spec: 'file:./' },
+      { name: 'c', field: 'optionalDependencies', spec: 'file:.' },
+    ]);
+  });
+
+  it('finds the real tree\'s shape: a self-link declared in overrides', () => {
+    expect(selfLinkDependenciesOf(manifestWithSelfLink)).toEqual([
+      { name: SELF_NAME, field: 'overrides', spec: 'file:.' },
+    ]);
+  });
+
+  it('finds a self-link in a nested override object under its "." key', () => {
+    expect(selfLinkDependenciesOf({ overrides: { a: { '.': 'file:.', b: '1.0.0' } } })).toEqual([
+      { name: 'a', field: 'overrides', spec: 'file:.' },
+    ]);
+  });
+
+  it('ignores overrides that redirect elsewhere', () => {
+    expect(selfLinkDependenciesOf({ overrides: { a: '2.0.0', b: 'file:../out', c: { d: 'file:.' } } })).toEqual([]);
+  });
+
+  it('ignores peerDependencies - a peer declaration installs no entry to lose', () => {
+    expect(selfLinkDependenciesOf({ peerDependencies: { a: 'file:.' } })).toEqual([]);
+  });
+
+  it('returns nothing for a manifest with no self-link', () => {
+    expect(selfLinkDependenciesOf({ dependencies: { a: '1.0.0', b: 'file:../sibling' } })).toEqual([]);
+  });
+});
+
+describe('findMissingSelfLinks', () => {
+  const base = { templateName: 'template-shell', lockfilePath: 'template-shell/package-lock.json' };
+
+  it('passes when the lockfile carries the link entry', () => {
+    expect(
+      findMissingSelfLinks({ ...base, manifest: manifestWithSelfLink, lockfile: lockfileWithSelfLink }),
+    ).toEqual([]);
+  });
+
+  it('reports entry-missing when npm reconciliation dropped it (#524)', () => {
+    const lockfile = { lockfileVersion: 3, packages: { '': { name: SELF_NAME } } };
+    const findings = findMissingSelfLinks({ ...base, manifest: manifestWithSelfLink, lockfile });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].problem).toBe('entry-missing');
+    expect(findings[0].dependency.name).toBe(SELF_NAME);
+  });
+
+  it('reports entry-not-link when the entry exists but would install from the registry', () => {
+    const lockfile = {
+      lockfileVersion: 3,
+      packages: {
+        '': { name: SELF_NAME },
+        [`node_modules/${SELF_NAME}`]: { version: '0.1.0-alpha.2', resolved: 'https://registry.npmjs.org/...' },
+      },
+    };
+    const findings = findMissingSelfLinks({ ...base, manifest: manifestWithSelfLink, lockfile });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].problem).toBe('entry-not-link');
+  });
+
+  it('has nothing to assert for a manifest without a self-link', () => {
+    expect(
+      findMissingSelfLinks({ ...base, manifest: { dependencies: { x: '1.0.0' } }, lockfile: { packages: {} } }),
+    ).toEqual([]);
+  });
+});
+
+describe('runCli', () => {
+  it('passes on a template whose lockfile carries the self-link entry', async () => {
+    const root = await makeRoot();
+    const dir = path.join(root, 'template-shell');
+    await writeManifest(dir);
+    await writeJson(path.join(dir, 'package.json'), manifestWithSelfLink);
+    await writeJson(path.join(dir, 'package-lock.json'), lockfileWithSelfLink);
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('passed');
+  });
+
+  it('fails naming the lockfile, the entry, and the #524 remediation when the entry is gone', async () => {
+    const root = await makeRoot();
+    const dir = path.join(root, 'template-shell');
+    await writeManifest(dir);
+    await writeJson(path.join(dir, 'package.json'), manifestWithSelfLink);
+    await writeJson(path.join(dir, 'package-lock.json'), { lockfileVersion: 3, packages: { '': {} } });
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain(`packages["node_modules/${SELF_NAME}"] is missing`);
+    expect(output).toContain(path.join('template-shell', 'package-lock.json'));
+    expect(output).toContain('issues/524');
+    expect(output).toContain('Do NOT re-run `npm install`');
+  });
+
+  it('skips an overlay template with no root package.json instead of failing on it', async () => {
+    const root = await makeRoot();
+    const shell = path.join(root, 'template-shell');
+    await writeManifest(shell);
+    await writeJson(path.join(shell, 'package.json'), manifestWithSelfLink);
+    await writeJson(path.join(shell, 'package-lock.json'), lockfileWithSelfLink);
+    // Overlay: manifest marker only, nothing installable at its root.
+    await writeManifest(path.join(root, 'template-mfe'));
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('1 installable template(s) of 2 discovered');
+  });
+
+  it('skips a template that has a package.json but no lockfile', async () => {
+    const root = await makeRoot();
+    const shell = path.join(root, 'template-shell');
+    await writeManifest(shell);
+    await writeJson(path.join(shell, 'package.json'), manifestWithSelfLink);
+    await writeJson(path.join(shell, 'package-lock.json'), lockfileWithSelfLink);
+    // Lockfile-less: nothing `npm ci` installs at its root, so nothing to assert.
+    const bare = path.join(root, 'template-x');
+    await writeManifest(bare);
+    await writeJson(path.join(bare, 'package.json'), manifestWithSelfLink);
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('1 installable template(s) of 2 discovered');
+  });
+
+  it('fails hard when every discovered template is skipped - a lost lockfile must not disarm the guard', async () => {
+    const root = await makeRoot();
+    const dir = path.join(root, 'template-shell');
+    await writeManifest(dir);
+    await writeJson(path.join(dir, 'package.json'), manifestWithSelfLink);
+    // No package-lock.json: the one discovered template is skipped, so a
+    // vacuous pass here would hide a renamed or deleted lockfile forever.
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('nothing was checked');
+  });
+
+  it('fails hard when discovery finds no template at all', async () => {
+    const root = await makeRoot();
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('no template found');
+  });
+
+  it('fails closed on a lockfile that is not valid JSON, naming the file', async () => {
+    const root = await makeRoot();
+    const dir = path.join(root, 'template-shell');
+    await writeManifest(dir);
+    await writeJson(path.join(dir, 'package.json'), manifestWithSelfLink);
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, 'package-lock.json'), '{ not json');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('not valid JSON');
+    expect(output).toContain('package-lock.json');
+  });
+});
+
+// The guard must stay true on the real tree it protects: template-shell's
+// committed manifest and lockfile. A fixture-only suite would keep passing
+// after a repo change broke the guard's assumptions about either file's shape
+// - which is exactly how the first version of this guard shipped vacuous: it
+// scanned only dependency fields while the real manifest declares its
+// self-link in `overrides`, so it passed on a lockfile with the entry deleted.
+describe('against the real repository', () => {
+  const repoRoot = path.resolve(import.meta.dirname, '..');
+
+  it('sees at least one self-link in the committed template-shell manifest (vacuity guard)', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const manifest = JSON.parse(await readFile(path.join(repoRoot, 'template-shell', 'package.json'), 'utf8'));
+    expect(selfLinkDependenciesOf(manifest)).not.toEqual([]);
+  });
+
+  it('passes on the committed template-shell manifest and lockfile', () => {
+    const { exitCode, output } = run(repoRoot);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('passed');
+  });
+});


### PR DESCRIPTION
## Summary

Implements direction 2 from #524: a guard that fails **by name** when a template's lockfile loses the `file:.` self-link entry, instead of the loss surfacing later as a generic `npm ci` red in template CI.

The quirk it guards (#524, observed on npm 11.7.0 / node 25.4.0): when `npm install` has to *reconcile* an out-of-sync lockfile — the state a pin bump that skips the lockfile leaves behind, as `309d77fc` did — the lockfile it writes back omits

```json
"node_modules/@gears-frontx/frontx-template-shell": { "resolved": "", "link": true }
```

and `npm ci` then rejects that lockfile (`Missing: ... from lock file`). Reconciling with `npm install` is exactly what `npm ci`'s out-of-sync error message instructs, so the documented remediation produces a second broken lockfile with nothing naming what vanished.

## What's in the change

- **`scripts/template-lockfile-selflink-check.mjs`** — in the mold of `template-pin-drift-check.mjs`: templates discovered by `frontx-template.json` presence via the shared `template-discovery.mjs` (zero templates found is a hard failure, never a vacuous pass); what to assert is read from each template's own root manifest — self-link `file:.` specs in the installed dependency fields **and in `overrides`**, which is where the real tree declares it (`packages/framework` depends on the template by name, the root override pins the resolution to `file:.`). Overlay templates without a root `package.json`/lockfile (e.g. `template-mfe/`) are skipped — no `npm ci` contract to protect. Unreadable/malformed JSON fails closed. The failure message quotes the missing entry, links #524, and warns that re-running `npm install` is what removed it.
- **`scripts/template-lockfile-selflink-check.test.mjs`** — 20 tests in the sibling suites' fixture style, plus two against the committed repo tree. One of those is a **vacuity guard** asserting the guard sees at least one self-link in the real `template-shell/package.json` — the first draft of this script scanned only dependency fields, missed the `overrides` declaration, and passed on a lockfile with the entry deleted; that test makes this failure shape impossible to reship.
- **Wiring** — `npm run policy:template-lockfile-selflink`, plus a `main.yml` step beside the pin-drift check (no build-order dependency: reads JSON directly).

## Verification

- All 289 tests of the `repo-scripts` vitest project pass (20 new).
- The guard passes on the committed tree and was verified end-to-end against a copy of `template-shell` with the entry deleted — it fails with the message naming the entry.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure installable templates retain valid lockfile self-link entries.
  * Improved diagnostics for missing, invalid, or unreadable template lockfiles.

* **Tests**
  * Added automated coverage for template discovery, dependency overrides, malformed files, and validation outcomes.

* **Chores**
  * Integrated template lockfile validation into continuous integration checks to catch issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->