### PR TITLE
fix: repoint post-split config paths to real trees (#531)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,21 +30,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    # MFE packages under `src/mfe_packages/*` are NOT npm workspaces — each
-    # has its own lockfile because Module Federation runtimes load them as
-    # isolated apps. The root `npm ci` above does not install their deps, so
-    # `type-check:mfe` and MFE-scoped unit tests can't resolve third-party
-    # packages (@radix-ui, @tanstack/react-table, recharts, vaul, …) until
-    # each MFE is installed in place.
-    - name: Install MFE dependencies
-      run: |
-        for mfe in src/mfe_packages/*/; do
-          if [ -f "$mfe/package-lock.json" ]; then
-            echo "==> npm ci in $mfe"
-            (cd "$mfe" && npm ci)
-          fi
-        done
-
     # Consumer packages (framework, react, studio, cli) resolve workspace deps
     # via their sibling packages' `dist/` types. A fresh `npm ci` has no dist,
     # so `type-check:packages:*` fails to resolve `@gears-frontx/*` imports.

--- a/knip.json
+++ b/knip.json
@@ -3,11 +3,10 @@
   "workspaces": {
     ".": {
       "entry": [
-        "src/app/main.tsx",
-        "src/screensets/*/*[Ss]creenset.tsx"
+        "scripts/**/*.test.{mjs,ts}"
       ],
-      "project": ["src/**/*.{ts,tsx}"],
-      "ignore": ["src/screensets/_blank/**"]
+      "project": ["scripts/**/*.{ts,mjs}"],
+      "ignore": ["scripts/manual-auth-tests/**"]
     },
     "packages/cli": {
       "ignore": ["templates/**", "template-sources/**"]
@@ -20,20 +19,10 @@
     "**/node_modules/**",
     "**/templates/**",
     "**/template-sources/**",
-    "eslint-plugin-local/**",
-    "**/*.config.{ts,js,cjs,mjs}",
-    "vite.config.ts",
-    ".eslintrc.cjs"
-  ],
-  "ignoreDependencies": [
-    "@types/*",
-    "@gears-frontx/depcruise-config/*"
+    "**/*.config.{ts,js,cjs,mjs}"
   ],
   "ignoreBinaries": [
     "dot"
   ],
-  "ignoreExportsUsedInFile": true,
-  "ignoreIssues": {
-    "**/*Screen.tsx": ["duplicates"]
-  }
+  "ignoreExportsUsedInFile": true
 }


### PR DESCRIPTION
## Summary

Closes #531. Two config files still referenced the pre-split `src/` layout from before #470's split into `template-shell/` + `template-mfe/` (both now live under `src-app/`).

- **`.github/workflows/main.yml`** — removed the "Install MFE dependencies" step. Its `src/mfe_packages/*/` glob predates #470 and matches nothing at base or head. Independent of that dead glob: the `type-check:mfe` script the deleted comment cited lives only in `template-shell/package.json` now, not root's, and neither `template-mfe/src-app/mfe_packages/*` nor `template-shell/src-app/mfe_packages/*` carries a per-package `package-lock.json` — so even a correctly repointed loop's `-f package-lock.json` guard would skip every directory. Nothing in the root `validate` job installs or consumes MFE package deps today, so deleting the step is safe on `develop` as it stands — independent of #491's still-unmerged `template-validate` job (once merged, that job's per-template `npm ci` is where MFE deps actually get installed).
- **`knip.json`** — repointed the root workspace's `entry`/`project`/`ignore` globs from the removed `src/` tree to `scripts/**`, the only thing knip's root scope still owns post-split. Also dropped `ignoreDependencies` (`@types/*`, `@gears-frontx/depcruise-config/*`), the `ignoreIssues` entry for `*Screen.tsx`, and three dead global `ignore` globs (`eslint-plugin-local/**`, `vite.config.ts`, `.eslintrc.cjs`) naming removed `src/`-era paths/files.

Config-path fix only — no logic changes elsewhere.

## Verification

- `npm run arch:check` no longer prints the three "Refine entry pattern (no matches)" / "Refine project pattern (no matches)" / "Remove from ignoreDependencies" warnings — 12/12 checks pass.
- `npm run arch:unused`'s finding set (unused files/dependencies/devDependencies/exports) is byte-identical before and after the `knip.json` rewrite. Dropping `ignoreDependencies` does not surface `@gears-frontx/depcruise-config` (knip's dependency-cruiser plugin already resolves `packages/api/.dependency-cruiser.cjs`'s `require()` of it) or `@types/lodash` (unused either way) as a new finding.
- Confirmed no remaining `mfe_packages` references in `main.yml`.

## Out of scope

- Other configs at head with the same dead-glob pattern (`.codacy.yaml:41,85`, `eslint.config.js:445-446`) — flagged in review; left for a follow-up issue since #531 scoped itself to `main.yml` and `knip.json`.