### PR TITLE
feat(ui-kit): open the alpha channel — first publication at 0.3.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8156,7 +8156,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.3.0-alpha.0",
+      "version": "0.3.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -66,8 +66,10 @@ npm run test:unit --workspace=@gears-frontx/ui-kit
 npm run demo:ui-kit                              # browser sandbox: tokens + components pages (demo/)
 ```
 
-See [design-notes.md](design-notes.md) for the design and its history. The package is
-`private` until the MVP component set lands and #495 approves its architecture
-ownership, traceability, and version policy. The required CDSL artifacts must
-also replace the temporary `artifacts.toml` ignore. Only then may `private` be
-removed for publication through the standard version-gated workflow.
+See [design-notes.md](design-notes.md) for the design and its history. The package
+publishes on the `alpha` channel through the standard version-gated workflow while
+it matures: the 19-component set is live, the remaining MVP components land under
+the same pre-release line. A stable (`latest`) release stays gated on the full MVP
+component set and on #495 approving the package's architecture ownership,
+traceability, and version policy — the required CDSL artifacts must also replace
+the temporary `artifacts.toml` ignore before a stable version may be cut.

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -98,12 +98,14 @@ the `sidebar` / `data-table` exclusions above intact.
   color, plus `color-scheme`), not just the tokens: a bare consumer page
   goes correctly dark under `prefers-color-scheme` with no attribute and no
   CSS of its own.
-- Publishing: version-gated like every ecosystem package. `private: true`
-  remains in place until both the MVP component set lands and #495 approves
-  the package's architecture ownership, traceability, and version policy. The
-  required CDSL artifacts must then replace the temporary `artifacts.toml`
-  ignore. Only after all of those gates pass is flipping `private` the release
-  act.
+- Publishing: version-gated like every ecosystem package. Originally
+  `private: true` gated *any* publication on the full MVP set plus #495; that
+  gate was consciously revised (2026-08-07) — the `alpha` pre-release channel
+  opened with the 19-component set so templates can consume the kit while the
+  remaining MVP components land. The original gates now guard the *stable*
+  (`latest`) release instead: the full MVP component set, #495 approving the
+  package's architecture ownership, traceability, and version policy, and the
+  required CDSL artifacts replacing the temporary `artifacts.toml` ignore.
 
 ## Component set (MVP, 31 components)
 
@@ -203,7 +205,10 @@ unblocked; the mockup-block recipes additionally wait on step-5 components
 ## Delivery plan
 
 Oldest first; steps 1–4 are done (step 4's design answers are still
-pending, see its entry), 5–6 remain. Completed
+pending, see its entry), 5–6 remain. The first `alpha` publication
+(0.3.0-alpha.1, 2026-08-07) happened *before* step 5, per the revised
+Publishing gate above — steps 5–6 now gate the stable release, not
+publication as such. Completed
 steps are a log, not a description of the current build (see Architecture
 for that; the tsup pipeline step 1 names was later replaced by Vite, per
 Architecture's build bullet).
@@ -366,10 +371,10 @@ Architecture's build bullet).
    `empty` are in both the mockups and the `insight-front` set and go first;
    `pagination` and `breadcrumb` are the mockups-only additions;
    `toggle`, `toggle-group`, `sheet`, `preview-card`, `collapsible`,
-   `spinner` close the `insight-front` list. Before the release step, not
-   after: they are part of the MVP set the `private` gate names, and the
+   `spinner` close the `insight-front` list. Before the stable release, not
+   after: they are part of the MVP set the stable gate names, and the
    kitchen-sink app and composition recipes should cover the whole set once
-   rather than be extended right after publication.
+   rather than be extended right after the stable release.
 6. Composition recipes (incl. the mockup building blocks) + kitchen-sink to
-   full coverage; satisfy the #495 publication gates, remove the temporary
-   artifact ignore, then flip `private` and publish.
+   full coverage; satisfy the #495 gates, remove the temporary
+   artifact ignore, then cut the first stable (`latest`) version.

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0-alpha.1",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",
@@ -68,7 +68,6 @@
   "sideEffects": [
     "**/*.css"
   ],
-  "private": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What

Opens the `alpha` publication channel for `@gears-frontx/ui-kit`: removes `private: true` and bumps the version to `0.3.0-alpha.1`, so the version-gated publish workflow (PART 1 of `publish-packages.yml`) picks the package up on the next `develop` push and publishes it with the `alpha` dist-tag.

## Why now — the gate was consciously revised

The package originally gated *any* publication on the full 31-component MVP set plus #495 (architecture ownership, traceability, version policy, and the CDSL artifacts replacing the temporary `artifacts.toml` ignore). That all-or-nothing gate is hereby revised: the alpha pre-release line opens with the current 19-component set (post-#536, on the Studio design) so templates can consume the kit while the remaining 12 MVP components land.

The original gates now guard the **stable (`latest`) release** instead:

- full MVP component set (12 gap components, delivery-plan step 5),
- composition recipes + kitchen-sink coverage (step 6),
- #495 approval + CDSL artifacts replacing the `artifacts.toml` ignore.

README and design-notes are reworded accordingly (the delivery plan records the publication as a deliberate reordering, not a drive-by).

## Contents

- `packages/ui-kit/package.json` — drop `private: true`, `0.3.0-alpha.0 → 0.3.0-alpha.1` (`publishConfig.access: public` was already in place).
- `packages/ui-kit/README.md`, `design-notes.md` — gate rewording as above.
- `package-lock.json` — carries **only** the version bump; a full regeneration was reverted because local npm again tried to drop optional-peer `@emnapi/*` entries. Verified with `npm ci --dry-run`.

## Notes for reviewers

- **First publish also sets `latest`**: npm assigns `latest` on a package's first publication even with `--tag alpha` — same as happened to `@gears-frontx/telemetry` and `@gears-frontx/mfes`. Left consistent with them; `npm i @gears-frontx/ui-kit` without a tag will install the alpha until a stable is cut.
- The INTERIM dependency-cruiser rules (`frontx-ui-kit-interim-*`) stay: they govern imports, not publication, and remain until #495 approves the dependency policy.
- #503 (CJS declarations) does not apply to this package — its exports are ESM-only with no `require` condition.

## Verified

Green locally: `build:packages:ui-kit`, `npm pack --dry-run` (tarball: dist incl. `theme.css` + per-component `.d.ts`, `llms.txt`, README, LICENSE, NOTICE — 181 files, 102 kB), 253 unit tests, `type-check:packages:ui-kit` (+demo/tools), `lint` (incl. `lint:deps`), `test:consumer` (vite + esbuild barrel/subpath + webpack + types under `nodenext` and `bundler`), `arch:check` 12/12, `cfs validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The UI kit is now available for publication through the alpha release channel.
  - The alpha release includes 19 components.

- **Documentation**
  - Updated release guidance to clarify the distinction between alpha availability and the future stable release.
  - Documented the remaining requirements for the stable release, including completing the MVP component set and required approval and artifacts.

- **Chores**
  - Updated the package version to `0.3.0-alpha.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->