### PR TITLE
fix: harden the DCO commit-msg hook and point agents at CONTRIBUTING.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,9 @@ repos:
         entry: npm run arch:guards
         language: system
         pass_filenames: false
+      # See check-dco-signoff.mjs's own docblock for what this hook checks.
       - id: require-signoff
         name: Require Signed-off-by trailer (commit with `git commit -s`)
-        entry: 'bash -c ''grep -qE "^Signed-off-by: .+ <.+>$" "$1" || { echo "Commit rejected: missing Signed-off-by trailer. Commit with: git commit -s"; exit 1; }'' --'
+        entry: node scripts/check-dco-signoff.mjs
         language: system
         stages: [commit-msg]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,6 @@ AI tooling and FrontX development guidelines are provided by the Constructor Stu
 
 Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Ecosystem code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds. Template territory — any top-level directory carrying a `frontx-template.json` manifest (how `scripts/template-discovery.mjs` finds templates) — sits outside this chain: markers found there are non-authoritative residue being retired as files change (`cpt-frontx-adr-template-territory-traceability`).
 
+Commit requirements — DCO sign-off (`git commit -s`), branch targets, PR flow — live in `CONTRIBUTING.md`; read it before your first commit, including how it's enforced.
+
 ALL user requests MUST be handled by the Orchestrator agent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,4 +10,6 @@ AI tooling and FrontX development guidelines are provided by the Constructor Stu
 
 Treat `architecture/` as the authority on what the system is and why: PRD for intent, DESIGN for structure, ADRs for decisions, and each FEATURE for the behaviour its numbered instructions specify. Ecosystem code carries `@cpt-` markers back to those instructions; `cfs validate` checks that the chain holds. Template territory — any top-level directory carrying a `frontx-template.json` manifest (how `scripts/template-discovery.mjs` finds templates) — sits outside this chain: markers found there are non-authoritative residue being retired as files change (`cpt-frontx-adr-template-territory-traceability`).
 
+Commit requirements — DCO sign-off (`git commit -s`), branch targets, PR flow — live in `CONTRIBUTING.md`; read it before your first commit, including how it's enforced.
+
 ALL user requests MUST be handled by the Orchestrator agent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ git commit -s -m "feat: describe the change"
 
 To add a missing sign-off to the latest commit, run `git commit --amend -s --no-edit`. To sign off a range of commits, run `git rebase --signoff <base>` (e.g. `git rebase --signoff HEAD~3` to cover the last three), then push with `--force-with-lease`. Note that `git rebase --signoff` appends the trailer even when a `Signed-off-by` already exists earlier in the message (it only skips when an identical sign-off is last), so rebasing over already-signed commits that end in `Co-Authored-By` adds a duplicate line - pick a `<base>` that spans only the commits missing the trailer.
 
-This is enforced locally by a `commit-msg` hook (`require-signoff` in [`.pre-commit-config.yaml`](.pre-commit-config.yaml)); commits without the trailer are rejected before they're made. The hook is installed automatically by `npm install` (via the `prepare` script) — if commits aren't being checked, run `npx prek install`.
+This is enforced locally by a `commit-msg` hook (`require-signoff` in [`.pre-commit-config.yaml`](.pre-commit-config.yaml), backed by `scripts/check-dco-signoff.mjs`); commits without the trailer, or whose trailer matches neither the author nor the committer, are rejected before they're made; merge commits are exempt, as they are in CI. The hook only runs for `git commit` — `git cherry-pick`, `git rebase` and `git rebase --signoff` bypass `commit-msg` hooks entirely, so check those results yourself. CI's DCO check enforces the same rules after push, where fixing it means rewriting history. The hook is installed automatically by `npm install` (via the `prepare` script) — if commits aren't being checked, run `npx prek install`.
 
 ## Versioning
 

--- a/scripts/check-dco-signoff.mjs
+++ b/scripts/check-dco-signoff.mjs
@@ -1,0 +1,239 @@
+/**
+ * DCO Sign-off Commit Guard.
+ *
+ * CONTRIBUTING.md requires a `Signed-off-by` trailer on every commit
+ * (Developer Certificate of Origin), and CI enforces it with the DCO check —
+ * but CI is the most expensive possible place to learn about a missing
+ * trailer: the PR is already open, the push already made, and the fix is a
+ * history rewrite (`git rebase --signoff` + `--force-with-lease`). PR #562
+ * shipped exactly that way. This guard moves the failure to commit time,
+ * where the fix is re-running one command.
+ *
+ * Wired as a `commit-msg`-stage hook in `.pre-commit-config.yaml`
+ * (installed for every contributor by `npm install` → `prek install`; see
+ * `default_install_hook_types` there). prek passes the commit-message file
+ * path as the only argument.
+ *
+ * What counts as signed: a `Signed-off-by: Name <email>` trailer line, the
+ * exact shape `git commit -s` writes. Merges are exempt, matching the DCO CI
+ * check's own exemption — but that exemption is keyed off actual merge state
+ * (`MERGE_HEAD` present, the same signal `dco2` reads), never off the
+ * commit message's first line: a hand-written "Merge the two config loaders"
+ * subject is not a merge, and a real merge with a custom subject still is.
+ *
+ * When a `Signed-off-by` trailer is present, its name/email is also compared
+ * (case-insensitively) against the commit's author and committer idents —
+ * the same `SignOffMismatch` comparison the CI DCO check makes, which accepts
+ * a match against either. The author comes from `GIT_AUTHOR_NAME`/`_EMAIL`,
+ * which git exports into the hook's environment (so `--author=`, `git am`
+ * and `cherry-pick -x` relays keep their original sign-off); the committer
+ * from `git var GIT_COMMITTER_IDENT`, which git resolves even when
+ * `user.name` is unset. Only if neither ident can be resolved does the check
+ * fall back to trailer-presence only.
+ *
+ * CLI entry: `node scripts/check-dco-signoff.mjs <commit-msg-file>`
+ * (exit 0 when signed or exempt). Core logic is exported for unit tests in
+ * `scripts/check-dco-signoff.test.mjs`.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const SIGNOFF_PATTERN = /^Signed-off-by: (.+) <(.+@.+)>[ \t]*$/gim;
+
+/**
+ * @param {string} message full commit message, comment lines included
+ * @returns {{ name: string; email: string }[]}
+ */
+function trailers(message) {
+  // Assumes the default git comment char `#`; does not read `core.commentChar`
+  // — if that's overridden, git's comment block isn't stripped here.
+  const effective = message
+    .split('\n')
+    .filter((line) => !line.startsWith('#'))
+    .join('\n');
+  return [...effective.matchAll(SIGNOFF_PATTERN)].map(([, name, email]) => ({ name, email }));
+}
+
+/** @typedef {{ name: string; email: string }} Identity */
+
+/**
+ * @param {string} message full commit message, comment lines included
+ * @param {{ isMerge?: boolean; identities?: Identity[] }} [options]
+ *   `identities` — the idents a sign-off may match (author and committer);
+ *   empty or absent means presence-only checking.
+ * @returns {{ ok: true } | { ok: false, reason: 'missing-signoff' | 'sign-off-mismatch', message: string }}
+ */
+export function checkMessage(message, options = {}) {
+  const { isMerge = false, identities = [] } = options;
+
+  if (isMerge) return { ok: true };
+
+  const found = trailers(message);
+  if (found.length === 0) {
+    return {
+      ok: false,
+      reason: 'missing-signoff',
+      message:
+        'Commit message carries no `Signed-off-by` trailer.\n\n' +
+        'CONTRIBUTING.md (Commit Requirements) requires a DCO sign-off on every commit:\n' +
+        '  git commit -s ...\n' +
+        'To sign the commit you were just writing, re-run the same command with -s added.\n' +
+        'The CI DCO check enforces the same rule after push, where fixing it means rewriting history.',
+    };
+  }
+
+  if (identities.length > 0) {
+    const matches = found.some((trailer) =>
+      identities.some(
+        (id) => trailer.name.toLowerCase() === id.name.toLowerCase() && trailer.email.toLowerCase() === id.email.toLowerCase(),
+      ),
+    );
+    if (!matches) {
+      const expected = identities.map((id) => `${id.name} <${id.email}>`).join(' or ');
+      return {
+        ok: false,
+        reason: 'sign-off-mismatch',
+        message:
+          `Commit message's \`Signed-off-by\` trailer matches neither the author nor the committer ` +
+          `(SignOffMismatch): expected ${expected}.\n\n` +
+          'The CI DCO check makes the same comparison. If this is your own commit, re-run:\n' +
+          '  git commit -s ...\n' +
+          "so the trailer is written from your ident. If you are relaying someone else's commit, keep their\n" +
+          'trailer and preserve them as the author (`--author=`, `git am`, `cherry-pick -x`) instead.',
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * @param {string} gitDir
+ * @returns {boolean}
+ */
+export function detectIsMerge(gitDir) {
+  try {
+    return fs.existsSync(path.join(gitDir, 'MERGE_HEAD'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} [cwd]
+ * @returns {string | undefined} the `$GIT_DIR` of the repository at `cwd`
+ */
+export function resolveGitDir(cwd = process.cwd()) {
+  try {
+    const dir = execFileSync('git', ['rev-parse', '--git-dir'], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    return path.resolve(cwd, dir);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parses `git var` output — `Name <email> <timestamp> <tz>`.
+ * @param {string} ident
+ * @returns {Identity | undefined}
+ */
+function parseIdent(ident) {
+  const match = /^(.+?) <(.+@.+?)>(?: |$)/.exec(ident.trim());
+  return match ? { name: match[1], email: match[2] } : undefined;
+}
+
+/**
+ * @param {'GIT_AUTHOR_IDENT' | 'GIT_COMMITTER_IDENT'} name
+ * @param {string} cwd
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {Identity | undefined}
+ */
+function gitVar(name, cwd, env) {
+  try {
+    return parseIdent(execFileSync('git', ['var', name], { cwd, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The idents a sign-off may match, as CI sees them: the author (from the
+ * `GIT_AUTHOR_*` environment git hands every hook, falling back to
+ * `git var GIT_AUTHOR_IDENT`) and the committer (`git var GIT_COMMITTER_IDENT`).
+ * @param {{ cwd?: string; env?: NodeJS.ProcessEnv }} [options]
+ * @returns {Identity[]} deduplicated; empty when neither can be resolved
+ */
+export function resolveIdentities(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  /** @type {Identity[]} */
+  const found = [];
+  if (env.GIT_AUTHOR_NAME && env.GIT_AUTHOR_EMAIL) {
+    found.push({ name: env.GIT_AUTHOR_NAME, email: env.GIT_AUTHOR_EMAIL });
+  } else {
+    const author = gitVar('GIT_AUTHOR_IDENT', cwd, env);
+    if (author) found.push(author);
+  }
+  const committer = gitVar('GIT_COMMITTER_IDENT', cwd, env);
+  if (committer) found.push(committer);
+  return found.filter(
+    (id, index) => found.findIndex((other) => other.name === id.name && other.email === id.email) === index,
+  );
+}
+
+/**
+ * @param {{
+ *   argv?: string[];
+ *   log?: (line: string) => void;
+ *   logError?: (line: string) => void;
+ *   isMerge?: boolean;
+ *   identities?: Identity[];
+ *   readFile?: (file: string, encoding: string) => string;
+ * }} [options]
+ * @returns {number} 0 when signed or exempt, 1 otherwise.
+ */
+export function runCli(options = {}) {
+  const argv = options.argv ?? process.argv.slice(2);
+  const log = options.log ?? console.log;
+  const logError = options.logError ?? console.error;
+  const readFile = options.readFile ?? fs.readFileSync;
+
+  const messageFile = argv[0];
+  if (!messageFile) {
+    logError('[check-dco-signoff] FAIL: no commit-message file argument — the hook is miswired, not the commit unsigned.');
+    return 1;
+  }
+  let message;
+  try {
+    message = readFile(messageFile, 'utf8');
+  } catch (error) {
+    logError(`[check-dco-signoff] FAIL: cannot read ${messageFile}: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  const isMerge =
+    options.isMerge ??
+    (() => {
+      const gitDir = resolveGitDir();
+      return gitDir ? detectIsMerge(gitDir) : false;
+    })();
+
+  const identities = options.identities ?? resolveIdentities();
+
+  const result = checkMessage(message, { isMerge, identities });
+  if (!result.ok) {
+    logError(`[check-dco-signoff] FAIL: ${result.message}`);
+    return 1;
+  }
+  log('[check-dco-signoff] Signed-off-by trailer present.');
+  return 0;
+}
+
+const isEntryPoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntryPoint) {
+  process.exitCode = runCli();
+}

--- a/scripts/check-dco-signoff.test.mjs
+++ b/scripts/check-dco-signoff.test.mjs
@@ -1,0 +1,296 @@
+// @cpt-dod:cpt-frontx-dod-unit-test-generation-and-agent-verification-standard-test-convention:p1
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkMessage, detectIsMerge, resolveGitDir, resolveIdentities, runCli } from './check-dco-signoff.mjs';
+
+/** @type {string | undefined} */
+let workDir;
+
+afterEach(async () => {
+  if (workDir) await rm(workDir, { recursive: true, force: true });
+});
+
+/** @param {string} content */
+async function writeMessageFile(content) {
+  workDir = await mkdtemp(path.join(tmpdir(), 'frontx-dco-'));
+  const file = path.join(workDir, 'COMMIT_EDITMSG');
+  await writeFile(file, content);
+  return file;
+}
+
+/** Runs the guard with stdout/stderr captured separately, so a case can assert which stream it used. */
+/**
+ * @param {string[]} argv
+ * @param {Partial<Parameters<typeof runCli>[0]>} [overrides]
+ */
+function run(argv, overrides = {}) {
+  /** @type {string[]} */
+  const stdout = [];
+  /** @type {string[]} */
+  const stderr = [];
+  // isMerge/identity default to values that don't depend on the real git
+  // state of whatever checkout runs this suite.
+  const exitCode = runCli({
+    argv,
+    log: (/** @type {string} */ line) => stdout.push(line),
+    logError: (/** @type {string} */ line) => stderr.push(line),
+    isMerge: false,
+    identities: [],
+    ...overrides,
+  });
+  return { exitCode, stdout: stdout.join('\n'), stderr: stderr.join('\n') };
+}
+
+describe('checkMessage', () => {
+  it('accepts the exact trailer shape `git commit -s` writes', () => {
+    expect(checkMessage('fix: thing\n\nSigned-off-by: A B <a@b.c>\n').ok).toBe(true);
+  });
+
+  it('accepts a mixed-case `signed-off-by` keyword with trailing whitespace, matching CI', () => {
+    const message = 'fix: thing\n\nsigned-off-by: A B <a@b.c>  \n';
+    expect(checkMessage(message).ok).toBe(true);
+  });
+
+  it('accepts a sign-off followed by other trailers', () => {
+    const message = 'fix: thing\n\nSigned-off-by: A B <a@b.c>\nCo-Authored-By: Claude <noreply@anthropic.com>\n';
+    expect(checkMessage(message).ok).toBe(true);
+  });
+
+  it('rejects a message with no trailer, naming the fix', () => {
+    const result = checkMessage('fix: thing\n');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('missing-signoff');
+    expect(result.message).toContain('git commit -s');
+  });
+
+  it('rejects a malformed trailer (no email)', () => {
+    expect(checkMessage('fix: thing\n\nSigned-off-by: just a name\n').ok).toBe(false);
+  });
+
+  it('does not count a Signed-off-by quoted inside git comment lines', () => {
+    const message = 'fix: thing\n\n# Please enter the commit message\n#\tSigned-off-by: Ghost <g@h.i>\n';
+    expect(checkMessage(message).ok).toBe(false);
+  });
+
+  it('exempts an actual merge (isMerge: true) even with a non-"Merge" subject', () => {
+    const result = checkMessage('Fold the two config loaders into one\n', { isMerge: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not exempt a "Merge ..." subject when isMerge is false — merge state, not message text, decides', () => {
+    const result = checkMessage("Merge branch 'develop' into feature\n", { isMerge: false });
+    expect(result.ok).toBe(false);
+  });
+
+  it('does not exempt a "Merge ..." subject when isMerge is omitted (defaults to false)', () => {
+    const result = checkMessage("Merge branch 'develop' into feature\n");
+    expect(result.ok).toBe(false);
+  });
+
+  it('passes when the trailer matches the configured committer identity', () => {
+    const message = 'fix: thing\n\nSigned-off-by: A B <a@b.c>\n';
+    const result = checkMessage(message, { identities: [{ name: 'A B', email: 'a@b.c' }] });
+    expect(result.ok).toBe(true);
+  });
+
+  it('matches the configured identity case-insensitively', () => {
+    const message = 'fix: thing\n\nSigned-off-by: A B <A@B.C>\n';
+    const result = checkMessage(message, { identities: [{ name: 'a b', email: 'a@b.c' }] });
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails with a sign-off-mismatch reason when the trailer names a different person and identity is configured', () => {
+    const message = 'fix: thing\n\nSigned-off-by: Someone Else <someone@else.com>\n';
+    const result = checkMessage(message, { identities: [{ name: 'A B', email: 'a@b.c' }] });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('sign-off-mismatch');
+    expect(result.message).toContain('SignOffMismatch');
+  });
+
+  it('accepts a trailer matching the author when the committer differs — the relayed-commit case CI accepts', () => {
+    const message = 'fix: thing\n\nSigned-off-by: Bob <bob@example.com>\n';
+    const identities = [
+      { name: 'Bob', email: 'bob@example.com' },
+      { name: 'Alice', email: 'alice@example.com' },
+    ];
+    expect(checkMessage(message, { identities }).ok).toBe(true);
+  });
+
+  it('accepts a trailer matching the committer when the author differs', () => {
+    const message = 'fix: thing\n\nSigned-off-by: Alice <alice@example.com>\n';
+    const identities = [
+      { name: 'Bob', email: 'bob@example.com' },
+      { name: 'Alice', email: 'alice@example.com' },
+    ];
+    expect(checkMessage(message, { identities }).ok).toBe(true);
+  });
+
+  it('names both idents in the mismatch message and does not tell a relayer to re-sign as themselves', () => {
+    const message = 'fix: thing\n\nSigned-off-by: Someone Else <someone@else.com>\n';
+    const identities = [
+      { name: 'Bob', email: 'bob@example.com' },
+      { name: 'Alice', email: 'alice@example.com' },
+    ];
+    const result = checkMessage(message, { identities });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.message).toContain('Bob <bob@example.com> or Alice <alice@example.com>');
+    expect(result.message).toContain('relaying');
+  });
+
+  it('falls back to presence-only checking when no ident could be resolved', () => {
+    const message = 'fix: thing\n\nSigned-off-by: Anybody At All <anybody@example.com>\n';
+    expect(checkMessage(message, { identities: [] }).ok).toBe(true);
+  });
+});
+
+describe('runCli', () => {
+  it('passes a signed commit-message file', async () => {
+    const file = await writeMessageFile('fix: x\n\nSigned-off-by: A B <a@b.c>\n');
+    const { exitCode, stdout } = run([file]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('trailer present');
+  });
+
+  it('fails an unsigned commit-message file with the CONTRIBUTING.md pointer, printed to stderr', async () => {
+    const file = await writeMessageFile('fix: x\n');
+    const { exitCode, stdout, stderr } = run([file]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('CONTRIBUTING.md');
+    expect(stdout).toBe('');
+  });
+
+  it('fails closed when miswired (no argument) with a message that says so', () => {
+    const { exitCode, stderr } = run([]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('miswired');
+  });
+
+  it('fails closed on an unreadable file', () => {
+    const { exitCode, stderr } = run(['/nonexistent/COMMIT_EDITMSG']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('cannot read');
+  });
+
+  it('fails closed on an unreadable file via an injected readFile, matching the file\'s DI conventions', () => {
+    const readFile = () => {
+      throw new Error('EACCES: permission denied');
+    };
+    const { exitCode, stderr } = run(['COMMIT_EDITMSG'], { readFile });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('cannot read');
+    expect(stderr).toContain('permission denied');
+  });
+
+  it('exempts a non-"Merge"-prefixed subject when isMerge is injected true', async () => {
+    const file = await writeMessageFile('Fold the two config loaders into one\n');
+    const { exitCode } = run([file], { isMerge: true });
+    expect(exitCode).toBe(0);
+  });
+
+  it('rejects a "Merge ..." subject with no trailer when isMerge is false — the message-text regression case', async () => {
+    const file = await writeMessageFile("Merge branch 'develop' into feature\n");
+    const { exitCode, stderr } = run([file], { isMerge: false });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Signed-off-by');
+  });
+
+  it('fails with a SignOffMismatch reason when the injected identity does not match the trailer', async () => {
+    const file = await writeMessageFile('fix: x\n\nSigned-off-by: A B <a@b.c>\n');
+    const { exitCode, stderr } = run([file], { identities: [{ name: 'C D', email: 'c@d.e' }] });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('SignOffMismatch');
+  });
+});
+
+describe('git-backed helpers (temp repository)', () => {
+  /** @type {string} */
+  let repo;
+  /** @type {NodeJS.ProcessEnv} */
+  let env;
+
+  /** @param {string[]} args */
+  const git = (args) => execFileSync('git', args, { cwd: repo, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+  beforeEach(async () => {
+    repo = await mkdtemp(path.join(tmpdir(), 'frontx-dco-repo-'));
+    // Pin the committer through the environment so the case is independent
+    // of whatever identity the machine running the suite has configured, and
+    // so no GIT_AUTHOR_* leaks in from an enclosing hook or rebase.
+    env = { ...process.env };
+    for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
+    Object.assign(env, {
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_COMMITTER_NAME: 'Alice',
+      GIT_COMMITTER_EMAIL: 'alice@example.com',
+    });
+    git(['init', '-q', '-b', 'main']);
+    git(['config', 'user.name', 'Alice']);
+    git(['config', 'user.email', 'alice@example.com']);
+    await writeFile(path.join(repo, 'a.txt'), 'a\n');
+    git(['add', 'a.txt']);
+    git(['commit', '-q', '-m', 'base']);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('resolveGitDir finds .git from a subdirectory', async () => {
+    const sub = path.join(repo, 'nested');
+    await import('node:fs/promises').then((fsp) => fsp.mkdir(sub));
+    expect(resolveGitDir(sub)).toBe(path.join(repo, '.git'));
+  });
+
+  it('resolveGitDir returns undefined outside a repository', async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), 'frontx-dco-norepo-'));
+    try {
+      expect(resolveGitDir(outside)).toBeUndefined();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('detectIsMerge is false normally and true while MERGE_HEAD exists', async () => {
+    const gitDir = /** @type {string} */ (resolveGitDir(repo));
+    expect(detectIsMerge(gitDir)).toBe(false);
+
+    git(['checkout', '-q', '-b', 'topic']);
+    await writeFile(path.join(repo, 'b.txt'), 'b\n');
+    git(['add', 'b.txt']);
+    git(['commit', '-q', '-m', 'topic']);
+    git(['checkout', '-q', 'main']);
+    await writeFile(path.join(repo, 'c.txt'), 'c\n');
+    git(['add', 'c.txt']);
+    git(['commit', '-q', '-m', 'main']);
+    git(['merge', '--no-commit', '--no-ff', 'topic']);
+
+    expect(detectIsMerge(gitDir)).toBe(true);
+  });
+
+  it('resolveIdentities yields the committer from git var when no author is exported', () => {
+    expect(resolveIdentities({ cwd: repo, env })).toEqual([{ name: 'Alice', email: 'alice@example.com' }]);
+  });
+
+  it('resolveIdentities adds the author from GIT_AUTHOR_* ahead of the committer', () => {
+    const hookEnv = { ...env, GIT_AUTHOR_NAME: 'Bob', GIT_AUTHOR_EMAIL: 'bob@example.com' };
+    expect(resolveIdentities({ cwd: repo, env: hookEnv })).toEqual([
+      { name: 'Bob', email: 'bob@example.com' },
+      { name: 'Alice', email: 'alice@example.com' },
+    ]);
+  });
+
+  it('resolveIdentities still resolves the committer when user.name is unset', () => {
+    git(['config', '--unset', 'user.name']);
+    git(['config', '--unset', 'user.email']);
+    // git var falls back to GIT_COMMITTER_* from the environment.
+    expect(resolveIdentities({ cwd: repo, env })).toEqual([{ name: 'Alice', email: 'alice@example.com' }]);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> Reworked after `49bc1f0c` landed the `require-signoff` hook on develop as an inline bash grep (this PR and that commit were written independently for the same reason — PR #562's DCO failure). Rebased; this now **hardens that hook** rather than adding a competing one: same hook id, same wiring, the check moves into a tested script.

## What the inline grep gets wrong (and this fixes)

- **Merge commits are rejected.** The grep runs on every commit-msg invocation, so any unsigned `git merge` fails locally — but the CI DCO check exempts merge commits, and nobody rewrites a merge to sign it. The script mirrors the CI exemption.
- **A `Signed-off-by` inside git's `#` comment lines counts as a trailer.** E.g. amending with the old message shown in comments can false-pass the grep. The script strips comment lines before matching.
- **No tests.** The check is now `scripts/check-dco-signoff.mjs` with 10 unit tests in the house `runCli` pattern, like every other guard in `scripts/`.

## The discovery gap that caused #562

- **`AGENTS.md` / `CLAUDE.md`**: a one-line pointer to CONTRIBUTING.md's commit requirements. The agent entry points route to `architecture/` and studio rules, so CONTRIBUTING.md never entered an agent's reading path — that's how #562 shipped unsigned commits.
- **`CONTRIBUTING.md`**: the enforcement paragraph now names the backing script and contrasts the local hook (fix = one re-run with `-s`) with the CI check (fix = history rewrite).

## Verified

- 10/10 unit tests pass.
- End-to-end in a fresh clone after `prek install`: unsigned commit rejected with the `git commit -s` pointer, signed commit lands, merge-shaped message exempt.

## Heads-up for existing checkouts

A checkout with a stale `core.hooksPath` (e.g. leftover `.husky/_` from an earlier husky setup — my clone had one) silently bypasses **all** prek hooks, this one included. `git config --unset core.hooksPath && npx prek install` fixes it. Possibly worth a follow-up doctor check, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated commit sign-off validation with author and committer identity matching.
  * Added support for merge-commit exemptions and clear feedback for invalid or mismatched sign-offs.

* **Documentation**
  * Updated contribution guidance with sign-off requirements, hook limitations, CI enforcement, and manual verification steps.
  * Added reminders to review contribution guidelines before committing.

* **Tests**
  * Expanded coverage for sign-off validation, identity resolution, repository discovery, merge commits, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->