### PR TITLE
feat(ui-kit): select dropdown placement, button colours, input slots, badge dot/icon

### DIFF
--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -34,6 +34,7 @@ import {
   RadioGroupItem,
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -63,6 +64,11 @@ const REGIONS = [
   { value: 'eu-west', label: 'Dublin' },
   { value: 'us-east', label: 'Virginia' },
 ];
+
+const HOURS = Array.from({ length: 24 }, (_, hour) => ({
+  value: String(hour),
+  label: `${String(hour).padStart(2, '0')}:00`,
+}));
 
 function LoadingDemo() {
   const [busy, setBusy] = useState(false);
@@ -185,6 +191,20 @@ export function ComponentsPage() {
                     {item.label}
                   </SelectItem>
                 ))}
+              </SelectContent>
+            </Select>
+            <Select defaultValue="18" items={HOURS}>
+              <SelectTrigger aria-label="Hour">
+                <SelectValue placeholder="Hour" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {HOURS.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
               </SelectContent>
             </Select>
           </Row>

--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -58,7 +58,7 @@ import {
   TooltipTrigger,
 } from '@gears-frontx/ui-kit';
 
-import { DemoIcon, Row, Section } from './shared';
+import { CloseIcon, DemoIcon, Row, Section } from './shared';
 
 const REGIONS = [
   { value: 'eu-central', label: 'Frankfurt' },
@@ -187,7 +187,7 @@ export function ComponentsPage() {
               onChange={(e) => setQuery(e.currentTarget.value)}
               placeholder="Search projects…"
               icon={<MagnifierIcon />}
-              end={<Button variant="ghost" size="sm" icon={<DemoIcon />} aria-label="Clear search" onClick={() => setQuery('')} />}
+              end={<Button variant="ghost" size="sm" icon={<CloseIcon />} aria-label="Clear search" onClick={() => setQuery('')} />}
             />
           </Field>
           <Field name="notes">

--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -140,19 +140,27 @@ export function ComponentsPage() {
           <Badge>muted</Badge>
         </Row>
         <Row>
-          <Badge variant="success" shape="dot">
+          <Badge variant="success" shape="plain" dot>
             success
           </Badge>
-          <Badge variant="warning" shape="dot">
+          <Badge variant="warning" shape="plain" dot>
             warning
           </Badge>
-          <Badge variant="info" shape="dot">
+          <Badge variant="info" shape="plain" dot>
             info
           </Badge>
-          <Badge variant="danger" shape="dot">
+          <Badge variant="danger" shape="plain" dot>
             danger
           </Badge>
-          <Badge shape="dot">muted</Badge>
+          <Badge shape="plain" dot>muted</Badge>
+        </Row>
+        <Row>
+          <Badge variant="success" dot>
+            with dot
+          </Badge>
+          <Badge variant="info" icon={<DemoIcon />}>
+            with icon
+          </Badge>
         </Row>
       </Section>
 
@@ -323,7 +331,7 @@ export function ComponentsPage() {
             <TableRow data-state="restricted">
               <TableCell>gears-vault (restricted)</TableCell>
               <TableCell>
-                <Badge shape="dot">no access</Badge>
+                <Badge shape="plain" dot>no access</Badge>
               </TableCell>
               <TableCell>—</TableCell>
             </TableRow>

--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -70,6 +70,15 @@ const HOURS = Array.from({ length: 24 }, (_, hour) => ({
   label: `${String(hour).padStart(2, '0')}:00`,
 }));
 
+function MagnifierIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function LoadingDemo() {
   const [busy, setBusy] = useState(false);
   return (
@@ -162,7 +171,12 @@ export function ComponentsPage() {
           </Field>
           <Field name="query">
             <FieldLabel>Search</FieldLabel>
-            <Input type="search" placeholder="Search projects…" />
+            <Input
+              type="search"
+              placeholder="Search projects…"
+              icon={<MagnifierIcon />}
+              end={<Button variant="ghost" size="sm" icon={<DemoIcon />} aria-label="Clear search" />}
+            />
           </Field>
           <Field name="notes">
             <FieldLabel>Notes</FieldLabel>

--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -96,6 +96,7 @@ function LoadingDemo() {
 }
 
 export function ComponentsPage() {
+  const [query, setQuery] = useState('');
   const [region, setRegion] = useState<string | null>(null);
   return (
     <>
@@ -181,9 +182,11 @@ export function ComponentsPage() {
             <FieldLabel>Search</FieldLabel>
             <Input
               type="search"
+              value={query}
+              onChange={(e) => setQuery(e.currentTarget.value)}
               placeholder="Search projects…"
               icon={<MagnifierIcon />}
-              end={<Button variant="ghost" size="sm" icon={<DemoIcon />} aria-label="Clear search" />}
+              end={<Button variant="ghost" size="sm" icon={<DemoIcon />} aria-label="Clear search" onClick={() => setQuery('')} />}
             />
           </Field>
           <Field name="notes">

--- a/packages/ui-kit/demo/components-page.tsx
+++ b/packages/ui-kit/demo/components-page.tsx
@@ -36,6 +36,7 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
   Skeleton,
@@ -224,6 +225,7 @@ export function ComponentsPage() {
               </SelectTrigger>
               <SelectContent>
                 <SelectGroup>
+                  <SelectLabel>Hours</SelectLabel>
                   {HOURS.map((item) => (
                     <SelectItem key={item.value} value={item.value}>
                       {item.label}

--- a/packages/ui-kit/demo/shared.tsx
+++ b/packages/ui-kit/demo/shared.tsx
@@ -45,3 +45,11 @@ export function DemoIcon() {
     </svg>
   );
 }
+
+export function CloseIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+      <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -259,27 +259,34 @@ Architecture's build bullet).
    instruction that a color failing WCAG gets a new color, not a "kept as
    drawn" footnote:
    - **Button focus rings** (every variant, both themes) now clear the
-     3:1 floor against both the fill and the page background — `default`
-     and `destructive` needed a genuinely two-toned ring (the geometry
-     already supported one: an outer border color plus a separately
-     colorable inset shadow), `outline` gave up on `--border-strong`
-     entirely and now falls back to the kit-wide `--ring`. Ratios as
-     measured (light/dark), with button.test.tsx recomputing them from
-     the live CSS on every run:
+     3:1 floor against the page background. Originally shipped two-toned
+     (an outer border color plus a separately colorable inset shadow,
+     because the ring was drawn ON the button's edge and so had two WCAG
+     neighbors — the page outside, the button's own fill inside) — revised
+     after ship because `--info` (the `default` variant's outer tone) is
+     cyan in dark mode and blue in light, a hue that appears nowhere else
+     near the violet button, and because two custom properties per variant
+     was more machinery than the fix needed. The ring now sits OUTSIDE the
+     button instead (`outline` + `outline-offset`, not a border recolor
+     plus inset shadow), so its only WCAG neighbor is ever the page
+     background and a single tone per variant is enough: `default` and
+     `destructive` get their own family color (new tokens
+     `--primary-ring`/`--destructive-ring`, since violet/red read better
+     against the page than the plain kit-wide ring does), everything else
+     (`outline`, `secondary`, `ghost`, `link`) falls through to the
+     kit-wide `--ring`. `outline` was already on `--ring`, unchanged by
+     this revision. Ratios as measured (light/dark), with button.test.tsx
+     recomputing them from the live CSS on every run:
 
-     | variant | outer tone vs page bg | inner tone vs fill |
-     |---|---|---|
-     | `default` | `--info` 3.91 / 10.89 | `--foreground` 3.79 / 4.86 |
-     | `destructive` | `--primary-hover` 4.98 / 4.18 | `--destructive-foreground` 4.70 / 4.62 |
-     | `secondary` | `--primary-hover` 4.98 / 4.18 | same tone vs `--secondary` 4.76 / 3.10 |
-     | `ghost`, `link` | `--primary-hover` 4.98 / 4.18 | no fill of their own — the page bg again |
-     | `outline` | `--ring` 4.05 / 3.78 | `--ring` vs `--surface-elevated` 4.23 / 3.40 |
+     | variant | ring tone vs page bg |
+     |---|---|
+     | `default` | `--primary-ring` 6.79 / 7.23 |
+     | `destructive` | `--destructive-ring` 6.01 / 7.89 |
+     | `outline`, `secondary`, `ghost`, `link` | `--ring` 4.05 / 3.78 |
 
-     `secondary`, `ghost` and `link` are single-tone: `--primary-hover`
-     alone clears 3:1 on both of their surfaces, so they set no inner
-     override. 3.10 (dark `secondary`, the ring against its own fill) is
-     the tightest number in the table and the one to watch if `--secondary`
-     or `--primary-hover` ever moves.
+     `outline`/`secondary`/`ghost`/`link` share one number because they all
+     resolve to the same `--ring` token; 3.78 (dark) is the tightest in the
+     table and the one to watch if `--ring` ever moves.
    - **`--subtle-foreground`** (the table header label): each mode's drawn
      value failed the 4.5:1 AA floor against the header's own `--surface`
      fill — light `#94a3b8` at 2.56:1, dark `#667085` at 3.74:1. Both

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -365,7 +365,7 @@ Architecture's build bullet).
      the kit is driven by `variant` (+ `size`, or the occasional real extra
      axis: Badge's `shape`, Table's `density`). `shape` rather than `size`
      because the values are pill vs. plain (dot is a separate opt-in flag,
-   orthogonal to shape) and Badge has no size axis;
+     orthogonal to shape) and Badge has no size axis;
      not `form`, which is a real HTML attribute a styling prop would shadow
      for anyone rendering a form-associated element via `render`.
    - Four new tokens: `--link-foreground` (Button's `link` variant text),

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -223,11 +223,14 @@ Architecture's build bullet).
    "Studio / shadcn" variable collection. Landed: theme.css carries the
    palette and the new token groups (see Architecture's theme bullet), and
    the existing components follow the mockups' component specs — Badge on
-   semantic intents (pill/dot; the shadcn variant list retired), Button's
+   semantic intents (`pill`/`plain` shapes, with `dot` and `icon` both
+   opt-in; the shadcn variant list retired), Button's
    `icon` slot + auto icon-only + `loading`, Tabs on the trackless Kind=tab
    look (the spec's Kind=segment is the planned `toggle-group`'s styling,
    per the design file's own component description), the unified Field set
-   for Input/Textarea/Select with the `search` and `filter` types, Table
+   for Input/Textarea/Select with the `filter` type (Select's compact
+   toolbar chip) and `search`'s native searchbox role (no automatic icon;
+   pass one via `icon`), Table
    density + selected/stale/restricted row hooks, and component CSS on the
    metric tokens. The drawn-vs-spec control-height discrepancy was ruled
    in favor of the drawn specimens (32/36/40; buttons map sm/default/lg
@@ -361,7 +364,8 @@ Architecture's build bullet).
      than by an axis name only this component used, so every component in
      the kit is driven by `variant` (+ `size`, or the occasional real extra
      axis: Badge's `shape`, Table's `density`). `shape` rather than `size`
-     because the values are pill vs. bare dot and Badge has no size axis;
+     because the values are pill vs. plain (dot is a separate opt-in flag,
+   orthogonal to shape) and Badge has no size axis;
      not `form`, which is a real HTML attribute a styling prop would shadow
      for anyone rendering a form-associated element via `render`.
    - Four new tokens: `--link-foreground` (Button's `link` variant text),

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -56,7 +56,7 @@ Rules for generated code:
 ## Components
 
 - [Badge](dist/docs/badge.md): status label, an intent-colored caption with
-  an opt-in status dot (`dot`) or a leading `icon` render prop (icon wins
+  an opt-in status dot (`dot`) or a leading `icon` slot prop (icon wins
   when both are given; default is neither); variants
   success|warning|info|danger|muted (semantic states ONLY — pick by meaning,
   never by color; neutral/count/category = muted), shapes pill|plain (pill

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -55,19 +55,23 @@ Rules for generated code:
 
 ## Components
 
-- [Badge](dist/docs/badge.md): status label, a colored dot + matching
-  caption; variants success|warning|info|danger|muted (semantic states ONLY
-  — pick by meaning, never by color; neutral/count/category = muted), shapes
-  pill|dot (pill adds a soft fill; dot is the bare pair for dense/inline
-  spots); no Base UI primitive; `render` (e.g. `<a>`) makes it a clickable
-  tag — hover feedback only appears once it is.
+- [Badge](dist/docs/badge.md): status label, an intent-colored caption with
+  an opt-in status dot (`dot`) or a leading `icon` render prop (icon wins
+  when both are given; default is neither); variants
+  success|warning|info|danger|muted (semantic states ONLY — pick by meaning,
+  never by color; neutral/count/category = muted), shapes pill|plain (pill
+  adds a soft fill; plain is the bare label for dense/inline spots); no
+  Base UI primitive; `render` (e.g. `<a>`) makes it a clickable tag — hover
+  feedback only appears once it is.
 - [Button](dist/docs/button.md): action button; variants
-  default|destructive|outline|secondary|ghost|link, sizes default|sm|lg;
-  icons go in the `icon` slot prop, NEVER in children — `icon` with no
-  children makes a square icon-only button (always pass `aria-label`
-  then); `loading` spins, disables, and keeps the width and accessible
-  name; render prop for button-semantic actions over a real anchor (not
-  a link substitute).
+  default|destructive|outline|secondary|ghost|link, sizes default|sm|lg; a
+  consumer className can recolor a button in every state via
+  `--button-bg`/`--button-fg`/`--button-bg-hover`/`--button-fg-hover`/
+  `--button-border` — no new variant needed; icons go in the `icon` slot
+  prop, NEVER in children — `icon` with no children makes a square
+  icon-only button (always pass `aria-label` then); `loading` spins,
+  disables, and keeps the width and accessible name; render prop for
+  button-semantic actions over a real anchor (not a link substitute).
 - [Card](dist/docs/card.md): bounded content surface (Card/CardHeader/
   CardTitle/CardDescription/CardAction/CardContent/CardFooter); header
   becomes a two-column/two-row grid automatically when it contains a
@@ -91,9 +95,12 @@ Rules for generated code:
   aria-describedby, and validation display automatically — the default
   way to build forms.
 - [Input](dist/docs/input.md): single-line text field; `onValueChange`
-  for the string value, `aria-invalid` for the error state;
-  `type="search"` renders the leading magnifier and announces as a
-  searchbox — no extra prop; wires into Field automatically.
+  for the string value, `aria-invalid` for the error state; `icon` for a
+  leading decorative icon, `end` for trailing interactive content (e.g. a
+  clear button; rendered after the input, so tab order is field → slot) —
+  neither renders automatically; `type="search"` gives the searchbox role
+  but no icon by itself — pass one via `icon`; wires into Field
+  automatically.
 - [Label](dist/docs/label.md): caption for a form control; native
   `<label>` props; associate via `htmlFor` or by nesting the control.
 - [RadioGroup](dist/docs/radio-group.md): mutually exclusive options
@@ -102,8 +109,10 @@ Rules for generated code:
 - [Select](dist/docs/select.md): dropdown picking one value from a
   list (Select/SelectTrigger/SelectValue/SelectContent/SelectGroup/
   SelectItem); trigger sizes default|sm, trigger variants default|filter
-  (filter = compact toolbar filter chip, label stays muted); keyboard
-  and typeahead built in.
+  (filter = compact toolbar filter chip, label stays muted); the popup
+  always opens below the trigger (never overlays it), scrolling a selected
+  item into view when it sits beyond the fold; keyboard and typeahead
+  built in.
 - [Separator](dist/docs/separator.md): thin visual divider between content
   sections; orientation horizontal|vertical (default horizontal); no
   `decorative` prop — pass `aria-hidden="true"` for a purely visual

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/ui-kit/src/components/badge/badge.md
+++ b/packages/ui-kit/src/components/badge/badge.md
@@ -1,7 +1,7 @@
 # Badge
 
-A status label: a colored dot plus an intent-colored caption, as a soft
-pill or a bare dot+label pair. Badge has no Base UI primitive — it's a
+A status label: an intent-colored caption with an optional status dot or
+icon, as a soft pill or a bare label. Badge has no Base UI primitive — it's a
 styled `span`, plus a `render` prop (via Base UI's `useRender`/`mergeProps`
 utilities) for the one case that needs it: rendering as a link.
 
@@ -19,10 +19,11 @@ orange is a misuse, not a style choice.
   `beta`/`new` → `info`, anything neutral (`draft`, `archived`, a count,
   a category) → `muted`.
 - `shape="pill"` (default) on busy surfaces where the label needs its own
-  soft fill; `shape="dot"` inline with text or in dense tables where a fill
-  would be noise — same dot and label, no pill behind them.
+  soft fill; `shape="plain"` inline with text or in dense tables where a
+  fill would be noise. Add `dot` when the state deserves a colored marker,
+  or pass `icon` for a more specific one — neither renders by default.
 - A clickable status filter — pass `render={<a href="..." />}`. The pill's
-  fill deepens on hover and the dot shape underlines, but only when actually
+  fill deepens on hover and the plain shape underlines, but only when actually
   rendered as a link; a plain badge stays visually inert and never looks
   clickable when it isn't. The kit's focus ring appears automatically once
   the anchor receives keyboard focus. Give it discernible text — a badge
@@ -41,7 +42,9 @@ orange is a misuse, not a style choice.
 | Prop | Type | Default |
 |------|------|---------|
 | `variant` | `success` \| `warning` \| `info` \| `danger` \| `muted` | `muted` |
-| `shape` | `pill` \| `dot` | `pill` |
+| `shape` | `pill` \| `plain` | `pill` |
+| `dot` | `boolean` — show the status dot in the variant's accent color; ignored when `icon` is set | `false` |
+| `icon` | `ReactNode` — leading icon, decorative (`aria-hidden`), 12px, accent-colored; replaces the dot | — |
 | `render` | `ReactElement` — replaces the root `span`, e.g. with an `<a>` | — |
 | `className` | `string` — merged after the variant/shape classes | — |
 
@@ -61,8 +64,14 @@ import { Badge } from '@gears-frontx/ui-kit';
 <Badge variant="info">Beta</Badge>
 <Badge>Draft</Badge>  // muted is the default variant
 
-// Bare dot+label for dense/inline placements
-<Badge variant="success" shape="dot">Online</Badge>
+// Status dot is opt-in
+<Badge variant="success" dot>Running</Badge>
+
+// Bare label for dense/inline placements (dot optional there too)
+<Badge variant="success" shape="plain" dot>Online</Badge>
+
+// A custom marker instead of the dot
+<Badge variant="info" icon={<BetaIcon />}>Beta</Badge>
 
 // A badge that is actually a link — hover feedback only applies here
 <Badge variant="info" render={<a href="/filters/open" />}>
@@ -80,3 +89,5 @@ import { Badge } from '@gears-frontx/ui-kit';
   appears when the badge actually renders as a link via `render`.
 - Do not nest interactive controls inside a Badge — it is a label, not a
   container.
+- Do not pass both `icon` and `dot` expecting both to render — `icon`
+  replaces the dot by design.

--- a/packages/ui-kit/src/components/badge/badge.md
+++ b/packages/ui-kit/src/components/badge/badge.md
@@ -91,3 +91,6 @@ import { Badge } from '@gears-frontx/ui-kit';
   container.
 - Do not pass both `icon` and `dot` expecting both to render — `icon`
   replaces the dot by design.
+- Do not drop an icon into Badge's children (`<Badge><Icon />label</Badge>`)
+  — the kit no longer sizes a bare svg child; use the `icon` prop, which is
+  sized and accent-colored automatically.

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -1,7 +1,8 @@
 /*
  * Badge styles — the F-mockups' Badge/Status design (Figma frame 196:397):
- * a colored status dot plus an intent-colored label, as a soft pill or a
- * bare dot+label. Replaces the shadcn-translated variant set; the focus
+ * an intent-colored label, as a soft pill or a bare label, with an
+ * opt-in status dot (`dot` prop) or leading icon (`icon` slot) in front of
+ * it. Replaces the shadcn-translated variant set; the focus
  * ring/forced-colors/aria-invalid plumbing carries over from that
  * translation. Consumes only theme.css variables — no raw colors.
  *

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -59,13 +59,14 @@
 }
 
 /*
- * The status dot, drawn in both forms (the pill is dot+label on a fill, the
- * dot form is the same pair bare). Pure decoration duplicating the label's
- * intent color, which is why the dot itself is not held to the 3:1 non-text
+ * The status dot, drawn in both shapes when opted in via the `dot` prop
+ * (badge.tsx derives data-dot from dot/icon: the icon slot, when present,
+ * takes the dot's place). Pure decoration duplicating the label's intent
+ * color, which is why the dot itself is not held to the 3:1 non-text
  * floor (light warning's dot alone measures 2.84:1) — the AA-checked label
  * carries the information.
  */
-.badge::before {
+.badge[data-dot]::before {
   content: '';
   flex-shrink: 0;
   width: 0.375rem;
@@ -99,11 +100,18 @@
 }
 
 /*
- * A consumer-supplied icon child sits inline with the label at a fixed size,
- * matching the old registry behavior (no icon dependency of our own).
+ * The icon slot (badge.tsx renders it only when `icon` is passed) sits
+ * where the dot would, fixed at 12px, painted in the same accent the dot
+ * uses — it replaces the dot, so it speaks the same intent color.
  */
-.badge > svg {
+.badge .icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--badge-accent);
   pointer-events: none;
+}
+
+.badge .icon svg {
   width: 0.75rem;
   height: 0.75rem;
 }
@@ -158,7 +166,7 @@
   padding: 0 var(--space-2);
 }
 
-.badge.shapeDot {
+.badge.shapePlain {
   background-color: transparent;
   padding: 0;
 }
@@ -166,14 +174,14 @@
 /*
  * A badge only reads as interactive once it actually renders as a link via
  * `render` (same tag-gated idiom as the old translation): the pill's tint
- * deepens a step. The bare dot form gets underline instead — it has no fill
+ * deepens a step. The plain form gets underline instead — it has no fill
  * to deepen.
  */
 a.badge.shapePill:hover {
   background-color: color-mix(in oklab, var(--foreground) 9%, transparent);
 }
 
-a.badge.shapeDot:hover {
+a.badge.shapePlain:hover {
   text-decoration: underline;
   text-underline-offset: 4px;
 }

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -113,8 +113,8 @@
 }
 
 .badge .icon svg {
-  width: 0.75rem;
-  height: 0.75rem;
+  width: var(--icon-size-xs);
+  height: var(--icon-size-xs);
 }
 
 /*

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -85,7 +85,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .badge:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/badge/badge.test.tsx
+++ b/packages/ui-kit/src/components/badge/badge.test.tsx
@@ -72,6 +72,21 @@ describe('Badge', () => {
     expect(screen.getByTestId('both-icon')).toBeTruthy();
   });
 
+  it('treats a false icon as absent, keeping the dot and rendering no icon span', () => {
+    // `icon={cond && <Icon/>}` with cond=false passes `false` — a valid
+    // ReactNode that renders nothing, but `icon != null` alone reads it as
+    // present. That both suppressed the dot and rendered an empty icon
+    // wrapper; see hasIcon in badge.tsx.
+    render(
+      <Badge variant="success" dot icon={false}>
+        Running
+      </Badge>,
+    );
+    const badge = screen.getByText('Running');
+    expect(badge.getAttribute('data-dot')).toBe('true');
+    expect(badge.querySelector(`.${styles.icon}`)).toBeNull();
+  });
+
   it('lets its own derived data-dot win over a conflicting prop of the same name', () => {
     // A caller passing a literal data-dot that disagrees with the derived
     // value must not shadow it — same shadow-proofing as Button's

--- a/packages/ui-kit/src/components/badge/badge.test.tsx
+++ b/packages/ui-kit/src/components/badge/badge.test.tsx
@@ -14,6 +14,9 @@ describe('Badge', () => {
     expect(badge.className).toContain(styles.badge);
     expect(badge.className).toContain(styles.variantMuted);
     expect(badge.className).toContain(styles.shapePill);
+    // Neither dot nor icon by default.
+    expect(badge.hasAttribute('data-dot')).toBe(false);
+    expect(badge.querySelector('svg')).toBeNull();
   });
 
   it.each([
@@ -27,15 +30,46 @@ describe('Badge', () => {
     expect(screen.getByText('Label').className).toContain(variantClass);
   });
 
-  it('applies the dot shape class', () => {
+  it('applies the plain shape class', () => {
     render(
-      <Badge variant="success" shape="dot">
+      <Badge variant="success" shape="plain">
         Online
       </Badge>,
     );
     const badge = screen.getByText('Online');
-    expect(badge.className).toContain(styles.shapeDot);
+    expect(badge.className).toContain(styles.shapePlain);
     expect(badge.className).not.toContain(styles.shapePill);
+  });
+
+  it('renders the dot only when asked', () => {
+    render(
+      <Badge variant="success" dot>
+        Running
+      </Badge>,
+    );
+    expect(screen.getByText('Running').getAttribute('data-dot')).toBe('true');
+  });
+
+  it('renders the icon slot as decorative content', () => {
+    render(
+      <Badge variant="info" icon={<svg data-testid="beta-icon" />}>
+        Beta
+      </Badge>,
+    );
+    const slot = screen.getByTestId('beta-icon').parentElement;
+    expect(slot).toHaveProperty('tagName', 'SPAN');
+    expect(slot?.className).toContain(styles.icon);
+    expect(slot?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('resolves icon over dot when both are passed', () => {
+    render(
+      <Badge variant="success" dot icon={<svg data-testid="both-icon" />}>
+        Up
+      </Badge>,
+    );
+    expect(screen.getByText('Up').hasAttribute('data-dot')).toBe(false);
+    expect(screen.getByTestId('both-icon')).toBeTruthy();
   });
 
   it('merges a consumer className without dropping the kit class', () => {
@@ -47,13 +81,15 @@ describe('Badge', () => {
 
   it('does not leak the variant or shape props to the DOM as attributes', () => {
     render(
-      <Badge variant="info" shape="dot">
+      <Badge variant="info" shape="plain" dot icon={<svg />}>
         Tag
       </Badge>,
     );
     const badge = screen.getByText('Tag');
     expect(badge.hasAttribute('variant')).toBe(false);
     expect(badge.hasAttribute('shape')).toBe(false);
+    expect(badge.hasAttribute('dot')).toBe(false);
+    expect(badge.hasAttribute('icon')).toBe(false);
   });
 
   it('forwards native span props such as data-testid', () => {

--- a/packages/ui-kit/src/components/badge/badge.test.tsx
+++ b/packages/ui-kit/src/components/badge/badge.test.tsx
@@ -72,6 +72,28 @@ describe('Badge', () => {
     expect(screen.getByTestId('both-icon')).toBeTruthy();
   });
 
+  it('lets its own derived data-dot win over a conflicting prop of the same name', () => {
+    // A caller passing a literal data-dot that disagrees with the derived
+    // value must not shadow it — same shadow-proofing as Button's
+    // data-loading (see button.test.tsx).
+    render(
+      <Badge variant="success" dot data-dot="literal">
+        Running
+      </Badge>,
+    );
+    expect(screen.getByText('Running').getAttribute('data-dot')).toBe('true');
+  });
+
+  it('keeps data-dot absent when icon wins over dot, even with a caller-supplied data-dot', () => {
+    render(
+      <Badge variant="success" dot icon={<svg data-testid="icon-wins" />} data-dot="literal">
+        Up
+      </Badge>,
+    );
+    expect(screen.getByText('Up').hasAttribute('data-dot')).toBe(false);
+    expect(screen.getByTestId('icon-wins')).toBeTruthy();
+  });
+
   it('merges a consumer className without dropping the kit class', () => {
     render(<Badge className="consumer">Tag</Badge>);
     const badge = screen.getByText('Tag');

--- a/packages/ui-kit/src/components/badge/badge.tsx
+++ b/packages/ui-kit/src/components/badge/badge.tsx
@@ -1,6 +1,7 @@
 import { mergeProps } from '@base-ui/react/merge-props';
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
+import type { ReactNode } from 'react';
 
 import styles from './badge.module.css';
 
@@ -18,11 +19,12 @@ import styles from './badge.module.css';
  * itself keeps the kit-wide `variant` name rather than an axis name of its
  * own, so every component in the kit is driven the same way.
  *
- * `shape`, not `size`: the two values are pill vs. bare dot, and Badge has
- * no size axis at all (the pill is a fixed 24px). Not `form` either — that
- * is a real HTML attribute, so a styling prop by that name would shadow it
- * for anyone rendering a form-associated element via `render`. Both shapes
- * carry the colored dot; `pill` adds the fill behind it.
+ * `shape`, not `size`: the two values are pill vs. plain (bare text, no
+ * fill), and Badge has no size axis at all (the pill is a fixed 24px).
+ * Not `form` either — that is a real HTML attribute, so a styling prop by
+ * that name would shadow it for anyone rendering a form-associated element
+ * via `render`. The status dot and the icon slot are opt-in props, not
+ * shape values — both shapes can carry either.
  */
 const badgeVariants = cva(styles.badge, {
   variants: {
@@ -35,7 +37,7 @@ const badgeVariants = cva(styles.badge, {
     },
     shape: {
       pill: styles.shapePill,
-      dot: styles.shapeDot,
+      plain: styles.shapePlain,
     },
   },
   defaultVariants: {
@@ -45,12 +47,46 @@ const badgeVariants = cva(styles.badge, {
 });
 
 export interface BadgeProps
-  extends useRender.ComponentProps<'span'>, VariantProps<typeof badgeVariants> {}
+  extends useRender.ComponentProps<'span'>, VariantProps<typeof badgeVariants> {
+  /**
+   * Show the status dot, painted in the variant's accent color. Off by
+   * default; ignored when `icon` is present — the icon takes its place.
+   */
+  dot?: boolean;
+  /**
+   * Leading icon slot — decorative (`aria-hidden`), fixed 12px, painted in
+   * the variant's accent color like the dot it replaces. Wins over `dot`
+   * when both are set.
+   */
+  icon?: ReactNode;
+}
 
-export function Badge({ className, variant, shape, render, ...props }: BadgeProps) {
+export function Badge({ className, variant, shape, dot, icon, render, children, ...props }: BadgeProps) {
   return useRender({
     defaultTagName: 'span',
     render,
-    props: mergeProps<'span'>({ className: badgeVariants({ variant, shape, className }) }, props),
+    /*
+     * The derived attribute and the composed children are layered on top of
+     * the merged props, NOT passed through mergeProps: they must win over a
+     * caller's own `data-dot` (same shadow-proofing as Button's
+     * `data-loading`), and mergeProps types its arguments as the closed DOM
+     * attribute set, which rejects a `data-*` key in an object literal.
+     * `useRender`'s own `props` takes `Record<string, unknown>`, so the
+     * spread below type-checks while keeping the ordering that matters.
+     */
+    props: {
+      ...mergeProps<'span'>({ className: badgeVariants({ variant, shape, className }) }, props),
+      'data-dot': (dot && icon == null) || undefined,
+      children: (
+        <>
+          {icon != null && (
+            <span className={styles.icon} aria-hidden="true">
+              {icon}
+            </span>
+          )}
+          {children}
+        </>
+      ),
+    },
   });
 }

--- a/packages/ui-kit/src/components/badge/badge.tsx
+++ b/packages/ui-kit/src/components/badge/badge.tsx
@@ -1,7 +1,7 @@
 import { mergeProps } from '@base-ui/react/merge-props';
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 
 import styles from './badge.module.css';
 
@@ -62,6 +62,12 @@ export interface BadgeProps
 }
 
 export function Badge({ className, variant, shape, dot, icon, render, children, ...props }: BadgeProps) {
+  // `icon != null` is true for `icon={false}` — a valid ReactNode that
+  // renders nothing — which is exactly what `icon={cond && <Icon/>}` passes
+  // when `cond` is false. Same predicate as Button's `hasLabel`, applied to
+  // a slot instead of children: it answers "is this renderable" rather than
+  // "is this set".
+  const hasIcon = Children.toArray(icon).some((child) => child !== '');
   return useRender({
     defaultTagName: 'span',
     render,
@@ -76,10 +82,10 @@ export function Badge({ className, variant, shape, dot, icon, render, children, 
      */
     props: {
       ...mergeProps<'span'>({ className: badgeVariants({ variant, shape, className }) }, props),
-      'data-dot': (dot && icon == null) || undefined,
+      'data-dot': (dot && !hasIcon) || undefined,
       children: (
         <>
-          {icon != null && (
+          {hasIcon && (
             <span className={styles.icon} aria-hidden="true">
               {icon}
             </span>

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -48,7 +48,7 @@ brand/status button is a consumer class away — no new variant needed:
 | `--button-border` | border color on every variant (transparent by default outside `outline`) |
 
 ```css
-.buy { --button-bg: var(--success); --button-bg-hover: color-mix(in oklab, var(--success) 90%, var(--foreground) 10%); --button-fg: #fff; }
+.buy { --button-bg: var(--success); --button-bg-hover: color-mix(in oklab, var(--success) 90%, var(--foreground) 10%); --button-fg: var(--primary-foreground); }
 ```
 
 ```tsx
@@ -63,6 +63,14 @@ for its own variants, and give the focus ring the same care via
 `--button-focus-ring` (see Anti-patterns) — it is drawn outside the button
 as an `outline`, so only one tone is needed; it only ever borders the page
 background, never your custom fill.
+
+These properties are inherited custom properties and `.button` never resets
+them, so where you set them matters: on the button's own class (`.buy`
+above) it recolors that one button; on a container it themes every Button
+underneath, including ones you didn't mean to touch — a clear button
+sitting in an Input's `end` slot inside that container, for instance. Use
+container-level scoping deliberately, or scope to the button itself to
+avoid the surprise.
 
 Icon-only is derived, not a size: `icon` with no children renders a square
 button of the current `size`. There is no `size="icon"`.

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -45,7 +45,7 @@ brand/status button is a consumer class away — no new variant needed:
 |----------|--------|
 | `--button-bg` / `--button-fg` | fill / text at rest |
 | `--button-bg-hover` / `--button-fg-hover` | fill / text on hover |
-| `--button-border` | border color (visible on `outline`; transparent elsewhere) |
+| `--button-border` | border color on every variant (transparent by default outside `outline`) |
 
 ```css
 .buy { --button-bg: var(--success); --button-bg-hover: color-mix(in oklab, var(--success) 90%, var(--foreground) 10%); --button-fg: #fff; }

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -60,7 +60,9 @@ Setting only `--button-bg` keeps the button that color in EVERY state
 add `--button-bg-hover` to restore hover feedback. Contrast is yours to
 keep once you override: check your pairs against WCAG like the kit does
 for its own variants, and give the focus ring the same care via
-`--button-focus-ring`/`--button-focus-ring-inner` (see Anti-patterns).
+`--button-focus-ring` (see Anti-patterns) — it is drawn outside the button
+as an `outline`, so only one tone is needed; it only ever borders the page
+background, never your custom fill.
 
 Icon-only is derived, not a size: `icon` with no children renders a square
 button of the current `size`. There is no `size="icon"`.
@@ -112,13 +114,10 @@ import { Button } from '@gears-frontx/ui-kit';
 - Do not restyle via inline `style` or ad-hoc CSS rules against the kit's
   classes — kit-wide brand changes belong in the theme tokens (`theme.css`
   CSS variables), one-off button colors in the `--button-*` properties
-  above. If you rebrand the focus
-  ring specifically via `--button-focus-ring`, note that the `default` and
-  `destructive` variants also set an explicit `--button-focus-ring-inner`
-  of their own (a two-tone ring, needed to clear WCAG contrast against
-  their own fill) — overriding only `--button-focus-ring` on those two
-  leaves the old inner color in place instead of following it; set both
-  properties together when rebranding either variant's ring.
+  above. If you rebrand the focus ring specifically via
+  `--button-focus-ring`, check your color against WCAG 1.4.11's 3:1 floor
+  on `--background` — the only surface the ring touches, since it is drawn
+  outside the button as an `outline` rather than on its edge.
 - Do not put an icon in `children` next to text — it lands in the `icon`
   slot, which is what sizes it, spaces it, hides it during `loading`, and
   keeps it out of the accessible name.

--- a/packages/ui-kit/src/components/button/button.md
+++ b/packages/ui-kit/src/components/button/button.md
@@ -36,6 +36,32 @@ polymorphism, correct disabled/focus behavior, `type="button"` by default
 All other props are native `<button>` props (`onClick`, `disabled`, `type`,
 `aria-*`, ...) and are forwarded as-is.
 
+## Custom colors
+
+Variant colors are consumed through CSS custom properties, so a one-off
+brand/status button is a consumer class away — no new variant needed:
+
+| Property | Drives |
+|----------|--------|
+| `--button-bg` / `--button-fg` | fill / text at rest |
+| `--button-bg-hover` / `--button-fg-hover` | fill / text on hover |
+| `--button-border` | border color (visible on `outline`; transparent elsewhere) |
+
+```css
+.buy { --button-bg: var(--success); --button-bg-hover: color-mix(in oklab, var(--success) 90%, var(--foreground) 10%); --button-fg: #fff; }
+```
+
+```tsx
+<Button className={styles.buy}>Buy now</Button>
+```
+
+Setting only `--button-bg` keeps the button that color in EVERY state
+(hover falls back to your rest color, never back to the variant's token);
+add `--button-bg-hover` to restore hover feedback. Contrast is yours to
+keep once you override: check your pairs against WCAG like the kit does
+for its own variants, and give the focus ring the same care via
+`--button-focus-ring`/`--button-focus-ring-inner` (see Anti-patterns).
+
 Icon-only is derived, not a size: `icon` with no children renders a square
 button of the current `size`. There is no `size="icon"`.
 
@@ -83,8 +109,10 @@ import { Button } from '@gears-frontx/ui-kit';
 
 ## Anti-patterns
 
-- Do not restyle via inline `style` or ad-hoc CSS — brand changes belong in
-  the theme tokens (`theme.css` CSS variables). If you rebrand the focus
+- Do not restyle via inline `style` or ad-hoc CSS rules against the kit's
+  classes — kit-wide brand changes belong in the theme tokens (`theme.css`
+  CSS variables), one-off button colors in the `--button-*` properties
+  above. If you rebrand the focus
   ring specifically via `--button-focus-ring`, note that the `default` and
   `destructive` variants also set an explicit `--button-focus-ring-inner`
   of their own (a two-tone ring, needed to clear WCAG contrast against

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -32,6 +32,14 @@
    * genuinely two-toned. --button-focus-ring-inner defaults to the outer
    * value so a variant that only sets --button-focus-ring still gets one
    * matching color both places.
+   *
+   * The --button-bg/--button-fg/--button-border{,-hover} family below works
+   * the same way: consumer-override hooks that no kit rule ever declares —
+   * each variant CONSUMES them with its own token as the var() fallback, so
+   * a consumer class that sets them recolors the button without fighting
+   * the cascade, and hover falls back to the consumer's rest color (not the
+   * variant's token) via the var(--button-bg-hover, var(--button-bg, ...))
+   * chain. See button.md's "Custom colors".
    */
   --button-focus-ring: var(--ring);
   --button-focus-ring-inner: var(--button-focus-ring);
@@ -42,7 +50,7 @@
   justify-content: center;
   gap: var(--space-2);
   white-space: nowrap;
-  border: var(--border-width) solid transparent;
+  border: var(--border-width) solid var(--button-border, transparent);
   border-radius: var(--radius-md);
   font-family: inherit;
   /* The drawn buttons (frame 182:371) are BOUND to the Studio/Label text
@@ -117,8 +125,8 @@
 }
 
 .variantDefault {
-  background-color: var(--primary);
-  color: var(--primary-foreground);
+  background-color: var(--button-bg, var(--primary));
+  color: var(--button-fg, var(--primary-foreground));
 }
 
 /*
@@ -128,12 +136,13 @@
  * the fill stays fully opaque instead of letting the page tint through.
  */
 .variantDefault:hover {
-  background-color: var(--primary-hover);
+  background-color: var(--button-bg-hover, var(--button-bg, var(--primary-hover)));
+  color: var(--button-fg-hover, var(--button-fg, var(--primary-foreground)));
 }
 
 .variantDestructive {
-  background-color: var(--destructive);
-  color: var(--destructive-foreground);
+  background-color: var(--button-bg, var(--destructive));
+  color: var(--button-fg, var(--destructive-foreground));
 }
 
 /*
@@ -147,7 +156,8 @@
  * badge.module.css's destructive variant.
  */
 .variantDestructive:hover {
-  background-color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  background-color: var(--button-bg-hover, var(--button-bg, color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%)));
+  color: var(--button-fg-hover, var(--button-fg, var(--destructive-foreground)));
 }
 
 /*
@@ -157,23 +167,24 @@
  * border the shadcn translation started from.
  */
 .variantOutline {
-  border-color: var(--border-strong);
-  background-color: var(--surface-elevated);
-  color: var(--foreground);
+  border-color: var(--button-border, var(--border-strong));
+  background-color: var(--button-bg, var(--surface-elevated));
+  color: var(--button-fg, var(--foreground));
 }
 
 .variantOutline:hover {
-  background-color: var(--accent);
-  color: var(--accent-foreground);
+  background-color: var(--button-bg-hover, var(--button-bg, var(--accent)));
+  color: var(--button-fg-hover, var(--button-fg, var(--accent-foreground)));
 }
 
 .variantSecondary {
-  background-color: var(--secondary);
-  color: var(--secondary-foreground);
+  background-color: var(--button-bg, var(--secondary));
+  color: var(--button-fg, var(--secondary-foreground));
 }
 
 .variantSecondary:hover {
-  background-color: color-mix(in oklab, var(--secondary) 80%, transparent);
+  background-color: var(--button-bg-hover, var(--button-bg, color-mix(in oklab, var(--secondary) 80%, transparent)));
+  color: var(--button-fg-hover, var(--button-fg, var(--secondary-foreground)));
 }
 
 /*
@@ -184,13 +195,13 @@
  * 13px label text, so the alignment carries no WCAG cost.
  */
 .variantGhost {
-  background-color: transparent;
-  color: var(--muted-foreground);
+  background-color: var(--button-bg, transparent);
+  color: var(--button-fg, var(--muted-foreground));
 }
 
 .variantGhost:hover {
-  background-color: var(--accent);
-  color: var(--accent-foreground);
+  background-color: var(--button-bg-hover, var(--button-bg, var(--accent)));
+  color: var(--button-fg-hover, var(--button-fg, var(--accent-foreground)));
 }
 
 /*
@@ -204,12 +215,14 @@
  * theme.css).
  */
 .variantLink {
-  background-color: transparent;
-  color: var(--link-foreground);
+  background-color: var(--button-bg, transparent);
+  color: var(--button-fg, var(--link-foreground));
   text-underline-offset: 4px;
 }
 
 .variantLink:hover {
+  background-color: var(--button-bg-hover, var(--button-bg, transparent));
+  color: var(--button-fg-hover, var(--button-fg, var(--link-foreground)));
   text-decoration: underline;
 }
 

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -20,18 +20,14 @@
    */
   box-sizing: border-box;
   /*
-   * Focus ring colors; the variants below override one or both (see
-   * :focus-visible). Two custom properties, not one: the ring is drawn as
-   * an outer 1px border plus an inner 1px inset shadow (see the geometry
-   * comment below), and those two painted pixels have different WCAG
-   * neighbors — the border sits against the page background outside the
-   * button, the inset shadow sits against the button's own fill just
-   * inside it. A single hue clears both for outline/secondary/ghost/link,
-   * but default and destructive's fills sit too close in luminance to any
-   * one drawn accent color to pass on that side too, so those two are
-   * genuinely two-toned. --button-focus-ring-inner defaults to the outer
-   * value so a variant that only sets --button-focus-ring still gets one
-   * matching color both places.
+   * Focus ring color; the variants below override it (see :focus-visible).
+   * One custom property is enough because the ring is drawn OUTSIDE the
+   * button (`outline` + `outline-offset`, see :focus-visible below), so
+   * its only WCAG neighbor is ever the page background — there is no
+   * second, fill-side surface a second tone would need to also clear.
+   * default and destructive still get their own family color (set below);
+   * everything else falls through to this kit-wide --ring, same as every
+   * non-Button control.
    *
    * The --button-bg/--button-fg/--button-border{,-hover} family below works
    * the same way: consumer-override hooks that no kit rule ever declares —
@@ -42,7 +38,6 @@
    * chain. See button.md's "Custom colors".
    */
   --button-focus-ring: var(--ring);
-  --button-focus-ring-inner: var(--button-focus-ring);
   /* Anchors the absolutely-centered .spinner. */
   position: relative;
   display: inline-flex;
@@ -73,20 +68,21 @@
 }
 
 /*
- * Focus per the mockups' drawn state matrices (frames 184:413/191:406): a
- * 2px border in a color that contrasts the variant's fill — no translucent
- * halo. NOT implemented as an actual border-width switch: a button's width
- * is content-driven, so growing the border grows the button and shifts its
- * label sideways on every focus/blur. Instead the 1px border recolors and
- * an inset ring supplies the remaining thickness — same drawn 2px, zero
- * geometry change. The per-variant color arrives via --button-focus-ring
- * (set on .button below, overridden by the variants).
+ * The ring is drawn OUTSIDE the button, not on its edge: `outline` sits
+ * clear of the border box, offset a further 2px, so its only WCAG 1.4.11
+ * neighbor is ever the page background — never the button's own fill. That
+ * is what lets each variant use its own hue (see --button-focus-ring on
+ * .button and the per-variant overrides below) without needing a second,
+ * fill-side tone. `outline` is also layout-neutral — unlike a real
+ * border-width switch, it never changes the button's box, so the old
+ * reason for not simply thickening the border (the label shifting sideways
+ * on every focus/blur) no longer applies. The per-variant color arrives via
+ * --button-focus-ring (set on .button above, overridden by the variants
+ * below).
  */
 .button:focus-visible {
-  outline: none;
-  border-color: var(--button-focus-ring);
-  box-shadow: inset 0 0 0 var(--ring-inset)
-    var(--button-focus-ring-inner);
+  outline: var(--border-width-focus) solid var(--button-focus-ring);
+  outline-offset: 2px;
 }
 
 /*
@@ -227,41 +223,30 @@
 }
 
 /*
- * Focus colors. The constraint: the ring's two painted pixels touch two
- * different surfaces — the fill and the page background (see the
- * --button-focus-ring-inner comment on .button above) — and each must clear
- * WCAG 1.4.11's 3:1 floor.
- *
- * default and destructive need two TONES because no single hue clears both
- * of their surfaces at once: violet-on-violet vanishes against the primary
- * fill (the QA frame says so itself — "Primary focus uses the system info
- * ring for clear contrast", which is why --info is the outer tone), and the
- * mid-tone fills sit too close to a near-white/near-black page. ghost, link
- * and secondary take one tone, --primary-hover, which clears both of theirs.
- * outline gets no override at all: every drawn candidate (--border-strong)
- * reads too weak against both its --surface-elevated fill and the page, so
- * it falls through to .button's own --ring — the same ring every non-Button
- * kit control uses.
+ * Focus colors. The ring sits outside the button (see :focus-visible
+ * above), so it only ever borders the page — the one surface every
+ * variant needs to clear WCAG 1.4.11's 3:1 floor against. That single
+ * surface is what makes a single tone per variant enough: default and
+ * destructive keep a family color of their own (a violet a shade darker/
+ * lighter than --primary would otherwise be, and the destructive red's
+ * equivalent — see theme.css's --primary-ring/--destructive-ring), because
+ * their own accent reads better against the page than the plain kit-wide
+ * ring would. outline, secondary, ghost and link get no override at all:
+ * they fall through to .button's own --ring — the same ring every
+ * non-Button kit control uses.
  *
  * The ratios are not repeated here: button.test.tsx recomputes all six
- * variants against both surfaces in both themes from THIS file's live
- * values, so a token drift fails the suite instead of silently outdating a
- * hand-copied table. design-notes.md records the measured numbers.
+ * variants against the page background in both themes from THIS file's
+ * live values, so a token drift fails the suite instead of silently
+ * outdating a hand-copied table. design-notes.md records the measured
+ * numbers.
  */
 .variantDefault {
-  --button-focus-ring: var(--info);
-  --button-focus-ring-inner: var(--foreground);
+  --button-focus-ring: var(--primary-ring);
 }
 
 .variantDestructive {
-  --button-focus-ring: var(--primary-hover);
-  --button-focus-ring-inner: var(--destructive-foreground);
-}
-
-.variantGhost,
-.variantLink,
-.variantSecondary {
-  --button-focus-ring: var(--primary-hover);
+  --button-focus-ring: var(--destructive-ring);
 }
 
 /* Buttons sit on the control/height scale directly: sm/default/lg =

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -87,14 +87,17 @@
 }
 
 /*
- * Forced-colors mode drops box-shadow, so the ring above leaves the button with
- * no visible focus at all. Hand the indicator back to the UA outline, which the
- * mode does paint, and keep it off the shadow.
+ * Forced-colors mode replaces author colors with a fixed system palette, so
+ * the per-variant --button-focus-ring color (--primary-ring/
+ * --destructive-ring, or the kit-wide --ring) would be dropped anyway. Hand
+ * the ring to the system's Highlight color instead so it survives the mode.
+ * Only the color needs overriding: width/style/offset already match the
+ * base :focus-visible rule above, so redeclaring them here would just be a
+ * duplicate.
  */
 @media (forced-colors: active) {
   .button:focus-visible {
-    outline: 2px solid Highlight;
-    outline-offset: 2px;
+    outline-color: Highlight;
   }
 }
 

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -29,13 +29,14 @@
    * everything else falls through to this kit-wide --ring, same as every
    * non-Button control.
    *
-   * The --button-bg/--button-fg/--button-border{,-hover} family below works
-   * the same way: consumer-override hooks that no kit rule ever declares —
-   * each variant CONSUMES them with its own token as the var() fallback, so
-   * a consumer class that sets them recolors the button without fighting
-   * the cascade, and hover falls back to the consumer's rest color (not the
-   * variant's token) via the var(--button-bg-hover, var(--button-bg, ...))
-   * chain. See button.md's "Custom colors".
+   * The --button-bg/--button-fg/--button-bg-hover/--button-fg-hover/
+   * --button-border family below works the same way: consumer-override
+   * hooks that no kit rule ever declares — each variant CONSUMES them with
+   * its own token as the var() fallback, so a consumer class that sets them
+   * recolors the button without fighting the cascade, and hover falls back
+   * to the consumer's rest color (not the variant's token) via the
+   * var(--button-bg-hover, var(--button-bg, ...)) chain. See button.md's
+   * "Custom colors".
    */
   --button-focus-ring: var(--ring);
   /* Anchors the absolutely-centered .spinner. */

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -101,6 +101,24 @@ describe('Button', () => {
     expect(button.hasAttribute('data-icon-only')).toBe(true);
   });
 
+  it('treats a false icon as absent, never going icon-only', () => {
+    // `icon={cond && <Icon/>}` with cond=false passes `false` — a valid
+    // ReactNode that renders nothing, but `icon != null` alone read it as
+    // present, forcing icon-only geometry around an empty square; see
+    // hasIcon in button.tsx.
+    render(<Button icon={false} aria-label="Refresh" />);
+    const button = screen.getByRole('button', { name: 'Refresh' });
+    expect(button.hasAttribute('data-icon-only')).toBe(false);
+    expect(button.querySelector(`.${styles.icon}`)).toBeNull();
+  });
+
+  it('treats a false icon as absent while a label is present', () => {
+    render(<Button icon={false}>Save</Button>);
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button.hasAttribute('data-icon-only')).toBe(false);
+    expect(button.querySelector(`.${styles.icon}`)).toBeNull();
+  });
+
   it('loading disables the button, reports aria-busy, and keeps the accessible name', () => {
     const onClick = vi.fn();
     render(

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -202,75 +202,91 @@ describe('Button', () => {
 });
 
 /*
- * Focus-ring contrast guard. It lives here rather than in tokens.test.ts
- * with the link-text/table-header cases (genuinely theme-level pairs),
- * because a Button focus ring is DERIVED from two things this file
- * already owns — which token button.module.css's --button-focus-ring{,
- * -inner} actually resolve to per variant, and which token that variant's
- * own `background-color` resolves to. Hardcoding "default's ring is --info
- * against --primary" here would restate the CSS instead of reading it: if
- * a future edit re-points --button-focus-ring, this guard needs to notice
- * on its own, not keep asserting yesterday's mapping. So it parses the raw
- * button.module.css source (not the hashed `styles` import, which has no
- * selector names or values left in it) with the same extractRules the
- * theme.css guards use, resolves each variant's custom-property cascade by
- * hand (button.module.css declares --button-focus-ring{,-inner} in more
- * than one rule per variant — a rest-fill rule and a separate focus-color
- * rule further down the file — so "merge every matching rule in source
- * order" is what actually reproduces the cascade, not a single lookup).
+ * Focus-ring contrast guard's raw-CSS parsing, shared with the
+ * custom-color API guard below. It lives here rather than in
+ * tokens.test.ts with the link-text/table-header cases (genuinely
+ * theme-level pairs), because a Button focus ring is DERIVED from two
+ * things this file already owns — which token button.module.css's
+ * --button-focus-ring{,-inner} actually resolve to per variant, and which
+ * token that variant's own `background-color` resolves to. Hardcoding
+ * "default's ring is --info against --primary" here would restate the CSS
+ * instead of reading it: if a future edit re-points --button-focus-ring,
+ * this guard needs to notice on its own, not keep asserting yesterday's
+ * mapping. So it parses the raw button.module.css source (not the hashed
+ * `styles` import, which has no selector names or values left in it) with
+ * the same extractRules the theme.css guards use, resolves each variant's
+ * custom-property cascade by hand (button.module.css declares
+ * --button-focus-ring{,-inner} in more than one rule per variant — a
+ * rest-fill rule and a separate focus-color rule further down the file —
+ * so "merge every matching rule in source order" is what actually
+ * reproduces the cascade, not a single lookup).
  */
-describe('Button focus-ring contrast', () => {
-  const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'button.module.css');
-  const rules = extractRules(readFileSync(cssPath, 'utf8'));
-  const { light, dark } = readThemeTokens();
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'button.module.css');
+const rules = extractRules(readFileSync(cssPath, 'utf8'));
 
-  // Every declaration from every rule whose selector list includes `.button`
-  // (the shared base) or `targetClass`, applied in source order — the same
-  // property from a later rule overrides an earlier one, same as the
-  // cascade would resolve two same-specificity rules for the same class.
-  function effectiveDeclarations(targetClass: string): Map<string, string> {
-    const merged = new Map<string, string>();
-    for (const rule of rules) {
-      const selectors = rule.selector.split(',').map((selector) => selector.replace(/\s+/g, ''));
-      if (selectors.includes('.button') || selectors.includes(targetClass)) {
-        for (const [prop, value] of declarationMap(rule.body)) {
-          merged.set(prop, value);
-        }
+// Every declaration from every rule whose selector list includes `.button`
+// (the shared base) or `targetClass`, applied in source order — the same
+// property from a later rule overrides an earlier one, same as the
+// cascade would resolve two same-specificity rules for the same class.
+function effectiveDeclarations(targetClass: string): Map<string, string> {
+  const merged = new Map<string, string>();
+  for (const rule of rules) {
+    const selectors = rule.selector.split(',').map((selector) => selector.replace(/\s+/g, ''));
+    if (selectors.includes('.button') || selectors.includes(targetClass)) {
+      for (const [prop, value] of declarationMap(rule.body)) {
+        merged.set(prop, value);
       }
     }
-    return merged;
   }
+  return merged;
+}
 
-  function localVarName(value: string): string | null {
-    return value.trim().match(/^var\((--[a-z0-9-]+)\)$/)?.[1] ?? null;
+const variants = [
+  'variantDefault',
+  'variantDestructive',
+  'variantOutline',
+  'variantSecondary',
+  'variantGhost',
+  'variantLink',
+];
+
+describe('Button focus-ring contrast', () => {
+  const { light, dark } = readThemeTokens();
+
+  // Parses `var(--name)` / `var(--name, <fallback>)`. Returns null for
+  // anything that isn't a var() expression (literal colors, `transparent`).
+  function parseVar(value: string): { name: string; fallback: string | null } | null {
+    const match = value.trim().match(/^var\(\s*(--[a-z0-9-]+)\s*(?:,\s*([\s\S]+))?\)$/);
+    if (!match) return null;
+    return { name: match[1] as string, fallback: match[2] ?? null };
   }
 
   // Peels away button.module.css's OWN indirection (--button-focus-ring-
-  // inner defaulting to `var(--button-focus-ring)`, or one variant class
-  // pointing at another local custom property) until the value names a
-  // token that ISN'T declared in `scope` — at that point it can only be a
-  // real theme.css token, which is what every caller here actually wants.
+  // inner defaulting to `var(--button-focus-ring)`, or a color routed
+  // through the consumer-override hooks like `var(--button-bg,
+  // var(--primary))`) until the value names a token that ISN'T declared in
+  // `scope`. An undeclared name WITH a fallback is an override hook nobody
+  // set — the fallback IS the kit default, so resolution descends into it;
+  // an undeclared name with NO fallback can only be a real theme.css token.
   function resolveThemeToken(rawValue: string, scope: Map<string, string>): string | null {
     let current = rawValue.trim();
     const seen = new Set<string>();
     for (;;) {
-      const name = localVarName(current);
-      if (!name) return null; // not a var() at all (e.g. a literal color, `transparent`)
-      if (!scope.has(name)) return name;
-      if (seen.has(name)) return null; // cycle guard — should never trigger
-      seen.add(name);
-      current = scope.get(name) as string;
+      const parsed = parseVar(current);
+      if (!parsed) return null; // not a var() at all (e.g. a literal color, `transparent`)
+      if (scope.has(parsed.name)) {
+        if (seen.has(parsed.name)) return null; // cycle guard — should never trigger
+        seen.add(parsed.name);
+        current = scope.get(parsed.name) as string;
+        continue;
+      }
+      if (parsed.fallback !== null) {
+        current = parsed.fallback;
+        continue;
+      }
+      return parsed.name;
     }
   }
-
-  const variants = [
-    'variantDefault',
-    'variantDestructive',
-    'variantOutline',
-    'variantSecondary',
-    'variantGhost',
-    'variantLink',
-  ];
 
   const themes: Array<[string, Map<string, string>]> = [
     ['light', light],
@@ -314,5 +330,44 @@ describe('Button focus-ring contrast', () => {
         `${themeName} ${variant} inner vs fill`,
       ).toBeGreaterThanOrEqual(3);
     }
+  });
+});
+
+/*
+ * Guards the custom-color override API: every variant's rest and hover
+ * colors must route through the documented --button-* hooks (with the
+ * variant's own token as the var() fallback), so a consumer class setting
+ * `--button-bg`/`--button-bg-hover`/`--button-fg`/`--button-fg-hover`
+ * recolors the button in every state. A hard-coded color here silently
+ * breaks that contract — this suite is what notices.
+ */
+describe('Button custom-color API', () => {
+  function hoverDeclarations(targetClass: string): Map<string, string> {
+    const merged = new Map<string, string>();
+    for (const rule of rules) {
+      const selectors = rule.selector.split(',').map((selector) => selector.replace(/\s+/g, ''));
+      if (selectors.includes(`${targetClass}:hover`)) {
+        for (const [prop, value] of declarationMap(rule.body)) {
+          merged.set(prop, value);
+        }
+      }
+    }
+    return merged;
+  }
+
+  it.each(variants)('%s routes rest colors through --button-bg/--button-fg', (variant) => {
+    const rest = effectiveDeclarations(`.${variant}`);
+    expect(rest.get('background-color'), `${variant} background-color`).toMatch(/^var\(--button-bg,/);
+    expect(rest.get('color'), `${variant} color`).toMatch(/^var\(--button-fg,/);
+  });
+
+  it.each(variants)('%s routes hover colors through the -hover chain', (variant) => {
+    const hover = hoverDeclarations(`.${variant}`);
+    expect(hover.get('background-color'), `${variant}:hover background-color`).toMatch(
+      /^var\(\s*--button-bg-hover,\s*var\(\s*--button-bg,/,
+    );
+    expect(hover.get('color'), `${variant}:hover color`).toMatch(
+      /^var\(\s*--button-fg-hover,\s*var\(\s*--button-fg,/,
+    );
   });
 });

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -205,21 +205,20 @@ describe('Button', () => {
  * Focus-ring contrast guard's raw-CSS parsing, shared with the
  * custom-color API guard below. It lives here rather than in
  * tokens.test.ts with the link-text/table-header cases (genuinely
- * theme-level pairs), because a Button focus ring is DERIVED from two
- * things this file already owns — which token button.module.css's
- * --button-focus-ring{,-inner} actually resolve to per variant, and which
- * token that variant's own `background-color` resolves to. Hardcoding
- * "default's ring is --info against --primary" here would restate the CSS
- * instead of reading it: if a future edit re-points --button-focus-ring,
- * this guard needs to notice on its own, not keep asserting yesterday's
+ * theme-level pairs), because a Button focus ring is DERIVED from
+ * something this file already owns — which token button.module.css's
+ * --button-focus-ring actually resolves to per variant. Hardcoding
+ * "default's ring is --primary-ring" here would restate the CSS instead
+ * of reading it: if a future edit re-points --button-focus-ring, this
+ * guard needs to notice on its own, not keep asserting yesterday's
  * mapping. So it parses the raw button.module.css source (not the hashed
  * `styles` import, which has no selector names or values left in it) with
  * the same extractRules the theme.css guards use, resolves each variant's
  * custom-property cascade by hand (button.module.css declares
- * --button-focus-ring{,-inner} in more than one rule per variant — a
- * rest-fill rule and a separate focus-color rule further down the file —
- * so "merge every matching rule in source order" is what actually
- * reproduces the cascade, not a single lookup).
+ * --button-focus-ring in more than one rule per variant — a rest-fill
+ * rule and a separate focus-color rule further down the file — so "merge
+ * every matching rule in source order" is what actually reproduces the
+ * cascade, not a single lookup).
  */
 const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'button.module.css');
 const rules = extractRules(readFileSync(cssPath, 'utf8'));
@@ -261,13 +260,14 @@ describe('Button focus-ring contrast', () => {
     return { name: match[1] as string, fallback: match[2] ?? null };
   }
 
-  // Peels away button.module.css's OWN indirection (--button-focus-ring-
-  // inner defaulting to `var(--button-focus-ring)`, or a color routed
-  // through the consumer-override hooks like `var(--button-bg,
-  // var(--primary))`) until the value names a token that ISN'T declared in
-  // `scope`. An undeclared name WITH a fallback is an override hook nobody
-  // set — the fallback IS the kit default, so resolution descends into it;
-  // an undeclared name with NO fallback can only be a real theme.css token.
+  // Peels away scope's own declared aliases — the base rule's
+  // `--button-focus-ring: var(--ring)`, a variant's own `var(--primary-
+  // ring)` / `var(--destructive-ring)` — until the value names a token
+  // that ISN'T declared in `scope`. An undeclared name WITH a fallback is
+  // an override hook nobody set (no current --button-focus-ring value
+  // actually carries one, but the branch stays general for the same
+  // reason the custom-color hooks below need it); an undeclared name with
+  // NO fallback can only be a real theme.css token.
   function resolveThemeToken(rawValue: string, scope: Map<string, string>): string | null {
     let current = rawValue.trim();
     const seen = new Set<string>();
@@ -304,31 +304,41 @@ describe('Button focus-ring contrast', () => {
     return hex as string;
   }
 
-  it.each(variants)('%s clears 3:1 against both the fill and the page background', (variant) => {
+  // The ring now lives OUTSIDE the button (see button.module.css's
+  // `:focus-visible`), so it only ever borders the page background —
+  // there is no second, fill-side surface to check anymore.
+  it.each(variants)('%s clears 3:1 against the page background', (variant) => {
     const scope = effectiveDeclarations(`.${variant}`);
-    const outerName = resolveThemeToken(scope.get('--button-focus-ring') ?? '', scope);
-    const innerName = resolveThemeToken(scope.get('--button-focus-ring-inner') ?? '', scope);
-    // Only --background is checked as the "page background" side — the
-    // one surface every variant is documented/drawn to sit on. A variant
-    // placed on --card/--surface instead is unverified; scoped to the one
-    // pair the brief actually asks about, not widened into a full matrix.
-    const fillName = resolveThemeToken(scope.get('background-color') ?? '', scope);
+    const ringName = resolveThemeToken(scope.get('--button-focus-ring') ?? '', scope);
     for (const [themeName, tokens] of themes) {
       const background = hexFor('--background', tokens, '--background');
-      const outerHex = hexFor(outerName, tokens, `${variant}'s --button-focus-ring`);
-      const innerHex = hexFor(innerName, tokens, `${variant}'s --button-focus-ring-inner`);
-      // A `transparent` (or otherwise unresolved) fill means the variant
-      // has no fill of its own — ghost/link's actual backdrop is the page
-      // itself, so the "fill" side of the check collapses onto --background.
-      const fillHex = fillName ? hexFor(fillName, tokens, `${variant}'s background-color`) : background;
+      const ringHex = hexFor(ringName, tokens, `${variant}'s --button-focus-ring`);
       expect(
-        contrastRatio(outerHex, background),
-        `${themeName} ${variant} outer vs page bg`,
+        contrastRatio(ringHex, background),
+        `${themeName} ${variant} ring vs page bg`,
       ).toBeGreaterThanOrEqual(3);
-      expect(
-        contrastRatio(innerHex, fillHex),
-        `${themeName} ${variant} inner vs fill`,
-      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  // The single-tone model's whole point is that only default and
+  // destructive need a family color of their own now that violet-on-violet
+  // is no longer the failure mode — everything else shares the kit-wide
+  // --ring, same as every non-Button control. Guards against a future edit
+  // silently re-special-casing one of those four (the old two-tone version
+  // of this file special-cased ghost/link/secondary too, and nothing here
+  // would have caught it drifting).
+  it('resolves default and destructive to their own ring tone and the rest to --ring', () => {
+    const ringNameFor = (variant: string) => {
+      const scope = effectiveDeclarations(`.${variant}`);
+      return resolveThemeToken(scope.get('--button-focus-ring') ?? '', scope);
+    };
+    expect(ringNameFor('variantDefault')).toBe('--primary-ring');
+    expect(ringNameFor('variantDestructive')).toBe('--destructive-ring');
+    const sharedRingVariants = variants.filter(
+      (variant) => variant !== 'variantDefault' && variant !== 'variantDestructive',
+    );
+    for (const variant of sharedRingVariants) {
+      expect(ringNameFor(variant), variant).toBe('--ring');
     }
   });
 });

--- a/packages/ui-kit/src/components/button/button.tsx
+++ b/packages/ui-kit/src/components/button/button.tsx
@@ -95,7 +95,13 @@ export function Button({
   // button stays a wide pill wrapping an empty label span instead of going
   // icon-only. `0` is deliberately NOT filtered — React renders it.
   const hasLabel = Children.toArray(children).some((child) => child !== '');
-  const iconOnly = icon != null && !hasLabel;
+  // Same predicate, applied to the icon slot: `icon != null` is true for
+  // `icon={false}` — a valid ReactNode that renders nothing — which is
+  // exactly what `icon={cond && <Icon/>}` passes when `cond` is false.
+  // Without this, a false condition still forced the button icon-only and
+  // rendered an empty square.
+  const hasIcon = Children.toArray(icon).some((child) => child !== '');
+  const iconOnly = hasIcon && !hasLabel;
   return (
     <ButtonPrimitive
       className={buttonVariants({ variant, size, className })}
@@ -123,7 +129,7 @@ export function Button({
       aria-busy={loading || undefined}
     >
       {loading && <span className={styles.spinner} aria-hidden="true" />}
-      {icon != null && (
+      {hasIcon && (
         <span className={styles.icon} aria-hidden="true">
           {icon}
         </span>

--- a/packages/ui-kit/src/components/checkbox/checkbox.module.css
+++ b/packages/ui-kit/src/components/checkbox/checkbox.module.css
@@ -55,7 +55,10 @@
   outline-offset: 2px;
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is already an outline, not a box-shadow — forced-colors
+ * mode still flattens its author --ring color, so pin it to the system's
+ * Highlight color explicitly (same reasoning as button.module.css's own
+ * ring, restated here rather than delegated to it). */
 @media (forced-colors: active) {
   .checkbox:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/input/input.md
+++ b/packages/ui-kit/src/components/input/input.md
@@ -36,6 +36,9 @@ presentational wrapper the component adds only when a slot is present),
 `end` overlays trailing content such as a clear button. Semantics still
 come from the native `type` — a search field is `type="search"` (searchbox
 role) plus a magnifier passed to `icon`; nothing renders automatically.
+A disabled input dims and disarms its `end` slot too (0.42 opacity,
+`pointer-events: none`) — a clear button left in `end` doesn't stay live
+just because it isn't the native control.
 
 ## Examples
 

--- a/packages/ui-kit/src/components/input/input.md
+++ b/packages/ui-kit/src/components/input/input.md
@@ -23,16 +23,19 @@ error, validation state) when rendered inside one.
 |------|------|---------|
 | `value` / `defaultValue` | controlled / uncontrolled value | — |
 | `onValueChange` | `(value: string, eventDetails) => void` — fires on every change | — |
+| `icon` | `ReactNode` — leading icon slot, decorative (`aria-hidden`, no pointer events); pair with the right native `type` for semantics | — |
+| `end` | `ReactNode` — trailing slot for live content (icon-button, adornment); rendered after the input, sized for an icon or a compact `size="sm"` icon-only Button | — |
 | `className` | `string` — merged after the kit class | — |
 
 All other props are native `<input>` props (`type`, `placeholder`,
 `disabled`, `required`, `aria-invalid`, ...) and are forwarded as-is.
 `aria-invalid` switches the border and ring to the destructive color.
 
-`type="search"` upgrades the field visually as well as semantically: a
-leading magnifier icon (decorative, `aria-hidden`) renders inside the
-field via a presentational wrapper element, and the input announces as a
-searchbox. No prop needed — the native type is the switch.
+Icons are explicit: `icon` draws a leading icon inside the field (via a
+presentational wrapper the component adds only when a slot is present),
+`end` overlays trailing content such as a clear button. Semantics still
+come from the native `type` — a search field is `type="search"` (searchbox
+role) plus a magnifier passed to `icon`; nothing renders automatically.
 
 ## Examples
 
@@ -42,8 +45,14 @@ import { Input } from '@gears-frontx/ui-kit';
 // Uncontrolled with placeholder
 <Input placeholder="Project name" />
 
-// Search field — the native type brings the magnifier and searchbox role
-<Input type="search" placeholder="Search projects…" />
+// Search field: the native type brings the searchbox role, the icon slot
+// brings the magnifier, and `end` can hold a clear button
+<Input
+  type="search"
+  placeholder="Search projects…"
+  icon={<MagnifierIcon />}
+  end={<Button variant="ghost" size="sm" icon={<CrossIcon />} aria-label="Clear" />}
+/>
 
 // Controlled
 <Input value={email} onValueChange={setEmail} type="email" />
@@ -63,3 +72,5 @@ import { Input } from '@gears-frontx/ui-kit';
   containers, colors to theme tokens.
 - Do not build a labelled input by hand — the `Field` composition handles
   label/error/description wiring.
+- Do not put an interactive control in `icon` — that slot is aria-hidden
+  and pointer-transparent; live content goes in `end`.

--- a/packages/ui-kit/src/components/input/input.md
+++ b/packages/ui-kit/src/components/input/input.md
@@ -36,9 +36,21 @@ presentational wrapper the component adds only when a slot is present),
 `end` overlays trailing content such as a clear button. Semantics still
 come from the native `type` — a search field is `type="search"` (searchbox
 role) plus a magnifier passed to `icon`; nothing renders automatically.
-A disabled input dims and disarms its `end` slot too (0.42 opacity,
-`pointer-events: none`) — a clear button left in `end` doesn't stay live
-just because it isn't the native control.
+A disabled input dims its `icon` and `end` slots too (0.42 opacity) — a
+clear button left in `end` doesn't stay visually live just because it isn't
+the native control. That dimming fires regardless of *why* the input is
+disabled (the direct `disabled` prop or a `<Field disabled>` ancestor both
+land on the real `<input>`). Removing `end`'s tab stop is a separate fix
+and only covers the direct prop: passing `disabled` straight to `Input`
+also sets `inert` on the `end` wrapper, which drops it from the tab order
+and blocks activation — the actual fix for a keyboard user, since dimming
+alone (`pointer-events: none`) only disarms the mouse. A field disabled
+through `<Field disabled>`'s context still dims `end`, but Input has no way
+to observe that context-driven disable from its own props, so it cannot set
+`inert` for that path — an interactive `end` slot under a `Field`-disabled
+input stays dim yet still tabbable and clickable via keyboard activation.
+Consumers composing `end` from a `Field` should disable their own
+interactive `end` content directly rather than relying on this.
 
 ## Examples
 

--- a/packages/ui-kit/src/components/input/input.module.css
+++ b/packages/ui-kit/src/components/input/input.module.css
@@ -147,6 +147,18 @@
   align-items: center;
 }
 
+/*
+ * .end is a sibling inside .wrap, not a descendant of .input, so
+ * .input:disabled above never reaches it: a disabled field's clear button
+ * (or whatever else lives in `end`) would otherwise stay fully opaque and
+ * clickable. Match the same 0.42 disabled dim as .input itself and make it
+ * inert.
+ */
+.input:disabled ~ .end {
+  opacity: 0.42;
+  pointer-events: none;
+}
+
 /* Icon inset + the icon + a gap, so the text clears the leading icon. */
 .hasIcon {
   padding-inline-start: calc(var(--space-3) + var(--icon-size-sm) + var(--space-2));

--- a/packages/ui-kit/src/components/input/input.module.css
+++ b/packages/ui-kit/src/components/input/input.module.css
@@ -112,29 +112,48 @@
 }
 
 /*
- * type="search" plumbing (see input.tsx): the wrapper positions the
- * magnifier over the field; the input just clears space for it. The icon
- * is aria-hidden decoration — the search semantic comes from the native
- * type.
+ * icon/end slot plumbing (see input.tsx): the wrapper positions the slots
+ * over the field; the input just clears space for whichever slots are
+ * present. The icon slot is aria-hidden decoration with pointer events
+ * off; the end slot is live content overlaid on the field's end padding.
  */
-.searchWrap {
+.wrap {
   position: relative;
   display: block;
   width: 100%;
 }
 
-.searchIcon {
+.icon {
   position: absolute;
   inset-inline-start: var(--space-3);
   top: 50%;
   translate: 0 -50%;
-  width: var(--icon-size-sm);
-  height: var(--icon-size-sm);
+  display: inline-flex;
   color: var(--muted-foreground);
   pointer-events: none;
 }
 
-.searchInput {
-  /* Icon inset + the icon + a gap, so the text clears the magnifier. */
+.icon svg {
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
+}
+
+.end {
+  position: absolute;
+  inset-inline-end: var(--space-2);
+  top: 50%;
+  translate: 0 -50%;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Icon inset + the icon + a gap, so the text clears the leading icon. */
+.hasIcon {
   padding-inline-start: calc(var(--space-3) + var(--icon-size-sm) + var(--space-2));
+}
+
+/* The end slot's stated maximum — a compact 32px icon-button — plus its
+ * inset and a gap. Wider end content is the consumer's padding to extend. */
+.hasEnd {
+  padding-inline-end: calc(var(--space-2) + var(--control-height-sm) + var(--space-1));
 }

--- a/packages/ui-kit/src/components/input/input.module.css
+++ b/packages/ui-kit/src/components/input/input.module.css
@@ -82,7 +82,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .input:focus-visible {
     outline: 2px solid Highlight;
@@ -148,13 +150,20 @@
 }
 
 /*
- * .end is a sibling inside .wrap, not a descendant of .input, so
- * .input:disabled above never reaches it: a disabled field's clear button
- * (or whatever else lives in `end`) would otherwise stay fully opaque and
- * clickable. Match the same 0.42 disabled dim as .input itself and make it
- * inert.
+ * .icon renders before .input in the DOM (leading slot) and .end after
+ * (trailing slot), so a plain `~` sibling combinator can reach only one of
+ * them — a prior `.input:disabled ~ .end` rule matched .end but never
+ * .icon, leaving a disabled search field's magnifier at full strength
+ * while its border, text and placeholder dimmed. `:has()` lets .wrap test
+ * the input's disabled state and dim both slots from there regardless of
+ * DOM order — and regardless of *why* .input is disabled, since the direct
+ * `disabled` prop and a `<Field disabled>` ancestor both land on the real
+ * <input>, so this selector fires either way. `pointer-events: none` still
+ * only disarms the mouse, not Tab/Enter — see input.tsx's `inert` on .end
+ * for the keyboard fix, which only the direct-prop path can apply.
  */
-.input:disabled ~ .end {
+.wrap:has(.input:disabled) .icon,
+.wrap:has(.input:disabled) .end {
   opacity: 0.42;
   pointer-events: none;
 }

--- a/packages/ui-kit/src/components/input/input.test.tsx
+++ b/packages/ui-kit/src/components/input/input.test.tsx
@@ -103,8 +103,8 @@ describe('Input', () => {
   });
 
   it('keeps a disabled input\'s end slot as its next sibling in the DOM', () => {
-    // input.module.css dims/disarms `end` via `.input:disabled ~ .end` — a
-    // sibling selector, not a class this component toggles in JS. jsdom
+    // input.module.css dims .icon/.end via `.wrap:has(.input:disabled) ...`
+    // — a :has() selector, not a class this component toggles in JS. jsdom
     // computes no styles, so there is no opacity/pointer-events to assert
     // here; what's verifiable is the DOM shape that selector depends on:
     // `end` rendered as .input's next sibling while `disabled` is set.
@@ -118,6 +118,33 @@ describe('Input', () => {
     const input = screen.getByPlaceholderText('Find');
     expect(input).toHaveProperty('disabled', true);
     expect(input.nextElementSibling?.className).toContain(styles.end);
+  });
+
+  it('makes a disabled input\'s end slot inert, removing its tab stop', () => {
+    // Dimming alone (opacity/pointer-events in CSS) only disarms the mouse
+    // — a Button inside `end` keeps its tab stop and still fires on
+    // Enter/Space. `inert` is the actual fix: it drops the slot from the
+    // tab order and blocks activation. Only wired from the direct
+    // `disabled` prop (see input.tsx/input.md for why a Field-driven
+    // disable can't be observed here).
+    render(
+      <Input
+        disabled
+        placeholder="Find"
+        end={<button type="button" aria-label="Clear" />}
+      />,
+    );
+    const input = screen.getByPlaceholderText('Find');
+    // jsdom's HTMLElement doesn't reflect `.inert` as an IDL property, so
+    // assert the attribute itself rather than the property `input.module.
+    // css`'s selectors don't care about either way.
+    expect(input.nextElementSibling?.hasAttribute('inert')).toBe(true);
+  });
+
+  it('leaves an enabled input\'s end slot un-inert', () => {
+    render(<Input placeholder="Find" end={<button type="button" aria-label="Clear" />} />);
+    const input = screen.getByPlaceholderText('Find');
+    expect(input.nextElementSibling?.hasAttribute('inert')).toBe(false);
   });
 
   it('marks the input disabled', () => {

--- a/packages/ui-kit/src/components/input/input.test.tsx
+++ b/packages/ui-kit/src/components/input/input.test.tsx
@@ -8,25 +8,62 @@ afterEach(cleanup);
 
 describe('Input', () => {
   it('renders a native input with the base class', () => {
-    render(<Input placeholder="Search" />);
+    const { container } = render(<Input placeholder="Search" />);
     const input = screen.getByPlaceholderText('Search');
     expect(input).toHaveProperty('tagName', 'INPUT');
     expect(input.className).toContain(styles.input);
-    // Every non-search type stays a bare input — no wrapper element.
-    expect(input.parentElement?.className ?? '').not.toContain(styles.searchWrap);
+    // No slots — no wrapper element: the input is the root.
+    expect(input.parentElement).toBe(container);
   });
 
-  it('type="search" adds the decorated wrapper and keeps the searchbox role', () => {
-    render(<Input type="search" placeholder="Find" className="consumer" />);
+  it('type="search" no longer decorates itself', () => {
+    const { container } = render(<Input type="search" placeholder="Find" />);
     const input = screen.getByRole('searchbox');
-    expect(input.className).toContain(styles.searchInput);
-    // The consumer className stays on the input itself, same as any type.
+    // Still a bare input (the searchbox role comes from the native type);
+    // the magnifier is gone — icons are always explicit now.
+    expect(input.parentElement).toBe(container);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('icon renders in a decorative leading slot and pads the input', () => {
+    render(<Input icon={<svg data-testid="magnifier" />} placeholder="Find" className="consumer" />);
+    const input = screen.getByPlaceholderText('Find');
+    expect(input.parentElement?.className).toContain(styles.wrap);
+    expect(input.className).toContain(styles.hasIcon);
+    // The consumer className stays on the input itself, wrapper or not.
     expect(input.className).toContain('consumer');
-    const wrap = input.parentElement;
-    expect(wrap?.className).toContain(styles.searchWrap);
-    // The magnifier is decoration; the accessible upgrade is the native type.
-    const icon = wrap?.querySelector('svg');
-    expect(icon?.getAttribute('aria-hidden')).toBe('true');
+    const slot = screen.getByTestId('magnifier').parentElement;
+    expect(slot).toHaveProperty('tagName', 'SPAN');
+    expect(slot?.className).toContain(styles.icon);
+    expect(slot?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('end renders an interactive trailing slot after the input in the DOM', () => {
+    const onClear = vi.fn();
+    render(
+      <Input
+        placeholder="Find"
+        end={<button type="button" aria-label="Clear" onClick={onClear} />}
+      />,
+    );
+    const input = screen.getByPlaceholderText('Find');
+    expect(input.className).toContain(styles.hasEnd);
+    const clear = screen.getByRole('button', { name: 'Clear' });
+    // Live content, not aria-hidden decoration — and placed after the
+    // input, so tab order is field first, then the slot.
+    expect(clear.closest(`.${styles.end}`)).not.toBeNull();
+    expect(input.nextElementSibling?.contains(clear)).toBe(true);
+    fireEvent.click(clear);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders both slots at once', () => {
+    render(<Input placeholder="Find" icon={<svg data-testid="lead" />} end={<span data-testid="trail" />} />);
+    const input = screen.getByPlaceholderText('Find');
+    expect(screen.getByTestId('lead')).toBeTruthy();
+    expect(screen.getByTestId('trail')).toBeTruthy();
+    expect(input.className).toContain(styles.hasIcon);
+    expect(input.className).toContain(styles.hasEnd);
   });
 
   it('reports value changes through onValueChange', () => {

--- a/packages/ui-kit/src/components/input/input.test.tsx
+++ b/packages/ui-kit/src/components/input/input.test.tsx
@@ -16,7 +16,7 @@ describe('Input', () => {
     expect(input.parentElement).toBe(container);
   });
 
-  it('type="search" no longer decorates itself', () => {
+  it('type="search" stays a bare input with the searchbox role and no icon', () => {
     const { container } = render(<Input type="search" placeholder="Find" />);
     const input = screen.getByRole('searchbox');
     // Still a bare input (the searchbox role comes from the native type);
@@ -100,6 +100,24 @@ describe('Input', () => {
   it('forwards the invalid state', () => {
     render(<Input aria-invalid={true} />);
     expect(screen.getByRole('textbox').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('keeps a disabled input\'s end slot as its next sibling in the DOM', () => {
+    // input.module.css dims/disarms `end` via `.input:disabled ~ .end` — a
+    // sibling selector, not a class this component toggles in JS. jsdom
+    // computes no styles, so there is no opacity/pointer-events to assert
+    // here; what's verifiable is the DOM shape that selector depends on:
+    // `end` rendered as .input's next sibling while `disabled` is set.
+    render(
+      <Input
+        disabled
+        placeholder="Find"
+        end={<button type="button" aria-label="Clear" />}
+      />,
+    );
+    const input = screen.getByPlaceholderText('Find');
+    expect(input).toHaveProperty('disabled', true);
+    expect(input.nextElementSibling?.className).toContain(styles.end);
   });
 
   it('marks the input disabled', () => {

--- a/packages/ui-kit/src/components/input/input.test.tsx
+++ b/packages/ui-kit/src/components/input/input.test.tsx
@@ -57,6 +57,19 @@ describe('Input', () => {
     expect(onClear).toHaveBeenCalledTimes(1);
   });
 
+  it('treats a false icon and end as absent, staying a bare input', () => {
+    // `icon={cond && <Icon/>}` with cond=false passes `false` — a valid
+    // ReactNode that renders nothing, but `icon != null`/`end != null` alone
+    // read it as present. That rendered the presentational wrapper plus
+    // stray hasIcon/hasEnd padding for slots with nothing in them; see
+    // hasIcon/hasEnd in input.tsx.
+    const { container } = render(<Input placeholder="Find" icon={false} end={false} />);
+    const input = screen.getByPlaceholderText('Find');
+    expect(input.parentElement).toBe(container);
+    expect(input.className).not.toContain(styles.hasIcon);
+    expect(input.className).not.toContain(styles.hasEnd);
+  });
+
   it('renders both slots at once', () => {
     render(<Input placeholder="Find" icon={<svg data-testid="lead" />} end={<span data-testid="trail" />} />);
     const input = screen.getByPlaceholderText('Find');

--- a/packages/ui-kit/src/components/input/input.tsx
+++ b/packages/ui-kit/src/components/input/input.tsx
@@ -1,40 +1,60 @@
 import { Input as InputPrimitive } from '@base-ui/react/input';
 import { cx } from 'class-variance-authority';
+import type { ReactNode } from 'react';
 
 import styles from './input.module.css';
 
 export interface InputProps extends Omit<InputPrimitive.Props, 'className'> {
   className?: string;
+  /**
+   * Leading icon slot — decorative only: rendered aria-hidden with pointer
+   * events off, so it never carries the field's name or steals a click.
+   * Semantics stay on the input itself — a search field is `type="search"`
+   * plus a magnifier passed here.
+   */
+  icon?: ReactNode;
+  /**
+   * Trailing slot for live content — an icon-button (clear, reveal
+   * password) or a small static adornment. Rendered after the <input> in
+   * the DOM, so tab order is field first, then slot. The input clears a
+   * compact icon-button's width (32px, size="sm") of end padding; anything
+   * wider is the consumer's padding to extend.
+   */
+  end?: ReactNode;
 }
 
-export function Input({ className, type, ...props }: InputProps) {
+/*
+ * An <input> is a replaced element — no ::before to draw into, and a
+ * background-image can't read the theme's color tokens — so the slots need
+ * a presentational wrapper. Only a slotted input pays for it: with neither
+ * prop this stays a bare <input>, and the consumer className stays on the
+ * input either way, so styling targets the same element regardless. Field
+ * wiring is unaffected — the primitive is still the control Field talks to.
+ */
+export function Input({ className, icon, end, ...props }: InputProps) {
   const input = (
     <InputPrimitive
-      type={type}
-      className={cx(styles.input, type === 'search' && styles.searchInput, className)}
+      className={cx(
+        styles.input,
+        icon != null && styles.hasIcon,
+        end != null && styles.hasEnd,
+        className,
+      )}
       {...props}
     />
   );
-  if (type !== 'search') {
+  if (icon == null && end == null) {
     return input;
   }
-  /*
-   * The mockups' Field/search type (Figma frame 193:433) is the same field
-   * with a leading magnifier. An <input> is a replaced element — no
-   * ::before to draw into, and a background-image can't read the theme's
-   * color tokens — so the icon needs this presentational wrapper. Only
-   * type="search" pays for it: every other type stays a bare <input>, and
-   * the consumer className stays on the input either way, so styling
-   * targets the same element regardless of type. Field wiring is
-   * unaffected — the primitive is still the control Field talks to.
-   */
   return (
-    <span className={styles.searchWrap}>
-      <svg className={styles.searchIcon} aria-hidden="true" viewBox="0 0 16 16" fill="none">
-        <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
-        <path d="m10.5 10.5 3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
+    <span className={styles.wrap}>
+      {icon != null && (
+        <span className={styles.icon} aria-hidden="true">
+          {icon}
+        </span>
+      )}
       {input}
+      {end != null && <span className={styles.end}>{end}</span>}
     </span>
   );
 }

--- a/packages/ui-kit/src/components/input/input.tsx
+++ b/packages/ui-kit/src/components/input/input.tsx
@@ -31,7 +31,7 @@ export interface InputProps extends Omit<InputPrimitive.Props, 'className'> {
  * input either way, so styling targets the same element regardless. Field
  * wiring is unaffected — the primitive is still the control Field talks to.
  */
-export function Input({ className, icon, end, ...props }: InputProps) {
+export function Input({ className, icon, end, disabled, ...props }: InputProps) {
   // `icon != null`/`end != null` are true for `icon={false}`/`end={false}` —
   // a valid ReactNode that renders nothing — which is exactly what
   // `icon={cond && <Icon/>}` passes when `cond` is false. Same predicate as
@@ -47,6 +47,7 @@ export function Input({ className, icon, end, ...props }: InputProps) {
         hasEnd && styles.hasEnd,
         className,
       )}
+      disabled={disabled}
       {...props}
     />
   );
@@ -61,7 +62,20 @@ export function Input({ className, icon, end, ...props }: InputProps) {
         </span>
       )}
       {input}
-      {hasEnd && <span className={styles.end}>{end}</span>}
+      {/*
+       * `inert` removes `end` from the tab order and blocks activation —
+       * dimming alone (see input.module.css) stops nothing for a keyboard
+       * user, since a Button inside `end` keeps its tab stop and still
+       * fires on Enter/Space. Only wired from this direct `disabled` prop:
+       * a Field-driven disable (`<Field disabled>`) reaches the rendered
+       * <input> through Base UI's own FieldControl, deeper than this
+       * component's props, so it can't be observed here — see input.md.
+       */}
+      {hasEnd && (
+        <span className={styles.end} inert={disabled}>
+          {end}
+        </span>
+      )}
     </span>
   );
 }

--- a/packages/ui-kit/src/components/input/input.tsx
+++ b/packages/ui-kit/src/components/input/input.tsx
@@ -1,6 +1,6 @@
 import { Input as InputPrimitive } from '@base-ui/react/input';
 import { cx } from 'class-variance-authority';
-import type { ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 
 import styles from './input.module.css';
 
@@ -32,29 +32,36 @@ export interface InputProps extends Omit<InputPrimitive.Props, 'className'> {
  * wiring is unaffected — the primitive is still the control Field talks to.
  */
 export function Input({ className, icon, end, ...props }: InputProps) {
+  // `icon != null`/`end != null` are true for `icon={false}`/`end={false}` —
+  // a valid ReactNode that renders nothing — which is exactly what
+  // `icon={cond && <Icon/>}` passes when `cond` is false. Same predicate as
+  // Button's `hasLabel`, applied to a slot instead of children: it answers
+  // "is this renderable" rather than "is this set".
+  const hasIcon = Children.toArray(icon).some((child) => child !== '');
+  const hasEnd = Children.toArray(end).some((child) => child !== '');
   const input = (
     <InputPrimitive
       className={cx(
         styles.input,
-        icon != null && styles.hasIcon,
-        end != null && styles.hasEnd,
+        hasIcon && styles.hasIcon,
+        hasEnd && styles.hasEnd,
         className,
       )}
       {...props}
     />
   );
-  if (icon == null && end == null) {
+  if (!hasIcon && !hasEnd) {
     return input;
   }
   return (
     <span className={styles.wrap}>
-      {icon != null && (
+      {hasIcon && (
         <span className={styles.icon} aria-hidden="true">
           {icon}
         </span>
       )}
       {input}
-      {end != null && <span className={styles.end}>{end}</span>}
+      {hasEnd && <span className={styles.end}>{end}</span>}
     </span>
   );
 }

--- a/packages/ui-kit/src/components/radio-group/radio-group.module.css
+++ b/packages/ui-kit/src/components/radio-group/radio-group.module.css
@@ -61,7 +61,10 @@
   outline-offset: 2px;
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is already an outline, not a box-shadow — forced-colors
+ * mode still flattens its author --ring color, so pin it to the system's
+ * Highlight color explicitly (same reasoning as button.module.css's own
+ * ring, restated here rather than delegated to it). */
 @media (forced-colors: active) {
   .item:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/select/select.md
+++ b/packages/ui-kit/src/components/select/select.md
@@ -35,12 +35,15 @@ raw value instead of the label until the popup has been opened once.
 | `className` | `string` — merged after the kit class | — |
 
 `SelectValue`: renders the selected item's label. Pass `placeholder`
-directly to `SelectValue` (see example). `SelectContent`
-accepts positioning props (`side`, `sideOffset`, `align`, `alignOffset`,
-`alignItemWithTrigger`, plus the escape hatch for triggers inside a
-`transform`/`filter` container: `positionMethod="fixed"`,
-`collisionBoundary`, `collisionPadding`) and `container` — the popup
-portals to `<body>`
+directly to `SelectValue` (see example). `SelectContent` always opens the
+list on its `side` (below the trigger by default) — it never overlays the
+trigger the way a native `<select>` does. With no value selected the list
+starts scrolled to the top; when the selected option is beyond the fold,
+it is scrolled into view on open. `SelectContent` accepts positioning
+props (`side`, `sideOffset`, `align`, `alignOffset`, plus the escape
+hatch for triggers inside a `transform`/`filter` container:
+`positionMethod="fixed"`, `collisionBoundary`, `collisionPadding`) and
+`container` — the popup portals to `<body>`
 by default, so if your theme lives on a subtree (`data-theme` on a
 section instead of `<html>`), pass that section as `container` or the
 popup renders with the root theme. `SelectItem` takes `value` (required) and

--- a/packages/ui-kit/src/components/select/select.md
+++ b/packages/ui-kit/src/components/select/select.md
@@ -6,7 +6,10 @@ form submission (hidden native input on the root) come from Base UI.
 
 Composition: `Select` (root, holds the value) → `SelectTrigger` (+
 `SelectValue` for the current label) → `SelectContent` → `SelectGroup` /
-`SelectLabel` / `SelectItem` / `SelectSeparator`.
+`SelectLabel` / `SelectItem` / `SelectSeparator`. `SelectGroup` is only for
+labelled sections — it is optional; the dropdown's inner padding lives on
+the list itself, not on the group, so items placed directly under
+`SelectContent` are padded the same either way.
 
 ## When to use
 
@@ -95,8 +98,6 @@ const REGIONS = [
 
 ## Anti-patterns
 
-- Do not put items directly under `SelectContent` without a `SelectGroup`
-  — the group carries the list padding.
 - Do not use a select for navigation — that is a menu/link pattern.
 - Do not omit a placeholder or default value — an empty trigger gives the
   user (and the agent) nothing to read.

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -184,8 +184,15 @@
   transform: scale(0.95);
 }
 
-.group {
+/*
+ * The list — not the group — carries the dropdown's inner padding, so a
+ * groupless list (items placed directly under SelectContent) is padded too.
+ */
+.list {
   padding: var(--space-1);
+}
+
+.group {
   scroll-margin: var(--space-1) 0;
 }
 

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -64,7 +64,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .trigger:focus-visible {
     outline: 2px solid Highlight;
@@ -146,6 +148,17 @@
    */
   box-sizing: border-box;
   /*
+   * Declared once here rather than on .list/.scrollArrow individually:
+   * both are DOM children of .popup, and custom properties inherit, so an
+   * ancestor declaration plus descendant reads (`.popup .list`, `.popup
+   * .scrollArrow` below) satisfies tokens.test.ts's local-variable guard
+   * without the formula being duplicated — same shape as card.module.css's
+   * --card-spacing. The value is the scroll arrow's own geometry: one icon
+   * plus its own padding on both edges (--space-1 top AND bottom below,
+   * not a single --space-2 — the two only ever agreed numerically).
+   */
+  --select-scroll-arrow-height: calc(var(--icon-size-sm) + var(--space-1) * 2);
+  /*
    * The popup itself does NOT scroll — .list does (see below). It stays a
    * flex column that clips (`overflow: hidden`) so its child (the List,
    * bracketed by the scroll arrows) is capped at `--available-height` and
@@ -212,27 +225,27 @@
  * is required alongside `overflow-y: auto`: as a child of .popup's flex
  * column, .list would otherwise refuse to shrink below its content's
  * height and grow the popup instead of scrolling within it.
- *
+ */
+.list {
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-height: 0;
+  padding: var(--space-1);
+}
+
+/*
  * `scroll-padding-block` keeps a scrolled-into-view item clear of the
  * arrows: Base UI scrolls the active item with `block: 'nearest'`, which
  * can park it flush against the scrollport edge, and the arrows are
  * `position: absolute` against .popup, overlaying that same edge — this
  * reserves exactly one arrow's box height as scroll padding so `nearest`
- * never lands an item underneath either arrow. The height is a local
- * custom property, not a shared one on .popup: the token-guard test
- * (tokens.test.ts) scopes a locally-declared `var()` to the rule's own
- * leading class, so .list and .scrollArrow below each declare the same
- * formula rather than one declaring it and the other reading it across
- * classes. Both derive it from the same two theme tokens (never a literal),
- * so the two declarations can't drift into different numbers even though
- * they're textually duplicated.
+ * never lands an item underneath either arrow. Read via `.popup .list`
+ * rather than bare `.list` — ancestor declares, children inherit (see
+ * .popup's --select-scroll-arrow-height comment above) — so this rule,
+ * not the bare-class one above, is the one tokens.test.ts's local-variable
+ * guard exempts.
  */
-.list {
-  --select-scroll-arrow-height: calc(var(--icon-size-sm) + var(--space-2));
-  overflow-x: hidden;
-  overflow-y: auto;
-  min-height: 0;
-  padding: var(--space-1);
+.popup .list {
   scroll-padding-block: var(--select-scroll-arrow-height);
 }
 
@@ -252,7 +265,7 @@
    * Substitutes for the preflight the kit lacks: without it, content-box
    * (this kit's ambient default) piles the 2.5rem of horizontal padding
    * on top of `width: 100%`, rendering each item 40px wider than the
-   * popup's content box — clipped by .popup's own overflow-x: hidden
+   * popup's content box — clipped by .popup's own `overflow: hidden`
    * above, which cuts off .itemIndicator (the checkmark, positioned
    * `right: var(--space-2)` from this box's now-invisible true right
    * edge) entirely. Found by auditing every module for this collision, not by
@@ -329,29 +342,36 @@
 }
 
 /*
- * `height` is pinned explicitly (not left to the icon + padding to imply
- * it) so it shares one formula with .list's `scroll-padding-block` above —
- * see that comment for why each declares its own copy of the custom
- * property rather than one reading the other's. `box-sizing: border-box`
- * is required for that formula to equal the box's actual rendered height:
- * without it (content-box, this kit's ambient default — see .trigger/
- * .popup/.item above for the same substitution), the padding below would
- * add on top of the 24px `height` instead of being absorbed into it,
- * rendering the arrow 8px taller than .list's reserved scroll padding and
- * leaving the selected item's edge visible underneath it again.
+ * `box-sizing: border-box` is required for the `height` below to equal
+ * this box's actual rendered size: without it (content-box, this kit's
+ * ambient default — see .trigger/.popup/.item above for the same
+ * substitution), the padding below would add on top of the 24px `height`
+ * instead of being absorbed into it, rendering the arrow 8px taller than
+ * .list's reserved scroll padding and leaving the selected item's edge
+ * visible underneath it again.
  */
 .scrollArrow {
-  --select-scroll-arrow-height: calc(var(--icon-size-sm) + var(--space-2));
   box-sizing: border-box;
   z-index: 10;
   display: flex;
   width: 100%;
-  height: var(--select-scroll-arrow-height);
   align-items: center;
   justify-content: center;
   padding: var(--space-1) 0;
   cursor: default;
   background-color: var(--popover);
+}
+
+/*
+ * `height` is pinned explicitly (not left to the icon + padding to imply
+ * it) so it shares exactly one formula with .list's `scroll-padding-block`
+ * — both read `--select-scroll-arrow-height` from .popup (declared once,
+ * above), so the two can't drift into different numbers. Read via
+ * `.popup .scrollArrow`, same ancestor-declares/children-inherit shape as
+ * `.popup .list` above.
+ */
+.popup .scrollArrow {
+  height: var(--select-scroll-arrow-height);
 }
 
 .scrollArrowUp {

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -145,14 +145,23 @@
    * only).
    */
   box-sizing: border-box;
+  /*
+   * The popup itself does NOT scroll — .list does (see below). It stays a
+   * flex column that clips (`overflow: hidden`) so its child (the List,
+   * bracketed by the scroll arrows) is capped at `--available-height` and
+   * never spills past its border; `position: relative` remains because the
+   * arrows anchor to this box via their own `position: absolute` (set
+   * inline by Base UI's SelectScrollArrow).
+   */
+  display: flex;
+  flex-direction: column;
   position: relative;
   isolation: isolate;
   z-index: 50;
   max-height: var(--available-height);
   width: var(--anchor-width);
   min-width: 9rem;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   border-radius: var(--radius-md);
   border: var(--border-width) solid var(--popover-border);
   background-color: var(--popover);
@@ -187,9 +196,44 @@
 /*
  * The list — not the group — carries the dropdown's inner padding, so a
  * groupless list (items placed directly under SelectContent) is padded too.
+ *
+ * The list is also the scroller, not .popup. Base UI's own scroller styles
+ * (LIST_FUNCTIONAL_STYLES: position/max-height/overflow) apply to
+ * Select.List only in its retired align-with-trigger mode (see
+ * node_modules/@base-ui/react/select/list/SelectList.mjs) — this kit always
+ * renders the popup below the trigger (select.tsx pins
+ * `alignItemWithTrigger={false}`), so those styles never land and something
+ * here must scroll instead. It has to be THIS element specifically, not
+ * .popup: Base UI computes scroll-arrow visibility from `store.state.
+ * listElement` (set by SelectList's ref callback), reading ITS scrollTop/
+ * scrollHeight/clientHeight — a scrolling .popup with a non-overflowing
+ * .list leaves that element permanently maxed at zero scroll, so the up/
+ * down arrows compute as never-visible and never mount. `min-height: 0`
+ * is required alongside `overflow-y: auto`: as a child of .popup's flex
+ * column, .list would otherwise refuse to shrink below its content's
+ * height and grow the popup instead of scrolling within it.
+ *
+ * `scroll-padding-block` keeps a scrolled-into-view item clear of the
+ * arrows: Base UI scrolls the active item with `block: 'nearest'`, which
+ * can park it flush against the scrollport edge, and the arrows are
+ * `position: absolute` against .popup, overlaying that same edge — this
+ * reserves exactly one arrow's box height as scroll padding so `nearest`
+ * never lands an item underneath either arrow. The height is a local
+ * custom property, not a shared one on .popup: the token-guard test
+ * (tokens.test.ts) scopes a locally-declared `var()` to the rule's own
+ * leading class, so .list and .scrollArrow below each declare the same
+ * formula rather than one declaring it and the other reading it across
+ * classes. Both derive it from the same two theme tokens (never a literal),
+ * so the two declarations can't drift into different numbers even though
+ * they're textually duplicated.
  */
 .list {
+  --select-scroll-arrow-height: calc(var(--icon-size-sm) + var(--space-2));
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-height: 0;
   padding: var(--space-1);
+  scroll-padding-block: var(--select-scroll-arrow-height);
 }
 
 .group {
@@ -284,10 +328,25 @@
   background-color: var(--border);
 }
 
+/*
+ * `height` is pinned explicitly (not left to the icon + padding to imply
+ * it) so it shares one formula with .list's `scroll-padding-block` above —
+ * see that comment for why each declares its own copy of the custom
+ * property rather than one reading the other's. `box-sizing: border-box`
+ * is required for that formula to equal the box's actual rendered height:
+ * without it (content-box, this kit's ambient default — see .trigger/
+ * .popup/.item above for the same substitution), the padding below would
+ * add on top of the 24px `height` instead of being absorbed into it,
+ * rendering the arrow 8px taller than .list's reserved scroll padding and
+ * leaving the selected item's edge visible underneath it again.
+ */
 .scrollArrow {
+  --select-scroll-arrow-height: calc(var(--icon-size-sm) + var(--space-2));
+  box-sizing: border-box;
   z-index: 10;
   display: flex;
   width: 100%;
+  height: var(--select-scroll-arrow-height);
   align-items: center;
   justify-content: center;
   padding: var(--space-1) 0;

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -265,9 +265,21 @@
   justify-content: center;
 }
 
+/*
+ * The separator now carries the ENTIRE gap between sections, not half of
+ * it: before the list took over the dropdown's padding (see .list above),
+ * a separator's block margin (--space-1) combined with the adjoining
+ * group's own padding (--space-1) for an 8px gap on each side. .group no
+ * longer pads, so this rule alone must supply that 8px — hence
+ * --space-2 rather than --space-1 — and this holds whether or not the
+ * consumer wraps items in a SelectGroup, since it no longer depends on
+ * grouping at all. The inline value is untouched: it still cancels
+ * exactly against the list's own --space-1 padding, so the rule still
+ * bleeds to the popup's left/right edges.
+ */
 .separator {
   pointer-events: none;
-  margin: var(--space-1) calc(-1 * var(--space-1));
+  margin: var(--space-2) calc(-1 * var(--space-1));
   height: var(--border-width);
   background-color: var(--border);
 }

--- a/packages/ui-kit/src/components/select/select.module.css
+++ b/packages/ui-kit/src/components/select/select.module.css
@@ -184,12 +184,6 @@
   transform: scale(0.95);
 }
 
-/* When the popup aligns an item over the trigger (native-select feel),
- * entering with a scale animation would visibly shift it — skip it. */
-.popup[data-align-trigger='true'] {
-  transition: none;
-}
-
 .group {
   padding: var(--space-1);
   scroll-margin: var(--space-1) 0;

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -18,6 +18,17 @@ import styles from './select.module.css';
 
 afterEach(cleanup);
 
+// Parsed once from the raw CSS source (not the hashed `styles` import, which
+// has no values left in it) so both the padding-ownership test below and the
+// scroll-arrow describe block can read declared property values directly.
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'select.module.css');
+const cssRules = extractRules(readFileSync(cssPath, 'utf8'));
+
+function declaredValue(leadingClass: string, prop: string): string | undefined {
+  const rule = cssRules.find((candidate) => candidate.selector.split(',')[0]?.trim() === leadingClass);
+  return rule ? declarationMap(rule.body).get(prop) : undefined;
+}
+
 const ITEMS = [
   { value: 'eu', label: 'Europe' },
   { value: 'us', label: 'Americas' },
@@ -149,15 +160,35 @@ describe('Select', () => {
     );
     const listbox = screen.getByRole('listbox');
     expect(listbox.className).toContain(styles.list);
+    // The class assertion above would still pass if `.list` lost its
+    // padding — `styles.list` is just a name. Pin the actual behaviour this
+    // test is named for: the list owns the dropdown's inset, and .group
+    // carries none of it, so a groupless list stays padded either way.
+    expect(declaredValue('.list', 'padding'), '.list should own the dropdown padding').toBe(
+      'var(--space-1)',
+    );
+    expect(
+      declaredValue('.group', 'padding'),
+      '.group should not duplicate the padding .list already owns',
+    ).toBeUndefined();
   });
 
   it('always opens the popup below the trigger, with no align-with-trigger attribute', () => {
     renderSelect({ defaultOpen: true });
     const popup = screen.getByRole('listbox').closest(`.${styles.popup}`);
-    // The popup exists and no longer advertises the retired overlay mode —
-    // the attribute is gone entirely, not set to "false".
     expect(popup).not.toBeNull();
+    // The retired overlay mode's attribute is gone entirely (not set to
+    // "false") — kept as a regression guard against the prop coming back.
     expect(popup?.hasAttribute('data-align-trigger')).toBe(false);
+    // What's actually load-bearing: this kit pins `alignItemWithTrigger=
+    // {false}` unconditionally (select.tsx), so Base UI's resolved side is
+    // never overridden to 'none' (its overlay-mode value) and always
+    // reflects the real positioning result. jsdom computes no layout, so
+    // floating-ui never has a reason to flip off the requested `side`
+    // default ('bottom') — this is the one placement outcome that's both
+    // genuinely computed by the library under jsdom and would go stale
+    // (stuck at 'none') if the kit ever went back to overlay mode.
+    expect(popup?.getAttribute('data-side')).toBe('bottom');
   });
 });
 
@@ -177,14 +208,6 @@ describe('Select', () => {
  * in it) — the same technique button.test.tsx's focus-ring guard uses.
  */
 describe('Select scroll-arrow height', () => {
-  const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'select.module.css');
-  const rules = extractRules(readFileSync(cssPath, 'utf8'));
-
-  function declaredValue(leadingClass: string, prop: string): string | undefined {
-    const rule = rules.find((candidate) => candidate.selector.split(',')[0]?.trim() === leadingClass);
-    return rule ? declarationMap(rule.body).get(prop) : undefined;
-  }
-
   it('declares the identical --select-scroll-arrow-height formula on .list and .scrollArrow', () => {
     const listValue = declaredValue('.list', '--select-scroll-arrow-height');
     const scrollArrowValue = declaredValue('.scrollArrow', '--select-scroll-arrow-height');

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -151,7 +151,7 @@ describe('Select', () => {
     expect(listbox.className).toContain(styles.list);
   });
 
-  it('renders the popup without the align-with-trigger overlay mode', () => {
+  it('always opens the popup below the trigger, with no align-with-trigger attribute', () => {
     renderSelect({ defaultOpen: true });
     const popup = screen.getByRole('listbox').closest(`.${styles.popup}`);
     // The popup exists and no longer advertises the retired overlay mode —

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -61,8 +61,8 @@ describe('Select', () => {
     renderSelect({ defaultOpen: true, onValueChange });
     const option = screen.getByRole('option', { name: 'Europe' });
     // Base UI commits a mouse selection only when the click started on the
-    // item (guards against alignItemWithTrigger placing an item under the
-    // cursor), so the pointerdown must precede the click.
+    // item (guards against a stray pointerup landing on an item that wasn't
+    // clicked), so the pointerdown must precede the click.
     fireEvent.pointerDown(option);
     fireEvent.click(option);
     expect(onValueChange).toHaveBeenCalledTimes(1);

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -196,30 +196,14 @@ describe('Select', () => {
  * jsdom computes no layout, so the scroll-arrow fix itself (does the list
  * actually scroll and clear the selected item, do the arrows mount at the
  * right edges) can only be verified in a real browser — see the manual
- * verification in this change's PR/report, not a test here. What CAN be
- * guarded statically is the one thing that could silently regress without
- * any layout at all: .list's `scroll-padding-block` and .scrollArrow's
- * `height` each declare their OWN copy of `--select-scroll-arrow-height`
- * (tokens.test.ts's local-variable guard scopes a declared custom property
- * to its own leading class, so one rule can't read the other's declaration
- * — see select.module.css's comment on .list). Nothing enforces that the
- * two copies stay identical except this test, which parses the raw CSS
- * source directly (not the hashed `styles` import, which has no values left
- * in it) — the same technique button.test.tsx's focus-ring guard uses.
+ * verification in this change's PR/report, not a test here. `.list` and
+ * `.scrollArrow` now read a single `--select-scroll-arrow-height` declared
+ * once on `.popup` (see select.module.css), so there's no second copy left
+ * to drift — the two tests that used to police that drift are gone. What's
+ * still worth guarding statically, because nothing about it involves
+ * layout, is the one regression a browser check already caught once.
  */
 describe('Select scroll-arrow height', () => {
-  it('declares the identical --select-scroll-arrow-height formula on .list and .scrollArrow', () => {
-    const listValue = declaredValue('.list', '--select-scroll-arrow-height');
-    const scrollArrowValue = declaredValue('.scrollArrow', '--select-scroll-arrow-height');
-    expect(listValue, '.list is missing --select-scroll-arrow-height').toBeDefined();
-    expect(listValue).toBe(scrollArrowValue);
-  });
-
-  it('reads that property from .list scroll-padding-block and .scrollArrow height', () => {
-    expect(declaredValue('.list', 'scroll-padding-block')).toBe('var(--select-scroll-arrow-height)');
-    expect(declaredValue('.scrollArrow', 'height')).toBe('var(--select-scroll-arrow-height)');
-  });
-
   // Without this, the height above is a content-box size and .scrollArrow's
   // own padding would add on top of it, rendering the arrow taller than the
   // scroll padding .list reserves for it — the exact regression the browser

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -130,6 +130,22 @@ describe('Select', () => {
     expect(trigger.hasAttribute('variant')).toBe(false);
   });
 
+  it('pads the list directly, so items placed without a SelectGroup are still inset', () => {
+    render(
+      <Select items={ITEMS} defaultOpen>
+        <SelectTrigger aria-label="Region">
+          <SelectValue placeholder="Pick a region" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="eu">Europe</SelectItem>
+          <SelectItem value="us">Americas</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const listbox = screen.getByRole('listbox');
+    expect(listbox.className).toContain(styles.list);
+  });
+
   it('renders the popup without the align-with-trigger overlay mode', () => {
     renderSelect({ defaultOpen: true });
     const popup = screen.getByRole('listbox').closest(`.${styles.popup}`);

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -129,4 +129,13 @@ describe('Select', () => {
     // The prop is a styling axis, not a DOM attribute.
     expect(trigger.hasAttribute('variant')).toBe(false);
   });
+
+  it('renders the popup without the align-with-trigger overlay mode', () => {
+    renderSelect({ defaultOpen: true });
+    const popup = screen.getByRole('listbox').closest(`.${styles.popup}`);
+    // The popup exists and no longer advertises the retired overlay mode —
+    // the attribute is gone entirely, not set to "false".
+    expect(popup).not.toBeNull();
+    expect(popup?.hasAttribute('data-align-trigger')).toBe(false);
+  });
 });

--- a/packages/ui-kit/src/components/select/select.test.tsx
+++ b/packages/ui-kit/src/components/select/select.test.tsx
@@ -1,6 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { declarationMap, extractRules } from '../../__test-utils__/css-rules';
 import {
   Select,
   SelectContent,
@@ -153,5 +158,50 @@ describe('Select', () => {
     // the attribute is gone entirely, not set to "false".
     expect(popup).not.toBeNull();
     expect(popup?.hasAttribute('data-align-trigger')).toBe(false);
+  });
+});
+
+/*
+ * jsdom computes no layout, so the scroll-arrow fix itself (does the list
+ * actually scroll and clear the selected item, do the arrows mount at the
+ * right edges) can only be verified in a real browser — see the manual
+ * verification in this change's PR/report, not a test here. What CAN be
+ * guarded statically is the one thing that could silently regress without
+ * any layout at all: .list's `scroll-padding-block` and .scrollArrow's
+ * `height` each declare their OWN copy of `--select-scroll-arrow-height`
+ * (tokens.test.ts's local-variable guard scopes a declared custom property
+ * to its own leading class, so one rule can't read the other's declaration
+ * — see select.module.css's comment on .list). Nothing enforces that the
+ * two copies stay identical except this test, which parses the raw CSS
+ * source directly (not the hashed `styles` import, which has no values left
+ * in it) — the same technique button.test.tsx's focus-ring guard uses.
+ */
+describe('Select scroll-arrow height', () => {
+  const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'select.module.css');
+  const rules = extractRules(readFileSync(cssPath, 'utf8'));
+
+  function declaredValue(leadingClass: string, prop: string): string | undefined {
+    const rule = rules.find((candidate) => candidate.selector.split(',')[0]?.trim() === leadingClass);
+    return rule ? declarationMap(rule.body).get(prop) : undefined;
+  }
+
+  it('declares the identical --select-scroll-arrow-height formula on .list and .scrollArrow', () => {
+    const listValue = declaredValue('.list', '--select-scroll-arrow-height');
+    const scrollArrowValue = declaredValue('.scrollArrow', '--select-scroll-arrow-height');
+    expect(listValue, '.list is missing --select-scroll-arrow-height').toBeDefined();
+    expect(listValue).toBe(scrollArrowValue);
+  });
+
+  it('reads that property from .list scroll-padding-block and .scrollArrow height', () => {
+    expect(declaredValue('.list', 'scroll-padding-block')).toBe('var(--select-scroll-arrow-height)');
+    expect(declaredValue('.scrollArrow', 'height')).toBe('var(--select-scroll-arrow-height)');
+  });
+
+  // Without this, the height above is a content-box size and .scrollArrow's
+  // own padding would add on top of it, rendering the arrow taller than the
+  // scroll padding .list reserves for it — the exact regression the browser
+  // check caught before this was added.
+  it('keeps .scrollArrow border-box so its height absorbs its own padding', () => {
+    expect(declaredValue('.scrollArrow', 'box-sizing')).toBe('border-box');
   });
 });

--- a/packages/ui-kit/src/components/select/select.tsx
+++ b/packages/ui-kit/src/components/select/select.tsx
@@ -90,7 +90,6 @@ export interface SelectContentProps
       | 'alignOffset'
       | 'side'
       | 'sideOffset'
-      | 'alignItemWithTrigger'
       | 'positionMethod'
       | 'collisionBoundary'
       | 'collisionPadding'
@@ -112,7 +111,6 @@ export function SelectContent({
   sideOffset = 4,
   align = 'center',
   alignOffset = 0,
-  alignItemWithTrigger = true,
   positionMethod,
   collisionBoundary,
   collisionPadding,
@@ -125,17 +123,22 @@ export function SelectContent({
         sideOffset={sideOffset}
         align={align}
         alignOffset={alignOffset}
-        alignItemWithTrigger={alignItemWithTrigger}
+        /*
+         * Never the Base UI default overlay mode (selected item aligned over
+         * the trigger): the popup always opens on `side`, below by default.
+         * With nothing selected the list starts at the top; a selected item
+         * beyond the fold is scrolled into view natively on open — Floating
+         * UI's useListNavigation calls scrollIntoView({block: 'nearest'})
+         * when a selectedIndex exists (verified against @base-ui/react 1.6.0
+         * sources), so no scroll code of ours is needed.
+         */
+        alignItemWithTrigger={false}
         positionMethod={positionMethod}
         collisionBoundary={collisionBoundary}
         collisionPadding={collisionPadding}
         className={styles.positioner}
       >
-        <SelectPrimitive.Popup
-          data-align-trigger={alignItemWithTrigger}
-          className={cx(styles.popup, className)}
-          {...props}
-        >
+        <SelectPrimitive.Popup className={cx(styles.popup, className)} {...props}>
           <SelectScrollUpButton />
           <SelectPrimitive.List>{children}</SelectPrimitive.List>
           <SelectScrollDownButton />

--- a/packages/ui-kit/src/components/select/select.tsx
+++ b/packages/ui-kit/src/components/select/select.tsx
@@ -140,7 +140,7 @@ export function SelectContent({
       >
         <SelectPrimitive.Popup className={cx(styles.popup, className)} {...props}>
           <SelectScrollUpButton />
-          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectPrimitive.List className={styles.list}>{children}</SelectPrimitive.List>
           <SelectScrollDownButton />
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>

--- a/packages/ui-kit/src/components/switch/switch.module.css
+++ b/packages/ui-kit/src/components/switch/switch.module.css
@@ -51,7 +51,10 @@
   outline-offset: 2px;
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is already an outline, not a box-shadow — forced-colors
+ * mode still flattens its author --ring color, so pin it to the system's
+ * Highlight color explicitly (same reasoning as button.module.css's own
+ * ring, restated here rather than delegated to it). */
 @media (forced-colors: active) {
   .switch:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/table/table.module.css
+++ b/packages/ui-kit/src/components/table/table.module.css
@@ -26,7 +26,10 @@
   outline-offset: 2px;
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is already an outline, not a box-shadow — forced-colors
+ * mode still flattens its author --ring color, so pin it to the system's
+ * Highlight color explicitly (same reasoning as button.module.css's own
+ * ring, restated here rather than delegated to it). */
 @media (forced-colors: active) {
   .tableContainer:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/tabs/tabs.module.css
+++ b/packages/ui-kit/src/components/tabs/tabs.module.css
@@ -147,7 +147,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .trigger:focus-visible {
     outline: 2px solid Highlight;
@@ -249,7 +251,10 @@
   outline-offset: 2px;
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is already an outline, not a box-shadow — forced-colors
+ * mode still flattens its author --ring color, so pin it to the system's
+ * Highlight color explicitly (same reasoning as button.module.css's own
+ * ring, restated here rather than delegated to it). */
 @media (forced-colors: active) {
   .content:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/textarea/textarea.module.css
+++ b/packages/ui-kit/src/components/textarea/textarea.module.css
@@ -63,7 +63,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .textarea:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/components/toast/toast.module.css
+++ b/packages/ui-kit/src/components/toast/toast.module.css
@@ -127,7 +127,9 @@
     var(--ring);
 }
 
-/* See button.module.css: forced-colors drops box-shadow, restore UA outline. */
+/* The ring above is an inset box-shadow, and forced-colors mode doesn't
+ * render box-shadow at all — add an explicit outline or the focus
+ * indicator disappears entirely under the mode. */
 @media (forced-colors: active) {
   .toast:focus-visible {
     outline: 2px solid Highlight;

--- a/packages/ui-kit/src/docs.test.ts
+++ b/packages/ui-kit/src/docs.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 // Guards the AI docs layer: every component ships a colocated usage doc, is
 // indexed in llms.txt, and the doc mentions every value of every cva styling
 // axis the component's CSS module actually defines (naming convention:
-// `.<axis>Xxx`, e.g. `.variantOutline` / `.sizeSm` / `.shapeDot` /
+// `.<axis>Xxx`, e.g. `.variantOutline` / `.sizeSm` / `.shapePlain` /
 // `.densityCompact`). AXES lists the axis names in use across the kit —
 // extend it when a component introduces a new one, or its values ship
 // undocumented.

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -126,14 +126,16 @@
   --border-width-focus: 2px;
   /*
    * The thickness a --border-width-focus ring adds INSIDE a --border-width
-   * border. Every 2px ring in the kit — focus, aria-invalid, and Table's
-   * selected row — is drawn as a recolored 1px border plus an inset shadow
-   * of this width rather than as a real border-width switch, so the ring
+   * border. Every 2px ring drawn this way — a recolored 1px border plus an
+   * inset shadow of this width, rather than a real border-width switch —
    * thickens without the element's box changing: a genuine width switch
    * grows it 1px on each edge, which shifts a control's text and, in a
-   * table, every row below the selected one. Named here rather than spelled
-   * out per module because it is one decision shared by eight components,
-   * not eight coincidences.
+   * table, every row below the selected one. Named here rather than
+   * spelled out per module because it is one decision shared by the seven
+   * components that draw it this way (Tabs, Input, Toast, Table's selected
+   * row, Textarea, Badge, Select), not seven coincidences. Button is the
+   * deliberate exception: its focus ring is drawn OUTSIDE the button as an
+   * `outline` (see button.module.css), so it never consumes --ring-inset.
    */
   --ring-inset: calc(var(--border-width-focus) - var(--border-width));
 

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -119,6 +119,9 @@
   --control-height-sm: 2rem;
   --control-height-md: 2.25rem;
   --control-height-lg: 2.5rem;
+  /* Badge's icon/dot slot only — no drawn specimen at any other size uses
+   * 12px; every other icon consumer sits on sm/md/lg above. */
+  --icon-size-xs: 0.75rem;
   --icon-size-sm: 1rem;
   --icon-size-md: 1.25rem;
   --icon-size-lg: 1.5rem;
@@ -221,12 +224,14 @@
   --primary-hover: #7c4fde;
   --primary-foreground: #ffffff;
   /* Button default variant's focus-ring tone, measured against
-   * --background (6.79:1) — a literal hex, not a var() alias, because the
-   * contrast tests parse hex directly (see src/__test-utils__/contrast.ts).
-   * A dedicated token, not --primary itself: the ring is drawn OUTSIDE the
-   * button (see button.module.css), so it only ever borders the page, and
-   * a violet a shade darker than --primary reads more clearly there than
-   * --primary's own value would. */
+   * --background: 6.79:1 light / 7.23:1 dark (the dark values below carry
+   * no comment of their own — per this file's convention, a token's
+   * comment lives in the light block only). Literal hexes, not var()
+   * aliases, because the contrast tests parse hex directly (see
+   * src/__test-utils__/contrast.ts). A dedicated token, not --primary
+   * itself: the ring is drawn OUTSIDE the button (see button.module.css),
+   * so it only ever borders the page, and a violet a shade darker than
+   * --primary reads more clearly there than --primary's own value would. */
   --primary-ring: #6d28d9;
   --secondary: #f1f5f9;
   --secondary-foreground: #0f172a;
@@ -257,10 +262,10 @@
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
   /* Button destructive variant's focus-ring tone, measured against
-   * --background (6.01:1) — a literal hex, not a var() alias, for the same
-   * reason as --primary-ring above: the contrast tests parse hex directly
-   * (see src/__test-utils__/contrast.ts). The ring is drawn outside the
-   * button, so it only ever borders the page. */
+   * --background: 6.01:1 light / 7.89:1 dark. Literal hexes, not var()
+   * aliases, for the same reason as --primary-ring above: the contrast
+   * tests parse hex directly (see src/__test-utils__/contrast.ts). The
+   * ring is drawn outside the button, so it only ever borders the page. */
   --destructive-ring: #be123c;
 
   /*
@@ -360,9 +365,6 @@
   --primary: #7c4fde;
   --primary-hover: #8257e6;
   --primary-foreground: #ffffff;
-  /* Button default variant's focus-ring tone, measured against
-   * --background (7.23:1). See the light block's --primary-ring comment
-   * for why this is a literal hex rather than a var() alias. */
   --primary-ring: #a78bfa;
   --secondary: #1e293b;
   --secondary-foreground: #f8fafc;
@@ -373,9 +375,6 @@
   --accent-foreground: #ede9fe;
   --destructive: #d63853;
   --destructive-foreground: #ffffff;
-  /* Button destructive variant's focus-ring tone, measured against
-   * --background (7.89:1). See the light block's --destructive-ring
-   * comment for why this is a literal hex rather than a var() alias. */
   --destructive-ring: #f87f8f;
   --link-foreground: #a78bfa;
   --success: #34d399;
@@ -417,9 +416,6 @@
     --primary: #7c4fde;
     --primary-hover: #8257e6;
     --primary-foreground: #ffffff;
-    /* Button default variant's focus-ring tone, measured against
-     * --background (7.23:1). See the light block's --primary-ring comment
-     * for why this is a literal hex rather than a var() alias. */
     --primary-ring: #a78bfa;
     --secondary: #1e293b;
     --secondary-foreground: #f8fafc;
@@ -430,9 +426,6 @@
     --accent-foreground: #ede9fe;
     --destructive: #d63853;
     --destructive-foreground: #ffffff;
-    /* Button destructive variant's focus-ring tone, measured against
-     * --background (7.89:1). See the light block's --destructive-ring
-     * comment for why this is a literal hex rather than a var() alias. */
     --destructive-ring: #f87f8f;
     --link-foreground: #a78bfa;
     --success: #34d399;

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -218,6 +218,14 @@
    * The dark value is Figma's own. */
   --primary-hover: #7c4fde;
   --primary-foreground: #ffffff;
+  /* Button default variant's focus-ring tone, measured against
+   * --background (6.79:1) — a literal hex, not a var() alias, because the
+   * contrast tests parse hex directly (see src/__test-utils__/contrast.ts).
+   * A dedicated token, not --primary itself: the ring is drawn OUTSIDE the
+   * button (see button.module.css), so it only ever borders the page, and
+   * a violet a shade darker than --primary reads more clearly there than
+   * --primary's own value would. */
+  --primary-ring: #6d28d9;
   --secondary: #f1f5f9;
   --secondary-foreground: #0f172a;
   /* derived (dark only): light muted equals light secondary in the
@@ -246,6 +254,12 @@
    * on both modes' reds (4.7:1 light, 4.6:1 dark). */
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
+  /* Button destructive variant's focus-ring tone, measured against
+   * --background (6.01:1) — a literal hex, not a var() alias, for the same
+   * reason as --primary-ring above: the contrast tests parse hex directly
+   * (see src/__test-utils__/contrast.ts). The ring is drawn outside the
+   * button, so it only ever borders the page. */
+  --destructive-ring: #be123c;
 
   /*
    * Link text token — Button's `link` variant, which has no drawn
@@ -344,6 +358,10 @@
   --primary: #7c4fde;
   --primary-hover: #8257e6;
   --primary-foreground: #ffffff;
+  /* Button default variant's focus-ring tone, measured against
+   * --background (7.23:1). See the light block's --primary-ring comment
+   * for why this is a literal hex rather than a var() alias. */
+  --primary-ring: #a78bfa;
   --secondary: #1e293b;
   --secondary-foreground: #f8fafc;
   --muted: #1e293b;
@@ -353,6 +371,10 @@
   --accent-foreground: #ede9fe;
   --destructive: #d63853;
   --destructive-foreground: #ffffff;
+  /* Button destructive variant's focus-ring tone, measured against
+   * --background (7.89:1). See the light block's --destructive-ring
+   * comment for why this is a literal hex rather than a var() alias. */
+  --destructive-ring: #f87f8f;
   --link-foreground: #a78bfa;
   --success: #34d399;
   --success-soft: #0d2921;
@@ -393,6 +415,10 @@
     --primary: #7c4fde;
     --primary-hover: #8257e6;
     --primary-foreground: #ffffff;
+    /* Button default variant's focus-ring tone, measured against
+     * --background (7.23:1). See the light block's --primary-ring comment
+     * for why this is a literal hex rather than a var() alias. */
+    --primary-ring: #a78bfa;
     --secondary: #1e293b;
     --secondary-foreground: #f8fafc;
     --muted: #1e293b;
@@ -402,6 +428,10 @@
     --accent-foreground: #ede9fe;
     --destructive: #d63853;
     --destructive-foreground: #ffffff;
+    /* Button destructive variant's focus-ring tone, measured against
+     * --background (7.89:1). See the light block's --destructive-ring
+     * comment for why this is a literal hex rather than a var() alias. */
+    --destructive-ring: #f87f8f;
     --link-foreground: #a78bfa;
     --success: #34d399;
     --success-soft: #0d2921;

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -373,6 +373,7 @@ describe('theme tokens', () => {
       '--control-height-sm',
       '--control-height-md',
       '--control-height-lg',
+      '--icon-size-xs',
       '--icon-size-sm',
       '--icon-size-md',
       '--icon-size-lg',

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -120,6 +120,13 @@ describe('theme tokens', () => {
     const css = readFileSync(file, 'utf8');
     const rules = extractRules(css);
 
+    // A component's own public override hooks (button.module.css's
+    // --button-bg/-fg/-border{,-hover}, see button.md's "Custom colors")
+    // are named `--<component>-*`, derived from the module's own filename —
+    // NOT declared anywhere in the module, by design: the kit never sets
+    // them, a consumer class does. `--${basename(file, '.module.css')}-`.
+    const hookPrefix = `--${basename(file, '.module.css')}-`;
+
     // Collect each class's own locally-declared custom properties first...
     const locallyDeclaredByClass = new Map<string, Set<string>>();
     for (const rule of rules) {
@@ -143,15 +150,38 @@ describe('theme tokens', () => {
     // since there's no "part" to scope one to; they must be a real token.
     for (const rule of rules) {
       const cls = leadingClass(rule.selector);
+      // Captures whether a fallback follows the name (`match[2] === ','`)
+      // so the loop below can dedup by token+fallback-shape, not token
+      // alone — the same token consumed once with a fallback and once
+      // without (a bug: the fallback-less usage resolves to nothing at
+      // runtime if nobody sets it) must still be flagged for that second
+      // usage even though the first is exempt.
       const used = Array.from(
-        rule.body.matchAll(/var\((--[a-z0-9-]+)/g),
-        (match) => match[1] ?? '',
+        rule.body.matchAll(/var\((--[a-z0-9-]+)\s*([,)])/g),
+        (match) => ({ token: match[1] ?? '', hasFallback: match[2] === ',' }),
       );
-      for (const token of Array.from(new Set(used))) {
+      const seen = new Set<string>();
+      for (const { token, hasFallback } of used) {
+        const key = `${token}${hasFallback ? ',' : ''}`;
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
         if (BASE_UI_RUNTIME_VARS.has(token)) {
           continue;
         }
         if (cls && locallyDeclaredByClass.get(cls)?.has(token)) {
+          continue;
+        }
+        // Consumer-override hook: a `--<component>-*` property consumed
+        // WITH a fallback needs no declaration anywhere — the fallback IS
+        // the kit default, so the var() resolves by construction whether
+        // or not a consumer ever sets the property. This guard exists to
+        // catch vars that resolve to nothing; a hook with a fallback
+        // never does. The component-name prefix (not "any fallback var is
+        // exempt") keeps this from also waving through a typoed theme
+        // token that happens to carry a fallback.
+        if (hasFallback && token.startsWith(hookPrefix)) {
           continue;
         }
         expect(definedTokens.has(token), `${token} is not defined in theme.css`).toBe(true);

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -464,9 +464,10 @@ describe('theme tokens', () => {
     // above, live off theme.css, so a token drifting back under its floor
     // fails this test instead of shipping a color no one re-measured.
     // Button's OWN focus-ring cases live in button.test.tsx instead: they
-    // need to read button.module.css's actual --button-focus-ring{,-inner}
-    // declarations per variant, which makes them a Button-specific guard,
-    // not a theme-level one — see that file for why, and for the shared
+    // need to read button.module.css's actual --button-focus-ring
+    // declaration (a single tone drawn outside the button via outline +
+    // outline-offset), which makes them a Button-specific guard, not a
+    // theme-level one — see that file for why, and for the shared
     // contrastRatio/extractRules utilities both files import.
     //
     // Every case below reads a token's LITERAL hex out of theme.css via


### PR DESCRIPTION
Four requested API changes to the kit, plus two follow-ups that came out of reviewing the result. Backward compatibility was explicitly not a goal — the package is in early alpha.

## Select — the list always sits below the input

`SelectContent` no longer overlays the trigger the way a native `<select>` does; the popup opens on its `side` (below by default). With nothing selected the list starts at the top, and a selected option beyond the fold is scrolled into view when the popup opens — Base UI's own `scrollIntoView` on open does this, so the kit carries no scroll code of its own. `alignItemWithTrigger` is gone from the props.

The dropdown's inner padding moved from `SelectGroup` to the list itself, so a select whose items sit directly under `SelectContent` is padded identically to a grouped one — previously a groupless list had its options flush against the popup edges, and the fix means `SelectGroup` is now purely about labelled sections. `SelectSeparator` took over the full gap between sections so the inter-group rhythm survived the move.

## Button — arbitrary colours from a consumer className

Variant colours now resolve through `var(--button-bg, <variant token>)` and friends, so a consumer class can recolour a button without a new variant:

```css
.buy { --button-bg: var(--success); --button-bg-hover: color-mix(in oklab, var(--success) 90%, var(--foreground) 10%); }
```

Five hooks: `--button-bg`, `--button-fg`, `--button-border`, `--button-bg-hover`, `--button-fg-hover`. Setting only `--button-bg` keeps the button that colour in every state — hover falls back to your rest colour rather than snapping back to the variant's token. Before this, a rest-state override was a stylesheet-order race and hover always lost.

## Input — `icon` and `end` slots

`icon` renders a leading decorative icon (aria-hidden, no pointer events); `end` renders trailing interactive content — a clear button, a reveal toggle — after the input in the DOM, so tab order is field then slot. With neither prop the component is still a bare `<input>` with no wrapper.

## Badge — opt-in dot, new icon slot

The status dot is now the `dot` prop instead of an unconditional `::before`, and a new `icon` render prop takes its place when both are given. Default is neither. The `shape` axis frees the name: `pill | plain`.

## Focus ring, reworked

Button's focus ring used to be two-toned — an outer border in `--info` plus an inner inset shadow — because it was drawn on the button's edge, where a same-hue ring cannot clear WCAG 1.4.11's 3:1 against the button's own fill. The result was a blue ring in light mode and a cyan one in dark, next to a violet button.

The ring now sits outside the element (`outline` + `outline-offset: 2px`), so it only ever borders the page background. That allows a single tone per variant in the button's own colour family: `--primary-ring` for default (6.79:1 light / 7.23:1 dark against the page), `--destructive-ring` for destructive (6.01 / 7.89), and the shared `--ring` for the rest (4.05 / 3.78). The previous outer tone measured 3.91:1 in light mode, so this is more headroom, not less. `--button-focus-ring-inner` is retired.

One consequence worth knowing: the ring occupies 4px beyond the button's box, so in a tightly packed group with no gaps it sits closer to neighbours than the old on-edge ring did, and an `overflow: hidden` ancestor can clip it.

## Breaking changes

| Change | Migration |
|---|---|
| `SelectContent` dropped `alignItemWithTrigger` | Remove the prop; the behaviour it selected is now the only behaviour |
| `type="search"` no longer auto-renders a magnifier | Pass one via `icon` |
| Badge renders no dot by default | Add `dot` where the marker is wanted |
| `shape="dot"` → `shape="plain"` | Rename |
| `--button-focus-ring-inner` retired | Set `--button-focus-ring` alone; it is a single tone now |
| Badge no longer sizes a bare `<svg>` child | Move the icon into the `icon` prop |

`llms.txt` and every touched component's `.md` were updated in step, since insight-front's migration reads them.

## Verification

284 tests pass (21 files), including new coverage for the derived `data-dot` precedence, the slot DOM/tab order, a disabled field's `end` slot going inert, dropdown padding belonging to the list rather than the group, the popup's resolved side, and each variant's focus-ring token identity. `type-check`, `type-check:test`, `type-check:demo`, `eslint --max-warnings 0`, `test:consumer` (vite / esbuild barrel + subpath / webpack / types) and `cfs validate` (54 artifacts, 0 errors) are all clean.

Checked in a browser as well: popup below the trigger with the pre-selected item already visible, identical 4px padding across grouped and groupless dropdowns, a `--button-bg` override holding through hover, the search field's slots with correct tab order, and the badge dot/icon states. The focus ring was verified per variant in both themes against its expected token.

Version moves to `0.3.0-alpha.2` — the next alpha of the in-flight 0.3.0 line, which has never shipped, so the breaks ride the alpha counter rather than burning a minor (per Gera's review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Badges support optional status dots or icons, with a new plain shape.
  - Inputs support explicit leading icons and trailing content, including clear actions; search icons are no longer added automatically.
  - Select menus provide improved grouping, spacing, scrolling, and positioning.
  - Buttons support customizable colors and improved focus-ring styling.

- **Documentation**
  - Updated component guidance and examples for Badge, Button, Input, and Select.

- **Chores**
  - Updated the UI kit release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
