### PR TITLE
chore: require Signed-off-by trailer on commits (DCO enforcement)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@
 # Run: npx prek install (to install git hooks)
 # Run: npx prek run --all-files (to run all hooks)
 
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+
 repos:
   # Built-in hooks (fast, Rust-native)
   - repo: builtin
@@ -62,3 +65,8 @@ repos:
         entry: npm run arch:guards
         language: system
         pass_filenames: false
+      - id: require-signoff
+        name: Require Signed-off-by trailer (commit with `git commit -s`)
+        entry: 'bash -c ''grep -qE "^Signed-off-by: .+ <.+>$" "$1" || { echo "Commit rejected: missing Signed-off-by trailer. Commit with: git commit -s"; exit 1; }'' --'
+        language: system
+        stages: [commit-msg]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ git commit -s -m "feat: describe the change"
 
 To add a missing sign-off to the latest commit, run `git commit --amend -s --no-edit`. To sign off a range of commits, run `git rebase --signoff <base>` (e.g. `git rebase --signoff HEAD~3` to cover the last three), then push with `--force-with-lease`. Note that `git rebase --signoff` appends the trailer even when a `Signed-off-by` already exists earlier in the message (it only skips when an identical sign-off is last), so rebasing over already-signed commits that end in `Co-Authored-By` adds a duplicate line - pick a `<base>` that spans only the commits missing the trailer.
 
+This is enforced locally by a `commit-msg` hook (`require-signoff` in [`.pre-commit-config.yaml`](.pre-commit-config.yaml)); commits without the trailer are rejected before they're made. The hook is installed automatically by `npm install` (via the `prepare` script) — if commits aren't being checked, run `npx prek install`.
+
 ## Versioning
 
 The project is **pre-1.0** — backward compatibility is not guaranteed.


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md already documents the DCO sign-off requirement ("## Commit Requirements"), but nothing enforced it locally — commits without `Signed-off-by` went through unchecked.
- Add a `require-signoff` commit-msg hook to `.pre-commit-config.yaml` that rejects commits missing the trailer.
- Set `default_install_hook_types: [pre-commit, commit-msg]` so `npm install`'s `prepare` script (`prek install`, no args) actually installs the commit-msg hook — by default `prek` only installs `pre-commit` hooks.
- Add a short note to CONTRIBUTING.md's existing sign-off section pointing at the new enforcement.

## Test plan
- [x] `git commit -s -m "..."` — hook passes, trailer present
- [x] Verified `prek run --all-files` still passes for existing hooks
- [ ] Reviewer: confirm a commit made without `-s` is rejected locally after `npx prek install`