### PR TITLE
refactor(demo-mfe): extract bridge-property and RTL direction into shared hooks

### DIFF
--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.test.tsx
@@ -200,43 +200,4 @@ describe('HelloWorldScreen', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     }
   });
-
-  // The host may hand the screen a different bridge without unmounting it. The
-  // lazy useState initializers ran once on mount, so only the re-read during
-  // render carries the new instance's current values across; the subscription
-  // effect delivers future changes and never fires here. Getting this wrong is
-  // silent: the screen keeps painting the previous host's theme and language
-  // while listening to a bridge nobody is publishing on any more.
-  it('re-reads current properties when the host swaps the bridge instance', async () => {
-    const { HelloWorldScreen, bridgeFixture, expectedTheme, host, rerender } =
-      await setupHelloWorldScreen();
-    const swapped = createMfeBridgeFixture({
-      extDomainId: 'swapped-domain',
-      extensionId: 'swapped-screen',
-      initialProperties: {
-        [FRONTX_SHARED_PROPERTY_THEME]: 'swapped-theme',
-        [FRONTX_SHARED_PROPERTY_LANGUAGE]: 'ar',
-      },
-    });
-
-    rerender(<HelloWorldScreen bridge={swapped.bridge} />);
-
-    expect(screen.getByText('swapped-theme')).toBeTruthy();
-    expect(screen.getByText('ar')).toBeTruthy();
-    expect(screen.getByText('swapped-domain')).toBeTruthy();
-    expect(screen.getByText('swapped-screen')).toBeTruthy();
-    expect(screen.queryByText(expectedTheme)).toBeNull();
-
-    await waitFor(() => {
-      expect(host.getAttribute('dir')).toBe(TextDirection.RightToLeft);
-    });
-
-    // The first bridge is released exactly once, and the second one is
-    // subscribed to in its place.
-    expect(bridgeFixture.unsubscriptions).toHaveLength(2);
-    for (const { unsubscribe } of bridgeFixture.unsubscriptions) {
-      expect(unsubscribe).toHaveBeenCalledTimes(1);
-    }
-    expect(swapped.subscribeToProperty).toHaveBeenCalledTimes(2);
-  });
 });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/helloworld/HelloWorldScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useRef, useCallback } from 'react';
 import type { ChildMfeBridge } from '@gears-frontx/react';
 import { FRONTX_ACTION_MOUNT_EXT, FRONTX_SCREEN_DOMAIN, FRONTX_SHARED_PROPERTY_THEME, FRONTX_SHARED_PROPERTY_LANGUAGE } from '@gears-frontx/react';
 import {
@@ -11,6 +11,8 @@ import {
   Skeleton,
 } from '@gears-frontx/ui-kit';
 import { useScreenTranslations } from '../../shared/useScreenTranslations';
+import { useBridgeProperty } from '../../shared/useBridgeProperty';
+import { useHostDirection } from '../../shared/useHostDirection';
 import {
   THEME_EXTENSION_ID,
   PROFILE_EXTENSION_ID,
@@ -36,13 +38,6 @@ const languageModules = import.meta.glob('./i18n/*.json') as Record<
   () => Promise<{ default: Record<string, string> }>
 >;
 
-const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'];
-
-function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: string): string {
-  const current = bridge.getProperty(property);
-  return current && typeof current.value === 'string' ? current.value : fallback;
-}
-
 /**
  * Hello World Screen for the MFE remote.
  *
@@ -59,59 +54,12 @@ function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: 
  */
 export const HelloWorldScreen: React.FC<HelloWorldScreenProps> = ({ bridge }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Initial value read directly from the bridge's lazy useState initializer (runs once,
-  // synchronously, during the first render) instead of via setState in a mount effect —
-  // this avoids an extra render and the set-state-in-effect anti-pattern. The effect
-  // below only subscribes for subsequent property changes.
-  const [theme, setTheme] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default')
-  );
-  const [language, setLanguage] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en')
-  );
-  // The lazy initializers above run only on mount; if the host swaps the bridge
-  // instance, re-read its current properties during render ("adjusting state
-  // during render") — the subscription effect only delivers future changes.
-  const [prevBridge, setPrevBridge] = useState(bridge);
-  if (prevBridge !== bridge) {
-    setPrevBridge(bridge);
-    setTheme(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default'));
-    setLanguage(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en'));
-  }
+  const theme = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default');
+  const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+  useHostDirection(containerRef, language);
 
   // Load translations using the shared hook
   const { t, loading } = useScreenTranslations(languageModules, bridge);
-
-  useEffect(() => {
-    // Subscribe to theme domain property
-    const themeUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_THEME, (property) => {
-      if (typeof property.value === 'string') {
-        setTheme(property.value);
-      }
-    });
-
-    // Subscribe to language domain property
-    const languageUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_LANGUAGE, (property) => {
-      if (typeof property.value === 'string') {
-        setLanguage(property.value);
-      }
-    });
-
-    return () => {
-      themeUnsubscribe();
-      languageUnsubscribe();
-    };
-  }, [bridge]);
-
-  // Keep the Shadow DOM host's text direction in sync with the active language.
-  // An effect keyed by `language` (rather than logic inside the subscription
-  // callback) also covers the initial language, which never fires a callback.
-  useEffect(() => {
-    const rootNode = containerRef.current?.getRootNode();
-    if (rootNode && 'host' in rootNode) {
-      (rootNode.host as HTMLElement).dir = RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';
-    }
-  }, [language]);
 
   // Navigate to Theme Screen
   const handleGoToTheme = useCallback(async () => {

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/ProfileScreen.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/ProfileScreen.test.tsx
@@ -254,42 +254,4 @@ describe('ProfileScreen', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     }
   });
-
-  // The host may hand the screen a different bridge without unmounting it. The
-  // lazy useState initializers ran once on mount, so only the re-read during
-  // render carries the new instance's current values across; the subscription
-  // effect delivers future changes and never fires here. Getting this wrong is
-  // silent: the screen keeps painting the previous host's theme and language
-  // while listening to a bridge nobody is publishing on any more.
-  it('re-reads current properties when the host swaps the bridge instance', async () => {
-    const { ProfileScreen, bridgeFixture, host, rerender } = await setupProfileScreen();
-    const swapped = createMfeBridgeFixture({
-      extDomainId: 'swapped-domain',
-      extensionId: 'swapped-screen',
-      initialProperties: {
-        [FRONTX_SHARED_PROPERTY_THEME]: 'swapped-theme',
-        [FRONTX_SHARED_PROPERTY_LANGUAGE]: 'ar',
-      },
-    });
-
-    rerender(<ProfileScreen bridge={swapped.bridge} />);
-
-    expect(screen.getByText('swapped-theme')).toBeTruthy();
-    expect(screen.getByText('ar')).toBeTruthy();
-    expect(screen.getByText('swapped-domain')).toBeTruthy();
-    expect(screen.getByText('swapped-screen')).toBeTruthy();
-    expect(screen.queryByText('corporate')).toBeNull();
-
-    await waitFor(() => {
-      expect(host.getAttribute('dir')).toBe(TextDirection.RightToLeft);
-    });
-
-    // The first bridge is released exactly once, and the second one is
-    // subscribed to in its place.
-    expect(bridgeFixture.unsubscriptions).toHaveLength(2);
-    for (const { unsubscribe } of bridgeFixture.unsubscriptions) {
-      expect(unsubscribe).toHaveBeenCalledTimes(1);
-    }
-    expect(swapped.subscribeToProperty).toHaveBeenCalledTimes(2);
-  });
 });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/ProfileScreen.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import type { ChildMfeBridge } from '@gears-frontx/react';
 import {
   FRONTX_SHARED_PROPERTY_THEME,
@@ -9,6 +9,8 @@ import {
 } from '@gears-frontx/react';
 import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle, Skeleton } from '@gears-frontx/ui-kit';
 import { useScreenTranslations } from '../../shared/useScreenTranslations';
+import { useBridgeProperty } from '../../shared/useBridgeProperty';
+import { useHostDirection } from '../../shared/useHostDirection';
 import { kitThemeScopeFor } from '../../shared/kitThemeScope';
 import { AccountsApiService, type UpdateProfileVariables } from '../../api/AccountsApiService';
 import type { GetCurrentUserResponse } from '../../api/types';
@@ -33,13 +35,6 @@ const languageModules = import.meta.glob('./i18n/*.json') as Record<
   () => Promise<{ default: Record<string, string> }>
 >;
 
-const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'];
-
-function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: string): string {
-  const current = bridge.getProperty(property);
-  return current && typeof current.value === 'string' ? current.value : fallback;
-}
-
 /**
  * Profile Screen for the MFE remote.
  *
@@ -55,25 +50,9 @@ function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: 
  */
 export const ProfileScreen: React.FC<ProfileScreenProps> = ({ bridge }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Initial value read directly from the bridge's lazy useState initializer (runs once,
-  // synchronously, during the first render) instead of via setState in a mount effect —
-  // this avoids an extra render and the set-state-in-effect anti-pattern. The effect
-  // below only subscribes for subsequent property changes.
-  const [theme, setTheme] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default')
-  );
-  const [language, setLanguage] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en')
-  );
-  // The lazy initializers above run only on mount; if the host swaps the bridge
-  // instance, re-read its current properties during render ("adjusting state
-  // during render") — the subscription effect only delivers future changes.
-  const [prevBridge, setPrevBridge] = useState(bridge);
-  if (prevBridge !== bridge) {
-    setPrevBridge(bridge);
-    setTheme(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default'));
-    setLanguage(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en'));
-  }
+  const theme = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default');
+  const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+  useHostDirection(containerRef, language);
 
   const service = apiRegistry.getService(AccountsApiService);
 
@@ -123,36 +102,6 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({ bridge }) => {
     },
     [updateProfile]
   );
-
-  // Subscribe to theme and language domain properties
-  useEffect(() => {
-    const themeUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_THEME, (property) => {
-      if (typeof property.value === 'string') {
-        setTheme(property.value);
-      }
-    });
-
-    const languageUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_LANGUAGE, (property) => {
-      if (typeof property.value === 'string') {
-        setLanguage(property.value);
-      }
-    });
-
-    return () => {
-      themeUnsubscribe();
-      languageUnsubscribe();
-    };
-  }, [bridge]);
-
-  // Keep the Shadow DOM host's text direction in sync with the active language.
-  // An effect keyed by `language` (rather than logic inside the subscription
-  // callback) also covers the initial language, which never fires a callback.
-  useEffect(() => {
-    const rootNode = containerRef.current?.getRootNode();
-    if (rootNode && 'host' in rootNode) {
-      (rootNode.host as HTMLElement).dir = RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';
-    }
-  }, [language]);
 
   const kitThemeScope = kitThemeScopeFor(theme);
 

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/theme/CurrentThemeScreen.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/theme/CurrentThemeScreen.test.tsx
@@ -95,43 +95,4 @@ describe('CurrentThemeScreen', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     }
   });
-
-  // The host may hand the screen a different bridge without unmounting it. The
-  // lazy useState initializers ran once on mount, so only the re-read during
-  // render carries the new instance's current values across; the subscription
-  // effect delivers future changes and never fires here. Getting this wrong is
-  // silent: the screen keeps painting the previous host's theme and language
-  // while listening to a bridge nobody is publishing on any more.
-  it('re-reads current properties when the host swaps the bridge instance', async () => {
-    const { CurrentThemeScreen, bridgeFixture, host, rerender } =
-      await setupCurrentThemeScreen();
-    const swapped = createMfeBridgeFixture({
-      extDomainId: 'swapped-domain',
-      extensionId: 'swapped-screen',
-      initialProperties: {
-        [FRONTX_SHARED_PROPERTY_THEME]: 'swapped-theme',
-        [FRONTX_SHARED_PROPERTY_LANGUAGE]: 'ar',
-      },
-    });
-
-    rerender(<CurrentThemeScreen bridge={swapped.bridge} />);
-
-    expect(screen.getAllByText('swapped-theme').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('ar')).toBeTruthy();
-    expect(screen.getByText('swapped-domain')).toBeTruthy();
-    expect(screen.getByText('swapped-screen')).toBeTruthy();
-    expect(screen.queryByText('solarized')).toBeNull();
-
-    await waitFor(() => {
-      expect(host.getAttribute('dir')).toBe('rtl');
-    });
-
-    // The first bridge is released exactly once, and the second one is
-    // subscribed to in its place.
-    expect(bridgeFixture.unsubscriptions).toHaveLength(2);
-    for (const { unsubscribe } of bridgeFixture.unsubscriptions) {
-      expect(unsubscribe).toHaveBeenCalledTimes(1);
-    }
-    expect(swapped.subscribeToProperty).toHaveBeenCalledTimes(2);
-  });
 });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/theme/CurrentThemeScreen.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/theme/CurrentThemeScreen.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import type { ChildMfeBridge } from '@gears-frontx/react';
 import { FRONTX_SHARED_PROPERTY_THEME, FRONTX_SHARED_PROPERTY_LANGUAGE } from '@gears-frontx/react';
 import { useScreenTranslations } from '../../shared/useScreenTranslations';
+import { useBridgeProperty } from '../../shared/useBridgeProperty';
+import { useHostDirection } from '../../shared/useHostDirection';
 
 /*
  * This screen renders the SHELL's theme, so it paints from the shell's Tailwind
@@ -32,13 +34,6 @@ const languageModules = import.meta.glob('./i18n/*.json') as Record<
   () => Promise<{ default: Record<string, string> }>
 >;
 
-const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'];
-
-function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: string): string {
-  const current = bridge.getProperty(property);
-  return current && typeof current.value === 'string' ? current.value : fallback;
-}
-
 /**
  * Current Theme Screen for the MFE remote.
  *
@@ -56,60 +51,12 @@ function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: 
  */
 export const CurrentThemeScreen: React.FC<CurrentThemeScreenProps> = ({ bridge }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Initial value read directly from the bridge's lazy useState initializer (runs once,
-  // synchronously, during the first render) instead of via setState in a mount effect —
-  // this avoids an extra render and the set-state-in-effect anti-pattern. The effect
-  // below only subscribes for subsequent property changes.
-  const [theme, setTheme] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default')
-  );
-  const [language, setLanguage] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en')
-  );
-  // The lazy initializers above run only on mount; if the host swaps the bridge
-  // instance, re-read its current properties during render ("adjusting state
-  // during render") — the subscription effect only delivers future changes.
-  const [prevBridge, setPrevBridge] = useState(bridge);
-  if (prevBridge !== bridge) {
-    setPrevBridge(bridge);
-    setTheme(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default'));
-    setLanguage(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en'));
-  }
+  const theme = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default');
+  const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+  useHostDirection(containerRef, language);
 
   // Load translations using the shared hook
   const { t, loading } = useScreenTranslations(languageModules, bridge);
-
-  useEffect(() => {
-    // Subscribe to theme domain property
-    const themeUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_THEME, (property) => {
-      if (typeof property.value === 'string') {
-        setTheme(property.value);
-      }
-    });
-
-    // Subscribe to language domain property
-    const languageUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_LANGUAGE, (property) => {
-      if (typeof property.value === 'string') {
-        setLanguage(property.value);
-      }
-    });
-
-    // Cleanup subscriptions on unmount
-    return () => {
-      themeUnsubscribe();
-      languageUnsubscribe();
-    };
-  }, [bridge]);
-
-  // Keep the Shadow DOM host's text direction in sync with the active language.
-  // An effect keyed by `language` (rather than logic inside the subscription
-  // callback) also covers the initial language, which never fires a callback.
-  useEffect(() => {
-    const rootNode = containerRef.current?.getRootNode();
-    if (rootNode && 'host' in rootNode) {
-      (rootNode.host as HTMLElement).dir = RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';
-    }
-  }, [language]);
 
   // Color swatches data (names will be translated)
   const colorSwatches = [

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/UIKitElementsScreen.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/UIKitElementsScreen.test.tsx
@@ -220,43 +220,4 @@ describe('UIKitElementsScreen bridge wiring smoke', () => {
       expect(unsubscribe).toHaveBeenCalledTimes(1);
     }
   });
-
-  // The host may hand the screen a different bridge without unmounting it. The
-  // lazy useState initializers ran once on mount, so only the re-read during
-  // render carries the new instance's current values across; the subscription
-  // effect delivers future changes and never fires here. Getting this wrong is
-  // silent: the screen keeps painting the previous host's theme and language
-  // while listening to a bridge nobody is publishing on any more.
-  it('re-reads current properties when the host swaps the bridge instance', async () => {
-    const { UIKitElementsScreen, bridgeFixture, host, rerender } =
-      await setupUIKitElementsScreen();
-    const swapped = createMfeBridgeFixture({
-      extDomainId: 'swapped-domain',
-      extensionId: 'swapped-screen',
-      initialProperties: {
-        [FRONTX_SHARED_PROPERTY_THEME]: 'swapped-theme',
-        [FRONTX_SHARED_PROPERTY_LANGUAGE]: 'ar',
-      },
-    });
-
-    rerender(<UIKitElementsScreen bridge={swapped.bridge} />);
-
-    expect(screen.getByText('swapped-theme')).toBeTruthy();
-    expect(screen.getByText('ar')).toBeTruthy();
-    expect(screen.getByText('swapped-domain')).toBeTruthy();
-    expect(screen.getByText('swapped-screen')).toBeTruthy();
-    expect(screen.queryByText('ocean')).toBeNull();
-
-    await waitFor(() => {
-      expect(host.getAttribute('dir')).toBe('rtl');
-    });
-
-    // The first bridge is released exactly once, and the second one is
-    // subscribed to in its place.
-    expect(bridgeFixture.unsubscriptions).toHaveLength(2);
-    for (const { unsubscribe } of bridgeFixture.unsubscriptions) {
-      expect(unsubscribe).toHaveBeenCalledTimes(1);
-    }
-    expect(swapped.subscribeToProperty).toHaveBeenCalledTimes(2);
-  });
 });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/UIKitElementsScreen.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/UIKitElementsScreen.tsx
@@ -16,6 +16,8 @@ import type { ChildMfeBridge } from '@gears-frontx/react';
 import { FRONTX_SHARED_PROPERTY_LANGUAGE, FRONTX_SHARED_PROPERTY_THEME } from '@gears-frontx/react';
 import { Card, CardContent, CardHeader, CardTitle, Skeleton, Toaster } from '@gears-frontx/ui-kit';
 import { useScreenTranslations } from '../../shared/useScreenTranslations';
+import { useBridgeProperty } from '../../shared/useBridgeProperty';
+import { useHostDirection } from '../../shared/useHostDirection';
 import { kitThemeScopeFor } from '../../shared/kitThemeScope';
 import { CategoryMenu } from './components/CategoryMenu';
 import styles from './UIKitElements.module.css';
@@ -52,13 +54,6 @@ const languageModules = import.meta.glob('./i18n/*.json') as Record<
   string,
   () => Promise<{ default: Record<string, string> }>
 >;
-
-const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'];
-
-function readBridgeProperty(bridge: ChildMfeBridge, property: string, fallback: string): string {
-  const current = bridge.getProperty(property);
-  return current && typeof current.value === 'string' ? current.value : fallback;
-}
 
 /**
  * Placeholder for a category still loading.
@@ -99,62 +94,12 @@ export const UIKitElementsScreen: React.FC<UIKitElementsScreenProps> = ({ bridge
    */
   const portalContainerRef = useRef<HTMLDivElement>(null);
   const [activeElement, setActiveElement] = useState<string | undefined>();
-  // Initial value read directly from the bridge's lazy useState initializer (runs once,
-  // synchronously, during the first render) instead of via setState in a mount effect —
-  // this avoids an extra render and the set-state-in-effect anti-pattern. The effect
-  // below only subscribes for subsequent property changes.
-  const [theme, setTheme] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default')
-  );
-  const [language, setLanguage] = useState<string>(() =>
-    readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en')
-  );
-  // The lazy initializers above run only on mount; if the host swaps the bridge
-  // instance, re-read its current properties during render ("adjusting state
-  // during render") — the subscription effect only delivers future changes.
-  const [prevBridge, setPrevBridge] = useState(bridge);
-  if (prevBridge !== bridge) {
-    setPrevBridge(bridge);
-    setTheme(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default'));
-    setLanguage(readBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en'));
-  }
+  const theme = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default');
+  const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+  useHostDirection(containerRef, language);
 
   // Load translations
   const { t, loading: translationsLoading } = useScreenTranslations(languageModules, bridge);
-
-  // Subscribe to theme and language. Text direction is derived from
-  // `language` by the effect below only — useScreenTranslations consumes
-  // `language` for translation loading and has no role in direction.
-  useEffect(() => {
-    // Subscribe to theme domain property
-    const themeUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_THEME, (property) => {
-      if (typeof property.value === 'string') {
-        setTheme(property.value);
-      }
-    });
-
-    // Subscribe to language domain property
-    const languageUnsubscribe = bridge.subscribeToProperty(FRONTX_SHARED_PROPERTY_LANGUAGE, (property) => {
-      if (typeof property.value === 'string') {
-        setLanguage(property.value);
-      }
-    });
-
-    return () => {
-      themeUnsubscribe();
-      languageUnsubscribe();
-    };
-  }, [bridge]);
-
-  // Keep the Shadow DOM host's text direction in sync with the active language.
-  // An effect keyed by `language` (rather than logic inside the subscription
-  // callback) also covers the initial language, which never fires a callback.
-  useEffect(() => {
-    const rootNode = containerRef.current?.getRootNode();
-    if (rootNode && 'host' in rootNode) {
-      (rootNode.host as HTMLElement).dir = RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';
-    }
-  }, [language]);
 
   /*
    * Track which element is in view, for the menu's active highlight.

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useBridgeProperty.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useBridgeProperty.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react';
+import { FRONTX_SHARED_PROPERTY_THEME } from '@gears-frontx/react';
+import { createMfeBridgeFixture } from '@frontx-test-utils/createMfeBridgeFixture';
+import { describe, expect, it } from 'vitest';
+import { useBridgeProperty } from './useBridgeProperty';
+
+const TEST_DOMAIN_ID = 'test-domain';
+const TEST_INSTANCE_ID = 'test-instance';
+
+function themeBridgeFixture(initialProperties: Record<string, unknown> = {}) {
+  return createMfeBridgeFixture({
+    extDomainId: TEST_DOMAIN_ID,
+    extensionId: TEST_INSTANCE_ID,
+    initialProperties,
+  });
+}
+
+describe('useBridgeProperty', () => {
+  it('reads the initial value from the bridge on first render', () => {
+    const { bridge } = themeBridgeFixture({
+      [FRONTX_SHARED_PROPERTY_THEME]: 'initial-theme',
+    });
+
+    const { result } = renderHook(() =>
+      useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'fallback-theme')
+    );
+
+    expect(result.current).toBe('initial-theme');
+  });
+
+  it('returns the fallback when the property is not published', () => {
+    // No property registered at all: getProperty returns undefined.
+    const { bridge } = themeBridgeFixture();
+
+    const { result } = renderHook(() =>
+      useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'fallback-theme')
+    );
+
+    expect(result.current).toBe('fallback-theme');
+  });
+
+  it('passes non-string values through untouched', () => {
+    // Schema validation is the type-system plugin's job; the hook does not
+    // filter by runtime type.
+    const fixture = themeBridgeFixture({
+      [FRONTX_SHARED_PROPERTY_THEME]: { mode: 'dark' },
+    });
+
+    const { result } = renderHook(() =>
+      useBridgeProperty<{ mode: string }>(fixture.bridge, FRONTX_SHARED_PROPERTY_THEME, { mode: 'light' })
+    );
+
+    expect(result.current).toEqual({ mode: 'dark' });
+
+    act(() => {
+      fixture.setProperty(FRONTX_SHARED_PROPERTY_THEME, { mode: 'high-contrast' });
+    });
+
+    expect(result.current).toEqual({ mode: 'high-contrast' });
+  });
+
+  it('reacts to property updates', () => {
+    const fixture = themeBridgeFixture({
+      [FRONTX_SHARED_PROPERTY_THEME]: 'initial-theme',
+    });
+
+    const { result } = renderHook(() =>
+      useBridgeProperty(fixture.bridge, FRONTX_SHARED_PROPERTY_THEME, 'fallback-theme')
+    );
+
+    act(() => {
+      fixture.setProperty(FRONTX_SHARED_PROPERTY_THEME, 'updated-theme');
+    });
+
+    expect(result.current).toBe('updated-theme');
+  });
+
+  it('unsubscribes on unmount', () => {
+    const fixture = themeBridgeFixture({
+      [FRONTX_SHARED_PROPERTY_THEME]: 'initial-theme',
+    });
+
+    const { unmount } = renderHook(() =>
+      useBridgeProperty(fixture.bridge, FRONTX_SHARED_PROPERTY_THEME, 'fallback-theme')
+    );
+
+    unmount();
+
+    expect(fixture.unsubscriptions).toHaveLength(1);
+    for (const { unsubscribe } of fixture.unsubscriptions) {
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useBridgeProperty.ts
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useBridgeProperty.ts
@@ -1,0 +1,62 @@
+/**
+ * useBridgeProperty Hook
+ *
+ * Subscribes a screen to one of the host's shared bridge properties
+ * (e.g. theme or language) and keeps the returned value in sync:
+ *
+ * 1. Reads the initial value lazily during the first render, so the first
+ *    paint already reflects the host's current property (no extra render
+ *    from a mount effect).
+ * 2. Subscribes to subsequent property changes and unsubscribes on unmount.
+ *
+ * The bridge instance is stable for the component's whole lifetime: the
+ * runtime retains one bridge per extension across every mount/unmount cycle
+ * (see `MfeBridge` in @gears-frontx/mfes handler types), and the React
+ * lifecycle renders a fresh root per mount. The hook therefore does not
+ * guard against a bridge swap.
+ *
+ * The value is passed through untouched. Validating it against the
+ * property's schema is the type-system plugin's responsibility, so the hook
+ * does no runtime type filtering; the caller names the expected type via the
+ * fallback.
+ *
+ * Related: useSharedProperty in @gears-frontx/react is the same concept,
+ * but it pulls the bridge from MfeContext (which demo-mfe never mounts)
+ * and has no fallback; this hook takes the bridge as an argument instead.
+ *
+ * Usage in screen component:
+ * ```tsx
+ * const theme = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_THEME, 'default');
+ * const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+ * ```
+ */
+
+import { useEffect, useState } from 'react';
+import type { ChildMfeBridge } from '@gears-frontx/react';
+
+/**
+ * Hook returning the live value of a shared bridge property.
+ *
+ * @param bridge - ChildMfeBridge instance
+ * @param propertyId - Shared property id (e.g. FRONTX_SHARED_PROPERTY_THEME)
+ * @param fallback - Value used while the property is not yet published
+ * @returns The current value of the property
+ */
+export function useBridgeProperty<T>(bridge: ChildMfeBridge, propertyId: string, fallback: T): T {
+  const [value, setValue] = useState<T>(() => readBridgeProperty(bridge, propertyId, fallback));
+
+  useEffect(() => {
+    return bridge.subscribeToProperty(propertyId, (property) => {
+      setValue(property.value as T);
+    });
+  }, [bridge, propertyId]);
+
+  return value;
+}
+
+function readBridgeProperty<T>(bridge: ChildMfeBridge, propertyId: string, fallback: T): T {
+  const current = bridge.getProperty(propertyId);
+  // SharedProperty.value is `unknown`; the schema check already happened in
+  // the type-system plugin, so the caller's T is the only narrowing left.
+  return current ? (current.value as T) : fallback;
+}

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useHostDirection.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useHostDirection.test.tsx
@@ -1,0 +1,56 @@
+import { useRef } from 'react';
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useHostDirection } from './useHostDirection';
+
+function DirectionProbe({ language }: { language: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useHostDirection(containerRef, language);
+  return <div ref={containerRef} />;
+}
+
+const hosts: HTMLElement[] = [];
+
+// A real shadow root as the render container — rather than
+// @frontx-test-utils/mockShadowHost, which spies on getRootNode — so the
+// hook's actual getRootNode() walk is what gets exercised.
+function shadowMountNode() {
+  const host = document.createElement('div');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const mountNode = document.createElement('div');
+  shadowRoot.appendChild(mountNode);
+  document.body.appendChild(host);
+  hosts.push(host);
+  return { host, mountNode };
+}
+
+afterEach(() => {
+  for (const host of hosts.splice(0)) {
+    host.remove();
+  }
+});
+
+describe('useHostDirection', () => {
+  it('sets the shadow host direction to rtl for RTL languages and back to ltr', () => {
+    const { host, mountNode } = shadowMountNode();
+
+    const { rerender } = render(<DirectionProbe language="en" />, { container: mountNode });
+
+    expect(host.dir).toBe('ltr');
+
+    rerender(<DirectionProbe language="ar" />);
+
+    expect(host.dir).toBe('rtl');
+
+    rerender(<DirectionProbe language="en" />);
+
+    expect(host.dir).toBe('ltr');
+  });
+
+  it('is a no-op outside a Shadow DOM', () => {
+    render(<DirectionProbe language="ar" />);
+
+    // The document root has no `host`, so no direction is written anywhere.
+    expect(document.documentElement.dir).toBe('');
+  });
+});

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useHostDirection.ts
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/shared/useHostDirection.ts
@@ -1,0 +1,44 @@
+/**
+ * useHostDirection Hook
+ *
+ * Keeps the Shadow DOM host's text direction (`dir`) in sync with the active
+ * language:
+ *
+ * 1. An effect keyed by `language` (rather than logic inside a bridge
+ *    subscription callback) also covers the initial language, which never
+ *    fires a callback.
+ * 2. A DOM host mutation has to wait for commit, so this lives in an effect
+ *    rather than the render body.
+ * 3. Outside a Shadow DOM the hook is a no-op.
+ *
+ * Usage in screen component:
+ * ```tsx
+ * const containerRef = useRef<HTMLDivElement>(null);
+ * const language = useBridgeProperty(bridge, FRONTX_SHARED_PROPERTY_LANGUAGE, 'en');
+ * useHostDirection(containerRef, language);
+ * ```
+ */
+
+import { useEffect, type RefObject } from 'react';
+
+const RTL_LANGUAGES: readonly string[] = ['ar', 'he', 'fa', 'ur'];
+
+/**
+ * Hook syncing the Shadow DOM host element's `dir` attribute to the language.
+ *
+ * @param containerRef - Ref to any element rendered inside the MFE's shadow root
+ * @param language - Active language code (e.g. 'en', 'ar')
+ */
+export function useHostDirection(
+  containerRef: RefObject<HTMLElement | null>,
+  language: string
+): void {
+  useEffect(() => {
+    const rootNode = containerRef.current?.getRootNode();
+    if (rootNode && 'host' in rootNode) {
+      // The `in` check narrows Node only to Node & Record<'host', unknown>,
+      // so the cast to HTMLElement is forced.
+      (rootNode.host as HTMLElement).dir = RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';
+    }
+  }, [containerRef, language]);
+}


### PR DESCRIPTION
Implements #502 — follow-up from @itechmeat's review of #491.

## What

Extracts the pieces #491 pasted verbatim into the demo-mfe screens (`RTL_LANGUAGES`, `readBridgeProperty`, the property subscription, and the host `dir` effect) into two shared hooks in `demo-mfe/src/shared/`:

- **`useBridgeProperty<T>(bridge, propertyId, fallback)`** — lazy initial read on first render and the change subscription with cleanup. The value is passed through as the caller's `T`; schema validation stays with the type-system plugin.
- **`useHostDirection(containerRef, language)`** — Shadow DOM host `dir` sync keyed by language; no-op outside a shadow root.

All four demo-mfe screens (UIKitElements, Profile, CurrentTheme, HelloWorld) are rewired to the hooks; each duplicated ~60-line block becomes three lines.

## Tests

`useBridgeProperty` is pinned on initial read, fallback when the property is not yet published, non-string pass-through, update propagation, and unsubscribe on unmount. `useHostDirection` gets rtl/ltr transition and outside-shadow-DOM no-op coverage.

The bridge-swap cases (the `prevBridge` render-time re-read in the screens and the four screen tests pinning it) are removed rather than extracted: the runtime retains one bridge per extension across every mount/unmount cycle and `ThemeAwareReactLifecycle` renders a fresh root per mount, so a mounted screen never sees a different bridge instance (review round 3).

## What stays

Per the issue, `_blank-mfe/HomeScreen` keeps its inline copy and its test: `no-cross-mfe-imports` is error-severity, and per-MFE `src/shared/` duplication is the existing convention (`useScreenTranslations` precedent). No `src-app/mfe_packages/shared/` package is introduced.

## Verification

Reproduced the `template-validate` composition locally: overlaid `template-mfe`'s `exclusiveSubtrees` onto `template-shell` and ran `build`, `type-check`, `arch:deps`, `lint --max-warnings 0`, and `test:unit` over the union — all green (demo-mfe: 13 test files / 41 tests, including the new hook tests).

Behaviour change limited to the two round-3 removals above; otherwise a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved theme and language synchronization across demo screens.
  * Added automatic right-to-left and left-to-right layout direction based on the selected language.
  * Added consistent fallback handling when shared properties are unavailable.

* **Bug Fixes**
  * Improved responsiveness to theme and language property updates.

* **Tests**
  * Added coverage for property updates, fallback behavior, cleanup, and text-direction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
