### PR TITLE
fix(ui-kit): ship 'use client' per dist chunk, only where a hook is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -835,6 +835,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8156,7 +8156,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,31 +835,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -8156,7 +8131,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
@@ -8171,6 +8146,7 @@
         "@vitest/coverage-v8": "4.1.4",
         "esbuild": "0.25.12",
         "jsdom": "26.1.0",
+        "magic-string": "0.30.21",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "rollup-plugin-node-externals": "^9.0.1",

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -39,6 +39,20 @@ unused JS bindings the way it prunes JS. If your build uses esbuild directly
 (not through a framework that wraps it, like Vite does), prefer the subpath
 import for CSS you actually want dropped.
 
+In an RSC framework (Next.js App Router being the dominant case), most kit
+components render straight from a Server Component with zero client-side
+JS — they only compose Base UI primitives as JSX, and Base UI's own dist
+already carries `'use client'` on the modules that call hooks. Three
+components call a hook directly in their own render body and ship a
+`'use client'` banner on their own chunk instead: **Badge** (`useRender`,
+for its `render` prop), **DropdownMenu** (`useContext`, for the portal
+container it shares with nested submenus), and **Toast** (`useToastManager`,
+for the live toast list `Toaster` renders). Everything else — including
+interactive primitives like Button, Checkbox, Dialog, Select, Switch,
+RadioGroup, and Tabs — stays server-renderable; each one's own client
+interactivity comes from a Base UI primitive it renders as a child, which
+establishes its own client boundary as needed.
+
 The theme file paints the page (background, text, and UA-owned surfaces like
 the scrollbar) as well as defining the tokens, so dark mode works out of the
 box with no attribute at all: it follows `prefers-color-scheme` by default.

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -40,21 +40,19 @@ unused JS bindings the way it prunes JS. If your build uses esbuild directly
 import for CSS you actually want dropped.
 
 In an RSC framework (Next.js App Router being the dominant case), most kit
-components render straight from a Server Component with no kit-side client
-JS — they only compose Base UI primitives as JSX, and Base UI's own dist
-already carries `'use client'` on the modules that call hooks (an
-interactive primitive like Select or Dialog still ships Base UI's own
-client bundle; only the kit wrapper around it needs no directive of its
-own). Three
-components call a hook directly in their own render body and ship a
-`'use client'` banner on their own chunk instead: **Badge** (`useRender`,
-for its `render` prop), **DropdownMenu** (`useContext`, for the portal
-container it shares with nested submenus), and **Toast** (`useToastManager`,
-for the live toast list `Toaster` renders). Everything else — including
-interactive primitives like Button, Checkbox, Dialog, Select, Switch,
-RadioGroup, and Tabs — stays server-renderable; each one's own client
-interactivity comes from a Base UI primitive it renders as a child, which
-establishes its own client boundary as needed.
+components render straight from a Server Component with no kit-side client JS —
+they only compose Base UI primitives as JSX, and Base UI's own dist already
+carries `'use client'` on the modules that call hooks (an interactive primitive
+like Select or Dialog still ships Base UI's own client bundle; only the kit
+wrapper around it needs no directive of its own). Three components call a hook
+directly in their own render body and ship a `'use client'` banner on their own
+chunk instead: **Badge** (`useRender`, for its `render` prop), **DropdownMenu**
+(`useContext`, for the portal container it shares with nested submenus), and
+**Toast** (`useToastManager`, for the live toast list `Toaster` renders).
+Everything else — including interactive primitives like Button, Checkbox,
+Dialog, Select, Switch, RadioGroup, and Tabs — stays server-renderable; each
+one's own client interactivity comes from a Base UI primitive it renders as a
+child, which establishes its own client boundary as needed.
 
 The theme file paints the page (background, text, and UA-owned surfaces like
 the scrollbar) as well as defining the tokens, so dark mode works out of the

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -40,9 +40,12 @@ unused JS bindings the way it prunes JS. If your build uses esbuild directly
 import for CSS you actually want dropped.
 
 In an RSC framework (Next.js App Router being the dominant case), most kit
-components render straight from a Server Component with zero client-side
+components render straight from a Server Component with no kit-side client
 JS — they only compose Base UI primitives as JSX, and Base UI's own dist
-already carries `'use client'` on the modules that call hooks. Three
+already carries `'use client'` on the modules that call hooks (an
+interactive primitive like Select or Dialog still ships Base UI's own
+client bundle; only the kit wrapper around it needs no directive of its
+own). Three
 components call a hook directly in their own render body and ship a
 `'use client'` banner on their own chunk instead: **Badge** (`useRender`,
 for its `render` prop), **DropdownMenu** (`useContext`, for the portal

--- a/packages/ui-kit/llms.txt
+++ b/packages/ui-kit/llms.txt
@@ -19,6 +19,12 @@ Rules for generated code:
   tree-shakes unused components' JS from a root import already, but only
   drops their CSS from a subpath import — Vite and webpack drop both either
   way, so this only matters when esbuild is the actual bundler running.
+- In an RSC framework (Next.js App Router), every component EXCEPT Badge,
+  DropdownMenu, and Toast is safe to import and render directly from a
+  Server Component — no wrapping client-boundary module needed. Those three
+  ship their own `'use client'` banner (each calls a hook — `useRender`,
+  `useContext`, `useToastManager` — directly in its own render body) and so
+  always render on the client, wherever they're imported from.
 - The kit paints the page itself from its tokens and sets `color-scheme`: with
   no `data-theme` attribute anywhere, `prefers-color-scheme: dark` alone
   yields a correct, legible dark page (background, text, and UA-owned

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -56,6 +56,7 @@
     "@vitest/coverage-v8": "4.1.4",
     "esbuild": "0.25.12",
     "jsdom": "26.1.0",
+    "magic-string": "0.30.21",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "rollup-plugin-node-externals": "^9.0.1",

--- a/packages/ui-kit/scripts/buildPlugin.ts
+++ b/packages/ui-kit/scripts/buildPlugin.ts
@@ -153,10 +153,12 @@ export function buildPlugin(): PluginOption[] {
       renderChunk(code, chunk) {
         // Rollup has always already stripped the source directive by this
         // point (that's the whole problem this plugin exists to fix) — the
-        // `startsWith` check is a no-op today, kept only as a cheap guard
+        // `directiveRe` check is a no-op today, kept only as a cheap guard
         // against double-prepending if a future Rollup/Vite version stops
-        // stripping it.
-        if (code.startsWith(USE_CLIENT) || !chunk.moduleIds.some((id) => clientModuleIds.has(id))) {
+        // stripping it. Reuses `directiveRe` (rather than a plain
+        // `startsWith(USE_CLIENT)`) so this guard tolerates the same quote
+        // styles the detection above does.
+        if (directiveRe.test(code) || !chunk.moduleIds.some((id) => clientModuleIds.has(id))) {
           return null;
         }
 

--- a/packages/ui-kit/scripts/buildPlugin.ts
+++ b/packages/ui-kit/scripts/buildPlugin.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import MagicString from 'magic-string';
 import nodeExternals from 'rollup-plugin-node-externals';
 import type { Plugin, PluginOption, UserConfig } from 'vite';
 import dts from 'vite-plugin-dts';
@@ -30,6 +31,7 @@ export function buildPlugin(): PluginOption[] {
     // possible at all.
     libInjectCss(),
     buildEntries(),
+    preserveUseClientPlugin(),
     dts({
       outDir: 'dist',
       entryRoot: 'src',
@@ -101,6 +103,66 @@ export function buildPlugin(): PluginOption[] {
         for (const file of fs.globSync('src/components/*/*.md')) {
           fs.copyFileSync(file, path.join('dist/docs', path.basename(file)));
         }
+      },
+    };
+  }
+
+  /**
+   * Rollup strips a source module's `'use client'` directive prologue when
+   * it renders that module's code into a bundled chunk — the directive
+   * survives esbuild's per-file TS transpile (see the component sources'
+   * own comments) but not Rollup's own bundling step, so it never reaches
+   * dist/ without this plugin. `rollup-plugin-preserve-directives` (the
+   * community-standard fix) only re-adds directives under
+   * `output.preserveModules: true`, which emits one file per source module
+   * and would break the one-chunk-per-component shape this build already
+   * has (getBuildConfig's `lib.entry` + `treeshake` combination — see that
+   * comment) — so this does the same job at this build's actual chunk
+   * granularity: remember which source module declared the directive, then
+   * re-add it to whichever chunk that module's code lands in.
+   *
+   * A chunk earns the banner if ANY of its modules declared it (only
+   * badge.tsx, dropdown-menu.tsx, and toast.tsx do, each calling a hook —
+   * useRender/useContext/useToastManager — directly in its own render
+   * body). A component that merely renders a Base UI primitive as JSX
+   * (Button, Dialog, Select, …) does not need the directive on its own
+   * chunk: Base UI's own dist already carries 'use client' on the modules
+   * that call hooks, so composing them is safe as a Server Component and
+   * stays server-renderable — marking it here anyway would take that away
+   * for no reason.
+   */
+  function preserveUseClientPlugin(): Plugin {
+    const USE_CLIENT = "'use client';";
+    // Matches the directive as the file's first statement, tolerating
+    // leading whitespace (which also covers a byte-order mark — `\s`
+    // matches U+FEFF), license/comment headers, and either quote
+    // style/semicolon — esbuild only preserves a directive prologue found
+    // in exactly that position.
+    const directiveRe = /^(?:\s|\/\/[^\n]*\n|\/\*[\s\S]*?\*\/)*['"]use client['"];?/;
+    const clientModuleIds = new Set<string>();
+
+    return {
+      name: 'ui-kit-preserve-use-client',
+      apply: 'build',
+      transform(code, id) {
+        if (directiveRe.test(code)) {
+          clientModuleIds.add(id);
+        }
+        return null;
+      },
+      renderChunk(code, chunk) {
+        // Rollup has always already stripped the source directive by this
+        // point (that's the whole problem this plugin exists to fix) — the
+        // `startsWith` check is a no-op today, kept only as a cheap guard
+        // against double-prepending if a future Rollup/Vite version stops
+        // stripping it.
+        if (code.startsWith(USE_CLIENT) || !chunk.moduleIds.some((id) => clientModuleIds.has(id))) {
+          return null;
+        }
+
+        const magicString = new MagicString(code);
+        magicString.prepend(`${USE_CLIENT}\n`);
+        return { code: magicString.toString(), map: magicString.generateMap({ hires: true }) };
       },
     };
   }

--- a/packages/ui-kit/scripts/buildPlugin.ts
+++ b/packages/ui-kit/scripts/buildPlugin.ts
@@ -108,18 +108,20 @@ export function buildPlugin(): PluginOption[] {
   }
 
   /**
-   * Rollup strips a source module's `'use client'` directive prologue when
-   * it renders that module's code into a bundled chunk — the directive
-   * survives esbuild's per-file TS transpile (see the component sources'
-   * own comments) but not Rollup's own bundling step, so it never reaches
-   * dist/ without this plugin. `rollup-plugin-preserve-directives` (the
-   * community-standard fix) only re-adds directives under
-   * `output.preserveModules: true`, which emits one file per source module
-   * and would break the one-chunk-per-component shape this build already
-   * has (getBuildConfig's `lib.entry` + `treeshake` combination — see that
-   * comment) — so this does the same job at this build's actual chunk
-   * granularity: remember which source module declared the directive, then
-   * re-add it to whichever chunk that module's code lands in.
+   * Rollup strips a source module's `'use client'` directive prologue when it
+   * renders that module's code into a bundled chunk. Vite transpiles each
+   * TS/TSX module through esbuild individually (strip types, downlevel syntax)
+   * before Rollup ever bundles them, and esbuild's per-file transpile preserves
+   * a directive prologue verbatim — so the directive survives that step but not
+   * Rollup's own bundling step, which strips it when inlining the module's code
+   * into a shared chunk, so it never reaches dist/ without this plugin.
+   * `rollup-plugin-preserve-directives` (the community-standard fix) only
+   * re-adds directives under `output.preserveModules: true`, which emits one
+   * file per source module and would break the one-chunk-per-component shape
+   * this build already has (getBuildConfig's `lib.entry` + `treeshake`
+   * combination — see that comment) — so this does the same job at this build's
+   * actual chunk granularity: remember which source module declared the
+   * directive, then re-add it to whichever chunk that module's code lands in.
    *
    * A chunk earns the banner if ANY of its modules declared it (only
    * badge.tsx, dropdown-menu.tsx, and toast.tsx do, each calling a hook —

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -224,21 +224,41 @@ has_client_directive() {
   ' "$1" | grep -Eq "^[[:space:]]*('use client'|\"use client\");?[[:space:]]*\$"
 }
 
-# The lists are also only checked above against WHICH components exist, not
-# against what each one's source actually does — a hook added to (say)
-# select.tsx without also adding the directive would leave SERVER_COMPONENTS
-# unchanged and dist/select.js correctly bannerless, so every check above
-# stays green despite the component now being wrong. Check each real
-# component's own source file directly, independent of the classification
-# lists and of whatever the build produced, as a second, build-independent
-# signal tying the lists to source intent.
+assert_source_exists() {
+  # $1: component name. Without this, a missing source file (renamed, split,
+  # or restructured out from under this script) reads as "no directive" to
+  # has_client_directive (awk prints nothing, grep on empty input returns 1)
+  # — which makes the SERVER_COMPONENTS loop below pass silently on a file
+  # that was never checked at all, exactly the "no file reads as clean"
+  # defect the dist loops further down already guard against with `[ -f ]`.
+  if [ ! -f "$UIKIT_DIR/src/components/$1/$1.tsx" ]; then
+    echo "FAIL: src/components/$1/$1.tsx does not exist — was it renamed, split, or restructured without updating this script?"
+    exit 1
+  fi
+}
+
+# The lists above are only checked against WHICH components exist (the
+# exhaustiveness block) — this pins them to what each one's source actually
+# declares: every CLIENT_COMPONENTS source has the directive, every
+# SERVER_COMPONENTS source doesn't. That catches the two lists and the
+# source drifting apart — e.g. the directive added to (or removed from) a
+# component's .tsx without the matching list edit. It does NOT catch a hook
+# added to (say) select.tsx with no directive added at all: that leaves
+# SERVER_COMPONENTS unchanged, source correctly directiveless by this
+# check's own definition, and dist/select.js correctly bannerless, so every
+# check in this file — this one included — stays green despite the
+# component now needing the directive. Closing that gap needs a lint rule
+# that flags hook usage with no client directive in scope; out of scope
+# here.
 for name in "${CLIENT_COMPONENTS[@]}"; do
+  assert_source_exists "$name"
   if ! has_client_directive "$UIKIT_DIR/src/components/$name/$name.tsx"; then
     echo "FAIL: src/components/$name/$name.tsx is classified as CLIENT_COMPONENTS but its source has no 'use client' directive as its first statement"
     exit 1
   fi
 done
 for name in "${SERVER_COMPONENTS[@]}"; do
+  assert_source_exists "$name"
   if has_client_directive "$UIKIT_DIR/src/components/$name/$name.tsx"; then
     echo "FAIL: src/components/$name/$name.tsx has a 'use client' directive as its first statement but is classified as SERVER_COMPONENTS — move it to CLIENT_COMPONENTS"
     exit 1

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -205,13 +205,42 @@ for name in "${CLIENT_COMPONENTS[@]}" "${SERVER_COMPONENTS[@]}"; do
   fi
 done
 
+# The lists are also only checked above against WHICH components exist, not
+# against what each one's source actually does — a hook added to (say)
+# select.tsx without also adding the directive would leave SERVER_COMPONENTS
+# unchanged and dist/select.js correctly bannerless, so every check above
+# stays green despite the component now being wrong. Grep each real
+# component's own source file directly, independent of the classification
+# lists and of whatever the build produced, as a second, build-independent
+# signal tying the lists to source intent.
 for name in "${CLIENT_COMPONENTS[@]}"; do
+  if ! grep -qF "'use client';" "$UIKIT_DIR/src/components/$name/$name.tsx"; then
+    echo "FAIL: src/components/$name/$name.tsx is classified as CLIENT_COMPONENTS but its source has no 'use client' directive"
+    exit 1
+  fi
+done
+for name in "${SERVER_COMPONENTS[@]}"; do
+  if grep -qF "'use client';" "$UIKIT_DIR/src/components/$name/$name.tsx"; then
+    echo "FAIL: src/components/$name/$name.tsx has a 'use client' directive but is classified as SERVER_COMPONENTS — move it to CLIENT_COMPONENTS"
+    exit 1
+  fi
+done
+
+for name in "${CLIENT_COMPONENTS[@]}"; do
+  if [ ! -f "$UIKIT_DIR/dist/$name.js" ]; then
+    echo "FAIL: dist/$name.js does not exist — did the build fail for this component?"
+    exit 1
+  fi
   if ! head -c 20 "$UIKIT_DIR/dist/$name.js" | grep -qF "use client"; then
     echo "FAIL: dist/$name.js is missing its 'use client' banner"
     exit 1
   fi
 done
 for name in "${SERVER_COMPONENTS[@]}" index; do
+  if [ ! -f "$UIKIT_DIR/dist/$name.js" ]; then
+    echo "FAIL: dist/$name.js does not exist — did the build fail for this component?"
+    exit 1
+  fi
   if head -c 20 "$UIKIT_DIR/dist/$name.js" | grep -qF "use client"; then
     echo "FAIL: dist/$name.js carries a 'use client' banner it doesn't need — this removes it from server rendering for RSC consumers"
     exit 1

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -205,23 +205,42 @@ for name in "${CLIENT_COMPONENTS[@]}" "${SERVER_COMPONENTS[@]}"; do
   fi
 done
 
+# A flat `grep -qF "'use client';"` over the whole file would match a
+# decoy — a comment or string anywhere else in the file that happens to
+# contain that literal text — without the component actually having a real
+# directive, since a directive is only a directive as the file's first
+# statement. Reimplements buildPlugin.ts's `directiveRe` prologue-skipping
+# for bash (that TS regex can't be imported here): find the first line that
+# isn't blank, a `//` comment, or a self-contained `/* ... */` block
+# comment, then test whether THAT line — not any other line — is the
+# directive.
+has_client_directive() {
+  # $1: path to a .tsx source file
+  awk '
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*\/\// { next }
+    /^[[:space:]]*\/\*.*\*\/[[:space:]]*$/ { next }
+    { print; exit }
+  ' "$1" | grep -Eq "^[[:space:]]*('use client'|\"use client\");?[[:space:]]*\$"
+}
+
 # The lists are also only checked above against WHICH components exist, not
 # against what each one's source actually does — a hook added to (say)
 # select.tsx without also adding the directive would leave SERVER_COMPONENTS
 # unchanged and dist/select.js correctly bannerless, so every check above
-# stays green despite the component now being wrong. Grep each real
+# stays green despite the component now being wrong. Check each real
 # component's own source file directly, independent of the classification
 # lists and of whatever the build produced, as a second, build-independent
 # signal tying the lists to source intent.
 for name in "${CLIENT_COMPONENTS[@]}"; do
-  if ! grep -qF "'use client';" "$UIKIT_DIR/src/components/$name/$name.tsx"; then
-    echo "FAIL: src/components/$name/$name.tsx is classified as CLIENT_COMPONENTS but its source has no 'use client' directive"
+  if ! has_client_directive "$UIKIT_DIR/src/components/$name/$name.tsx"; then
+    echo "FAIL: src/components/$name/$name.tsx is classified as CLIENT_COMPONENTS but its source has no 'use client' directive as its first statement"
     exit 1
   fi
 done
 for name in "${SERVER_COMPONENTS[@]}"; do
-  if grep -qF "'use client';" "$UIKIT_DIR/src/components/$name/$name.tsx"; then
-    echo "FAIL: src/components/$name/$name.tsx has a 'use client' directive but is classified as SERVER_COMPONENTS — move it to CLIENT_COMPONENTS"
+  if has_client_directive "$UIKIT_DIR/src/components/$name/$name.tsx"; then
+    echo "FAIL: src/components/$name/$name.tsx has a 'use client' directive as its first statement but is classified as SERVER_COMPONENTS — move it to CLIENT_COMPONENTS"
     exit 1
   fi
 done

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -164,6 +164,18 @@ in_list() {
   return 1
 }
 
+count_matches() {
+  # $1: needle, $2+: haystack — total occurrences, not just presence, so a
+  # name duplicated within one list (or repeated across both) is caught
+  # too, not just membership.
+  local needle="$1" item count=0
+  shift
+  for item in "$@"; do
+    [ "$item" = "$needle" ] && count=$((count + 1))
+  done
+  echo "$count"
+}
+
 # The two lists above are hand-maintained, so a component added to (or
 # removed from) src/components/ without a matching edit here would
 # otherwise go unchecked by both loops below, silently. Diff the lists
@@ -176,12 +188,13 @@ for entry in "$UIKIT_DIR"/src/components/*/public.ts; do
 done
 
 for name in "${ALL_COMPONENTS[@]}"; do
-  if in_list "$name" "${CLIENT_COMPONENTS[@]}" && in_list "$name" "${SERVER_COMPONENTS[@]}"; then
-    echo "FAIL: '$name' is listed in both CLIENT_COMPONENTS and SERVER_COMPONENTS in this script — fix the classification"
+  count="$(count_matches "$name" "${CLIENT_COMPONENTS[@]}" "${SERVER_COMPONENTS[@]}")"
+  if [ "$count" -eq 0 ]; then
+    echo "FAIL: '$name' ships under src/components/ but isn't classified in CLIENT_COMPONENTS or SERVER_COMPONENTS in this script — add it to the list matching whether it calls a hook directly in its own render body"
     exit 1
   fi
-  if ! in_list "$name" "${CLIENT_COMPONENTS[@]}" && ! in_list "$name" "${SERVER_COMPONENTS[@]}"; then
-    echo "FAIL: '$name' ships under src/components/ but isn't classified in CLIENT_COMPONENTS or SERVER_COMPONENTS in this script — add it to the list matching whether it calls a hook directly in its own render body"
+  if [ "$count" -gt 1 ]; then
+    echo "FAIL: '$name' appears $count times across CLIENT_COMPONENTS/SERVER_COMPONENTS in this script (duplicate entry, or listed in both) — it must be classified exactly once"
     exit 1
   fi
 done

--- a/packages/ui-kit/scripts/verify-consumer.sh
+++ b/packages/ui-kit/scripts/verify-consumer.sh
@@ -141,6 +141,71 @@ for probe_name in BUTTON_CLASS TABLE_CLASS DIALOG_CLASS; do
 done
 echo "==> Probes: Button=$BUTTON_CLASS Table=$TABLE_CLASS Dialog=$DIALOG_CLASS"
 
+# 'use client' regression guard (#568): asserted against the kit's OWN
+# dist/, not a consumer bundle — an RSC framework like Next.js reads the
+# directive straight off the installed package's chunks, before any of this
+# script's bundler legs run, so none of them would catch it drifting. Split
+# by hook usage, not by any other property: badge/dropdown-menu/toast call a
+# hook directly in their own render body (useRender/useContext/
+# useToastManager — see buildPlugin.ts's preserveUseClientPlugin comment);
+# everything else only composes Base UI primitives as JSX, which already
+# carry their own directive in Base UI's dist, so marking them here would
+# take server-renderability away for no reason.
+CLIENT_COMPONENTS=(badge dropdown-menu toast)
+SERVER_COMPONENTS=(button card checkbox dialog field input label radio-group select separator skeleton switch table tabs textarea tooltip)
+
+in_list() {
+  # $1: needle, $2+: haystack
+  local needle="$1" item
+  shift
+  for item in "$@"; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# The two lists above are hand-maintained, so a component added to (or
+# removed from) src/components/ without a matching edit here would
+# otherwise go unchecked by both loops below, silently. Diff the lists
+# against the build's own entry glob (getBuildConfig's source of truth in
+# buildPlugin.ts) instead of trusting them: every real component must be
+# classified exactly once, and every classified name must be real.
+ALL_COMPONENTS=()
+for entry in "$UIKIT_DIR"/src/components/*/public.ts; do
+  ALL_COMPONENTS+=("$(basename "$(dirname "$entry")")")
+done
+
+for name in "${ALL_COMPONENTS[@]}"; do
+  if in_list "$name" "${CLIENT_COMPONENTS[@]}" && in_list "$name" "${SERVER_COMPONENTS[@]}"; then
+    echo "FAIL: '$name' is listed in both CLIENT_COMPONENTS and SERVER_COMPONENTS in this script — fix the classification"
+    exit 1
+  fi
+  if ! in_list "$name" "${CLIENT_COMPONENTS[@]}" && ! in_list "$name" "${SERVER_COMPONENTS[@]}"; then
+    echo "FAIL: '$name' ships under src/components/ but isn't classified in CLIENT_COMPONENTS or SERVER_COMPONENTS in this script — add it to the list matching whether it calls a hook directly in its own render body"
+    exit 1
+  fi
+done
+for name in "${CLIENT_COMPONENTS[@]}" "${SERVER_COMPONENTS[@]}"; do
+  if ! in_list "$name" "${ALL_COMPONENTS[@]}"; then
+    echo "FAIL: '$name' is classified in this script but has no src/components/$name/public.ts — remove the stale entry"
+    exit 1
+  fi
+done
+
+for name in "${CLIENT_COMPONENTS[@]}"; do
+  if ! head -c 20 "$UIKIT_DIR/dist/$name.js" | grep -qF "use client"; then
+    echo "FAIL: dist/$name.js is missing its 'use client' banner"
+    exit 1
+  fi
+done
+for name in "${SERVER_COMPONENTS[@]}" index; do
+  if head -c 20 "$UIKIT_DIR/dist/$name.js" | grep -qF "use client"; then
+    echo "FAIL: dist/$name.js carries a 'use client' banner it doesn't need — this removes it from server rendering for RSC consumers"
+    exit 1
+  fi
+done
+echo "==> 'use client': present on ${CLIENT_COMPONENTS[*]}, absent elsewhere (${#ALL_COMPONENTS[@]} components accounted for)"
+
 # Present/absent assertions against a glob, with the glob's own emptiness
 # checked explicitly rather than left to grep's exit code. Without this, an
 # absence check written as `grep … && { fail; }` passes *silently* when the

--- a/packages/ui-kit/src/components/badge/badge.tsx
+++ b/packages/ui-kit/src/components/badge/badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { mergeProps } from '@base-ui/react/merge-props';
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/packages/ui-kit/src/components/badge/badge.tsx
+++ b/packages/ui-kit/src/components/badge/badge.tsx
@@ -1,3 +1,6 @@
+// Load-bearing: Badge calls useRender directly, so this can't be dropped.
+// Coupled to CLIENT_COMPONENTS in scripts/verify-consumer.sh — keep both in
+// sync if this ever changes.
 'use client';
 
 import { mergeProps } from '@base-ui/react/merge-props';

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,3 +1,6 @@
+// Load-bearing: DropdownMenuContent calls useContext directly, so this
+// can't be dropped. Coupled to CLIENT_COMPONENTS in
+// scripts/verify-consumer.sh — keep both in sync if this ever changes.
 'use client';
 
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import { cva, cx, type VariantProps } from 'class-variance-authority';
 import { type ComponentProps, createContext, useContext } from 'react';

--- a/packages/ui-kit/src/components/toast/toast.tsx
+++ b/packages/ui-kit/src/components/toast/toast.tsx
@@ -1,3 +1,6 @@
+// Load-bearing: ToastList calls useToastManager directly, so this can't be
+// dropped. Coupled to CLIENT_COMPONENTS in scripts/verify-consumer.sh —
+// keep both in sync if this ever changes.
 'use client';
 
 import { Toast as ToastPrimitive } from '@base-ui/react/toast';

--- a/packages/ui-kit/src/components/toast/toast.tsx
+++ b/packages/ui-kit/src/components/toast/toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Toast as ToastPrimitive } from '@base-ui/react/toast';
 import { cx } from 'class-variance-authority';
 


### PR DESCRIPTION
## Summary
- `@gears-frontx/ui-kit` dist chunks shipped with no `'use client'` directive, so a React Server Component (Next.js App Router) importing a hook-using component like Badge crashes at render.
- Adds a small Rollup plugin (`buildPlugin.ts`) that re-attaches `'use client'` to a chunk when its source module declared the directive — Rollup strips module-level directives during bundling, and `rollup-plugin-preserve-directives` requires `output.preserveModules`, which would break this build's one-chunk-per-component output shape.
- Only **Badge** (`useRender`), **DropdownMenu** (`useContext`), and **Toast** (`useToastManager`) call a hook directly in their own render body and get the directive. The other 16 components stay directive-free — they only compose Base UI primitives as JSX, and Base UI's own dist already carries `'use client'` on its hook-using modules, so they remain server-renderable for RSC consumers.
- `verify-consumer.sh` gets a regression guard that derives the full component list from the same glob the build uses and asserts every component is classified in exactly one of the client/server lists — a future component landing in neither (or both) fails loudly instead of shipping unclassified.
- `README.md`/`llms.txt` document which components are server-renderable vs. client-bound.

Fixes #568

## Test plan
- [x] `npm run build --workspace=@gears-frontx/ui-kit`
- [x] `npm run type-check --workspace=@gears-frontx/ui-kit`
- [x] `npm run test:unit --workspace=@gears-frontx/ui-kit` (284/284)
- [x] `bash packages/ui-kit/scripts/verify-consumer.sh` (all 5 legs, including new directive-banner guard)
- [x] `npm run lint` / `npm run arch:check` (12/12)
- [x] Byte-level inspection of all 20 dist chunks: directive present only on `badge.js`, `dropdown-menu.js`, `toast.js`
- [x] Vite SPA demo build unaffected, no directive-related warnings
- [ ] Not verified against a real Next.js App Router harness (none exists in this repo) — server-renderability of the other 16 components is verified structurally (no hooks + Base UI leaves self-mark), not by rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added React Server Components guidance, clarifying which UI-kit components can render on the server and which require client-side execution.
  * Updated Badge, Dropdown Menu, and Toast for reliable client-side behavior.

* **Bug Fixes**
  * Improved build output so client-only component directives are preserved correctly.

* **Documentation**
  * Documented Server Components compatibility and usage guidance.

* **Tests**
  * Added checks to verify correct client and server component classifications in built bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->