### PR TITLE
feat(react): add explicit-bridge options form to useSharedProperty (#570)

### DIFF
--- a/template-mfe/package-lock.json
+++ b/template-mfe/package-lock.json
@@ -4497,7 +4497,7 @@
       "version": "0.2.0-alpha.0",
       "dependencies": {
         "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
-        "@gears-frontx/react": "0.2.0-alpha.6",
+        "@gears-frontx/react": "0.2.0-alpha.7",
         "@gears-frontx/ui-kit": "0.4.0-alpha.2",
         "@tanstack/react-query": "5.101.4",
         "react": "19.2.4",
@@ -4548,7 +4548,7 @@
       "version": "0.2.0-alpha.0",
       "dependencies": {
         "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
-        "@gears-frontx/react": "0.2.0-alpha.6",
+        "@gears-frontx/react": "0.2.0-alpha.7",
         "@gears-frontx/ui-kit": "0.4.0-alpha.2",
         "@tanstack/react-query": "5.101.4",
         "react": "19.2.4",
@@ -4613,7 +4613,7 @@
       "name": "@gears-frontx/widgets-fixture-a",
       "version": "0.1.0-alpha.1",
       "dependencies": {
-        "@gears-frontx/react": "0.2.0-alpha.6",
+        "@gears-frontx/react": "0.2.0-alpha.7",
         "@tanstack/react-query": "5.101.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -4658,7 +4658,7 @@
       "name": "@gears-frontx/widgets-fixture-b",
       "version": "0.1.0-alpha.0",
       "dependencies": {
-        "@gears-frontx/react": "0.2.0-alpha.6",
+        "@gears-frontx/react": "0.2.0-alpha.7",
         "@tanstack/react-query": "5.101.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"

--- a/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
@@ -16,7 +16,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
-    "@gears-frontx/react": "0.2.0-alpha.6",
+    "@gears-frontx/react": "0.2.0-alpha.7",
     "@gears-frontx/ui-kit": "0.4.0-alpha.2",
     "@tanstack/react-query": "5.101.4"
   },

--- a/template-mfe/src-app/mfe_packages/demo-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
-    "@gears-frontx/react": "0.2.0-alpha.6",
+    "@gears-frontx/react": "0.2.0-alpha.7",
     "@gears-frontx/ui-kit": "0.4.0-alpha.2",
     "@tanstack/react-query": "5.101.4",
     "react": "19.2.4",

--- a/template-mfe/src-app/mfe_packages/widgets-fixture-a/package.json
+++ b/template-mfe/src-app/mfe_packages/widgets-fixture-a/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "@gears-frontx/react": "0.2.0-alpha.6",
+    "@gears-frontx/react": "0.2.0-alpha.7",
     "@tanstack/react-query": "5.101.4"
   },
   "devDependencies": {

--- a/template-mfe/src-app/mfe_packages/widgets-fixture-b/package.json
+++ b/template-mfe/src-app/mfe_packages/widgets-fixture-b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "@gears-frontx/react": "0.2.0-alpha.6",
+    "@gears-frontx/react": "0.2.0-alpha.7",
     "@tanstack/react-query": "5.101.4"
   },
   "devDependencies": {

--- a/template-shell/package-lock.json
+++ b/template-shell/package-lock.json
@@ -11204,7 +11204,7 @@
     },
     "packages/react": {
       "name": "@gears-frontx/react",
-      "version": "0.2.0-alpha.6",
+      "version": "0.2.0-alpha.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@reduxjs/toolkit": "2.12.0",

--- a/template-shell/packages/react/CLAUDE.md
+++ b/template-shell/packages/react/CLAUDE.md
@@ -277,7 +277,9 @@ function MyExtension() {
 
 #### useSharedProperty
 
-Subscribe to shared property changes:
+Subscribe to shared property changes. Two forms: the context form reads the bridge from `MfeContext`, and the options form accepts an explicit bridge and a fallback.
+
+**Context form** — `useSharedProperty(propertyTypeId)`. Reads the bridge from `MfeContext` and throws if no `MfeProvider` is mounted. Returns the value (or `undefined` if the host has not published it), updating on every host publish.
 
 ```tsx
 import { useSharedProperty, Gears FrontX_SHARED_PROPERTY_THEME } from '@gears-frontx/react';
@@ -288,6 +290,31 @@ function ThemedComponent() {
   return <div style={{ backgroundColor: theme?.primaryColor }}>...</div>;
 }
 ```
+
+**Options form** — `useSharedProperty(propertyTypeId, { bridge, fallback })`. Use it for components that never mount `MfeProvider`, or to show a value until the host publishes one.
+
+```tsx
+import { useSharedProperty } from '@gears-frontx/react';
+import type { ChildMfeBridge } from '@gears-frontx/framework';
+
+function StandaloneComponent({ bridge }: { bridge: ChildMfeBridge }) {
+  const label = useSharedProperty<string>(LABEL_PROPERTY_ID, {
+    bridge,
+    fallback: 'Untitled',
+  });
+
+  return <span>{label}</span>;
+}
+```
+
+`UseSharedPropertyOptions<T>` fields:
+
+- `bridge` — bridge to read the property from, bypassing `MfeContext`. Pass it when the calling component never mounts `MfeProvider` (for example, a component that receives its bridge as a prop or from a non-React entry point). When omitted, the hook falls back to the bridge from `MfeContext` and throws if no `MfeProvider` is mounted. Changing `bridge` or `propertyTypeId` moves the subscription to the new source and the returned value follows on the same render.
+- `fallback` — value returned while the host has not published the property yet. Only `undefined` is substituted; a published `null` is a real value and comes through as-is. With `fallback` set the hook returns `T` rather than `T | undefined`. It may be passed inline on every render without affecting the subscription.
+
+There is no consumer-side validation option on purpose: the host validates every published value against the property's schema before it reaches any MFE (`TypeSystemPlugin.register()` throws on a mismatch and the update is never stored or delivered). `T` is the caller's declaration of that schema, as with `useState<T>`.
+
+Both forms read through `useSyncExternalStore`, so the first render shows the host's current value and the result is tearing-protected under concurrent rendering. The TSDoc block on `useSharedProperty` in `src/mfe/hooks/useSharedProperty.ts` is the authoritative reference; this guide summarizes consumer-facing usage.
 
 #### useHostAction
 
@@ -475,7 +502,7 @@ This allows users to import everything from `@gears-frontx/react` without needin
 - `useScreenTranslations` - Screen translation loading
 - `useTheme` - Theme utilities
 - `useMfeBridge` - Access MFE bridge
-- `useSharedProperty` - Subscribe to shared property
+- `useSharedProperty` - Subscribe to shared property, via `MfeContext` or an explicit bridge
 - `useHostAction` - Invoke host action
 - `useDomainExtensions` - Subscribe to domain extensions
 - `useRegisteredPackages` - Subscribe to registered GTS packages
@@ -494,6 +521,7 @@ This allows users to import everything from `@gears-frontx/react` without needin
 - `QueryCache` - Restricted cache interface (accepts descriptors or raw keys)
 - `MutationCallbackContext` - Context with queryCache injected into mutation callbacks
 - `MfeProviderProps`, `ExtensionDomainSlotProps`
+- `UseSharedPropertyOptions<T>` - Options for `useSharedProperty` (bridge, fallback)
 - `UseTranslationReturn`, `UseThemeReturn`
 - All types from @gears-frontx/framework (including `EndpointDescriptor`, `MutationDescriptor`, `StreamDescriptor`, `StreamStatus`)
 

--- a/template-shell/packages/react/__tests__/mfe/hooks.test.tsx
+++ b/template-shell/packages/react/__tests__/mfe/hooks.test.tsx
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import {
@@ -17,20 +17,32 @@ import {
   useHostAction,
   type MfeContextValue,
 } from '../../src/mfe';
-import type { ChildMfeBridge } from '@gears-frontx/framework';
+import type { ChildMfeBridge, SharedProperty } from '@gears-frontx/framework';
 
 // ============================================================================
 // Mock Data
 // ============================================================================
 
-const mockBridge: ChildMfeBridge = {
-  extDomainId: 'gts.frontx.mfes.ext.domain.v1~frontx.screensets.layout.sidebar.v1',
-  extensionId: 'test-instance-123',
-  executeActionsChain: vi.fn().mockResolvedValue(undefined),
-  subscribeToProperty: vi.fn().mockReturnValue(() => {}),
-  getProperty: vi.fn().mockReturnValue(undefined),
-  registerActionHandler: vi.fn(),
-};
+const TEST_DOMAIN_ID =
+  'gts.frontx.mfes.ext.domain.v1~frontx.screensets.layout.sidebar.v1';
+
+/**
+ * Build a ChildMfeBridge test double. Override only what the test cares
+ * about; everything else is an inert mock.
+ */
+function makeBridge(overrides: Partial<ChildMfeBridge> = {}): ChildMfeBridge {
+  return {
+    extDomainId: TEST_DOMAIN_ID,
+    extensionId: 'test-instance',
+    executeActionsChain: vi.fn().mockResolvedValue(undefined),
+    subscribeToProperty: vi.fn().mockReturnValue(() => {}),
+    getProperty: vi.fn().mockReturnValue(undefined),
+    registerActionHandler: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockBridge = makeBridge({ extensionId: 'test-instance-123' });
 
 const mockMfeContextValue: MfeContextValue = {
   bridge: mockBridge,
@@ -137,6 +149,181 @@ describe('MfeContext', () => {
 
       unmount();
       expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it('should throw when used outside MfeProvider and no explicit bridge is given', () => {
+      expect(() => {
+        renderHook(() =>
+          useSharedProperty('gts.frontx.mfes.comm.shared_property.v1~test.user_data.v1')
+        );
+      }).toThrow(/MfeProvider/);
+    });
+
+    it('should read from an explicit bridge without requiring MfeProvider', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.explicit_bridge.v1';
+      const explicitBridge = makeBridge({
+        extensionId: 'explicit-bridge-instance',
+        getProperty: vi.fn().mockReturnValue({ id: propertyId, value: 'hello' }),
+      });
+
+      // No MfeProvider in the tree -- only the option-supplied bridge is used.
+      const { result } = renderHook(() =>
+        useSharedProperty(propertyId, { bridge: explicitBridge })
+      );
+
+      expect(result.current).toBe('hello');
+      expect(explicitBridge.getProperty).toHaveBeenCalledWith(propertyId);
+    });
+
+    it('should return fallback while the property is unpublished, then the published value', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.fallback_unset.v1';
+      let subscribedCallback: ((property: SharedProperty) => void) | undefined;
+      let currentValue: unknown = undefined;
+
+      const explicitBridge = makeBridge({
+        subscribeToProperty: vi.fn((_id, callback) => {
+          subscribedCallback = callback;
+          return () => {};
+        }),
+        getProperty: vi.fn(() =>
+          currentValue === undefined ? undefined : { id: propertyId, value: currentValue }
+        ),
+      });
+
+      const { result } = renderHook(() =>
+        useSharedProperty<string>(propertyId, { bridge: explicitBridge, fallback: 'Untitled' })
+      );
+
+      expect(result.current).toBe('Untitled');
+
+      currentValue = 'Published';
+      act(() => subscribedCallback?.({ id: propertyId, value: 'Published' }));
+
+      expect(result.current).toBe('Published');
+    });
+
+    it('should resubscribe and reflect the new value when the bridge instance is swapped', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.bridge_swap.v1';
+      const unsubscribeA = vi.fn();
+      const unsubscribeB = vi.fn();
+
+      const bridgeA = makeBridge({
+        extensionId: 'instance-a',
+        subscribeToProperty: vi.fn().mockReturnValue(unsubscribeA),
+        getProperty: vi.fn().mockReturnValue({ id: propertyId, value: 'value-a' }),
+      });
+      const bridgeB = makeBridge({
+        extensionId: 'instance-b',
+        subscribeToProperty: vi.fn().mockReturnValue(unsubscribeB),
+        getProperty: vi.fn().mockReturnValue({ id: propertyId, value: 'value-b' }),
+      });
+
+      const { result, rerender } = renderHook(
+        ({ bridge }: { bridge: ChildMfeBridge }) =>
+          useSharedProperty(propertyId, { bridge, fallback: 'Untitled' }),
+        { initialProps: { bridge: bridgeA } }
+      );
+
+      expect(result.current).toBe('value-a');
+      expect(bridgeA.subscribeToProperty).toHaveBeenCalledTimes(1);
+
+      rerender({ bridge: bridgeB });
+
+      expect(unsubscribeA).toHaveBeenCalled();
+      expect(bridgeB.subscribeToProperty).toHaveBeenCalledTimes(1);
+      expect(result.current).toBe('value-b');
+    });
+
+    it('should resubscribe and reflect the new value when propertyTypeId changes on the same bridge', () => {
+      const propertyIdA = 'gts.frontx.mfes.comm.shared_property.v1~test.resync_prop_a.v1';
+      const propertyIdB = 'gts.frontx.mfes.comm.shared_property.v1~test.resync_prop_b.v1';
+      const unsubscribe = vi.fn();
+
+      const bridge = makeBridge({
+        subscribeToProperty: vi.fn().mockReturnValue(unsubscribe),
+        getProperty: vi.fn((id: string) => ({
+          id,
+          value: id === propertyIdA ? 'value-a' : 'value-b',
+        })),
+      });
+
+      const { result, rerender } = renderHook(
+        ({ propertyTypeId }: { propertyTypeId: string }) =>
+          useSharedProperty(propertyTypeId, { bridge }),
+        { initialProps: { propertyTypeId: propertyIdA } }
+      );
+
+      expect(result.current).toBe('value-a');
+
+      rerender({ propertyTypeId: propertyIdB });
+
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(bridge.subscribeToProperty).toHaveBeenLastCalledWith(
+        propertyIdB,
+        expect.any(Function)
+      );
+      expect(result.current).toBe('value-b');
+    });
+
+    it('should pick up a publish landing between render and subscription', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.commit_window.v1';
+      let currentValue = 'published-before-render';
+
+      // The value changes at the moment the hook subscribes, simulating a
+      // publish that landed inside the render->commit window. Nothing ever
+      // fires the subscription callback, so the only way to observe the new
+      // value is useSyncExternalStore's post-subscribe snapshot re-read.
+      const bridge = makeBridge({
+        subscribeToProperty: vi.fn(() => {
+          currentValue = 'published-before-subscribe';
+          return () => {};
+        }),
+        getProperty: vi.fn(() => ({ id: propertyId, value: currentValue })),
+      });
+
+      const { result } = renderHook(() =>
+        useSharedProperty(propertyId, { bridge })
+      );
+
+      expect(result.current).toBe('published-before-subscribe');
+    });
+
+    it('should treat a published null as a value, not as unpublished', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.null_value.v1';
+      const explicitBridge = makeBridge({
+        getProperty: vi.fn().mockReturnValue({ id: propertyId, value: null }),
+      });
+
+      // `null` is a real value, distinct from "unpublished" (getProperty
+      // returning undefined), so it must NOT collapse to `fallback`.
+      const { result } = renderHook(() =>
+        useSharedProperty<string | null>(propertyId, { bridge: explicitBridge, fallback: 'Untitled' })
+      );
+
+      expect(result.current).toBeNull();
+    });
+
+    it('should not resubscribe when an inline fallback changes identity across renders', () => {
+      const propertyId = 'gts.frontx.mfes.comm.shared_property.v1~test.no_churn.v1';
+      const unsubscribe = vi.fn();
+      const explicitBridge = makeBridge({
+        subscribeToProperty: vi.fn().mockReturnValue(unsubscribe),
+        getProperty: vi.fn().mockReturnValue({ id: propertyId, value: 'value' }),
+      });
+
+      // A fresh fallback object each render must not tear down and recreate
+      // the host subscription.
+      const { rerender } = renderHook(() =>
+        useSharedProperty(propertyId, { bridge: explicitBridge, fallback: { label: 'Untitled' } })
+      );
+
+      expect(explicitBridge.subscribeToProperty).toHaveBeenCalledTimes(1);
+
+      rerender();
+      rerender();
+
+      expect(explicitBridge.subscribeToProperty).toHaveBeenCalledTimes(1);
+      expect(unsubscribe).not.toHaveBeenCalled();
     });
   });
 

--- a/template-shell/packages/react/llms.txt
+++ b/template-shell/packages/react/llms.txt
@@ -26,7 +26,7 @@ Part of the FrontX React Layer (L3) - depends on @gears-frontx/framework. Peer d
 | Hook | Purpose |
 |------|---------|
 | `useMfeBridge()` | Access MFE bridge (child MFEs) |
-| `useSharedProperty()` | Subscribe to shared property changes |
+| `useSharedProperty()` | Subscribe to shared property changes, via `MfeContext` or an explicit `bridge` option |
 | `useHostAction()` | Invoke actions on host application |
 | `useDomainExtensions()` | Subscribe to extensions in a domain |
 
@@ -96,6 +96,26 @@ function MyExtension() {
   return <div style={{ backgroundColor: theme?.primaryColor }}>...</div>;
 }
 ```
+
+### Shared Properties Without MfeProvider
+
+`useSharedProperty(propertyTypeId, options)` takes an explicit `bridge` for components that never mount `MfeProvider`, plus a `fallback` returned until the host publishes the property (only `undefined` is substituted; a published `null` is a value). With `fallback` set the result type is `T`. There is no consumer-side validation option: the host validates published values against the property's schema before delivery, so `T` is the caller's declaration of that schema.
+
+```tsx
+import { useSharedProperty } from '@gears-frontx/react';
+import type { ChildMfeBridge } from '@gears-frontx/framework';
+
+function StandaloneComponent({ bridge }: { bridge: ChildMfeBridge }) {
+  const label = useSharedProperty<string>(LABEL_PROPERTY_ID, {
+    bridge,
+    fallback: 'Untitled',
+  });
+
+  return <span>{label}</span>;
+}
+```
+
+Omitting `bridge` falls back to `MfeContext`; the hook still throws when neither is available. Changing `bridge` or `propertyTypeId` moves the subscription and the value follows on the same render.
 
 ### Subscribing to Domain Extensions
 

--- a/template-shell/packages/react/package.json
+++ b/template-shell/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/react",
-  "version": "0.2.0-alpha.6",
+  "version": "0.2.0-alpha.7",
   "description": "React bindings and hooks for FrontX framework",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/template-shell/packages/react/src/index.ts
+++ b/template-shell/packages/react/src/index.ts
@@ -76,6 +76,7 @@ export type {
   MfeContextValue,
   MfeProviderProps,
   ExtensionDomainSlotProps,
+  UseSharedPropertyOptions,
 } from './mfe';
 
 // ============================================================================
@@ -539,8 +540,6 @@ export type {
 import type { EventPayloadMap as FrameworkEventPayloadMap, EventBus } from '@gears-frontx/framework';
 import { eventBus as frameworkEventBus } from '@gears-frontx/framework';
 
-// @cpt-dod:cpt-frontx-dod-react-bindings-event-payload-map:p2
-// @cpt-begin:cpt-frontx-dod-react-bindings-event-payload-map:p2:inst-event-payload-map
 export interface EventPayloadMap extends FrameworkEventPayloadMap { }
 
 /**
@@ -549,4 +548,3 @@ export interface EventPayloadMap extends FrameworkEventPayloadMap { }
  * type-safe access to both framework events and app-layer augmented events.
  */
 export const eventBus: EventBus<EventPayloadMap> = frameworkEventBus as EventBus<EventPayloadMap>;
-// @cpt-end:cpt-frontx-dod-react-bindings-event-payload-map:p2:inst-event-payload-map

--- a/template-shell/packages/react/src/mfe/hooks/index.ts
+++ b/template-shell/packages/react/src/mfe/hooks/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { useMfeBridge } from './useMfeBridge';
-export { useSharedProperty } from './useSharedProperty';
+export { useSharedProperty, type UseSharedPropertyOptions } from './useSharedProperty';
 export { useHostAction } from './useHostAction';
 export { useDomainExtensions } from './useDomainExtensions';
 export { useMountedExtensions } from './useMountedExtensions';

--- a/template-shell/packages/react/src/mfe/hooks/useSharedProperty.ts
+++ b/template-shell/packages/react/src/mfe/hooks/useSharedProperty.ts
@@ -1,76 +1,145 @@
 /**
  * useSharedProperty Hook - Shared property subscription
  *
- * Subscribes to shared property updates from the host.
+ * Subscribes to shared property updates from the host, either through the
+ * ambient MfeProvider context or through an explicitly supplied bridge.
  *
  * React Layer: L3
  */
-// @cpt-flow:cpt-frontx-flow-react-bindings-use-shared-property:p1
-// @cpt-algo:cpt-frontx-algo-react-bindings-mfe-context-guard:p1
-// @cpt-dod:cpt-frontx-dod-react-bindings-mfe-hooks:p1
 
-import { useSyncExternalStore, useCallback } from 'react';
-import { useMfeContext } from '../MfeContext';
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import type { ChildMfeBridge } from '@gears-frontx/framework';
+import { MfeContext } from '../MfeContext';
+
+// ============================================================================
+// Option Types
+// ============================================================================
+
+/**
+ * Options for {@link useSharedProperty}.
+ */
+export interface UseSharedPropertyOptions<T> {
+  /**
+   * Bridge to read the property from, bypassing `MfeContext`.
+   *
+   * Pass this when the calling component never mounts `MfeProvider` (for
+   * example, a component that receives its bridge directly as a prop or from
+   * a non-React entry point). When omitted, the hook falls back to the
+   * bridge from `MfeContext` and throws if no `MfeProvider` is mounted,
+   * matching the zero-argument form.
+   *
+   * `bridge` and `propertyTypeId` identify the subscription: changing either
+   * one unsubscribes from the old source and subscribes to the new one, and
+   * the returned value reflects the new source on the same render.
+   */
+  bridge?: ChildMfeBridge;
+
+  /**
+   * Value returned while the host has not published the property yet
+   * (`bridge.getProperty()` returns `undefined`).
+   *
+   * Only the `undefined` sentinel is substituted: a published `null` is a
+   * real value and is returned as-is. The host validates every published
+   * value against the property's schema before it reaches any MFE
+   * (`TypeSystemPlugin.register()` throws on a schema mismatch and the
+   * update is never stored or delivered), so no consumer-side filtering is
+   * needed -- `T` is simply the caller's declaration of that schema.
+   *
+   * `fallback` may be passed inline on every render; it does not affect the
+   * host subscription.
+   */
+  fallback?: T;
+}
 
 // ============================================================================
 // Hook Implementation
 // ============================================================================
 
 /**
- * Hook for subscribing to a shared property.
+ * Subscribe to a shared property from the host.
  *
- * Subscribes to property updates from the host and returns the current value.
- * Must be used within a MfeProvider (i.e., inside an MFE component).
+ * Two forms:
  *
- * NOTE: This hook provides the interface and uses useSyncExternalStore with a stub subscription.
- * Full bridge subscription should be implemented when bridge methods are available.
+ * 1. **Context form** -- `useSharedProperty(propertyTypeId)`. Reads the
+ *    bridge from `MfeContext` and throws if no `MfeProvider` is mounted.
+ * 2. **Options form** -- `useSharedProperty(propertyTypeId, options)`. Pass
+ *    `options.bridge` for components that never mount `MfeProvider`, and/or
+ *    `options.fallback` for a value to show until the host publishes one.
+ *    `options.bridge` may be omitted, in which case the hook still falls
+ *    back to `MfeContext`.
  *
- * @param _propertyTypeId - Type ID of the shared property to subscribe to (currently unused)
- * @returns Current property value
+ * Both forms read through `useSyncExternalStore`: the bridge is the store,
+ * `bridge.getProperty()` is the snapshot, so the first render already shows
+ * the host's current value, a publish between render and commit is picked
+ * up when React re-reads the snapshot after subscribing, and the value is
+ * tearing-protected under concurrent rendering.
  *
- * @example
+ * @param propertyTypeId - GTS type ID of the shared property to subscribe to
+ * @param options - Optional bridge override and fallback
+ * @returns The current property value; `T` when `options.fallback` is set,
+ *   otherwise `T | undefined`
+ *
+ * @example Context form (inside MfeProvider)
  * ```tsx
- * function MyMfeComponent() {
- *   const userData = useSharedProperty('gts.frontx.mfes.comm.shared_property.v1~myapp.user_data.v1');
+ * function ThemedComponent() {
+ *   const theme = useSharedProperty<{ primaryColor: string }>(THEME_PROPERTY_ID);
+ *   return <div style={{ color: theme?.primaryColor }} />;
+ * }
+ * ```
  *
- *   return <div>User: {userData?.name}</div>;
+ * @example Explicit bridge with fallback (no MfeProvider)
+ * ```tsx
+ * function StandaloneComponent({ bridge }: { bridge: ChildMfeBridge }) {
+ *   const label = useSharedProperty<string>(LABEL_PROPERTY_ID, {
+ *     bridge,
+ *     fallback: 'Untitled',
+ *   });
+ *   return <span>{label}</span>;
  * }
  * ```
  */
-// @cpt-begin:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-call-shared-property
-// @cpt-begin:cpt-frontx-dod-react-bindings-mfe-hooks:p1:inst-call-shared-property
-export function useSharedProperty<T = unknown>(propertyTypeId: string): T | undefined {
-  // @cpt-begin:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-read-bridge
-  // @cpt-begin:cpt-frontx-algo-react-bindings-mfe-context-guard:p1:inst-throw-no-mfe-context
-  // Enforce MfeProvider context requirement
-  const { bridge } = useMfeContext(); // Throws if not in MfeProvider
-  // @cpt-end:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-read-bridge
-  // @cpt-end:cpt-frontx-algo-react-bindings-mfe-context-guard:p1:inst-throw-no-mfe-context
+export function useSharedProperty<T = unknown>(propertyTypeId: string): T | undefined;
+export function useSharedProperty<T>(
+  propertyTypeId: string,
+  options: UseSharedPropertyOptions<T> & { fallback: T }
+): T;
+export function useSharedProperty<T = unknown>(
+  propertyTypeId: string,
+  options?: UseSharedPropertyOptions<T>
+): T | undefined;
+export function useSharedProperty<T = unknown>(
+  propertyTypeId: string,
+  options?: UseSharedPropertyOptions<T>
+): T | undefined {
+  // useContext is called unconditionally (Rules of Hooks) regardless of whether
+  // an explicit bridge was supplied; only the *result* is used conditionally below.
+  const contextValue = useContext(MfeContext);
+  const bridge = options?.bridge ?? contextValue?.bridge;
+  const fallback = options?.fallback;
 
-  // @cpt-begin:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-subscribe-property
-  // @cpt-begin:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-rerender-on-property-change
-  // Subscribe to property updates via bridge
-  const subscribe = useCallback((callback: () => void) => {
-    return bridge.subscribeToProperty(propertyTypeId, () => {
-      // When property changes, trigger React re-render
-      callback();
-    });
-  }, [bridge, propertyTypeId]);
-  // @cpt-end:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-subscribe-property
-  // @cpt-end:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-rerender-on-property-change
+  if (!bridge) {
+    throw new Error(
+      'useSharedProperty must be used within a MfeProvider, or given an explicit ' +
+      '`bridge` option, for components that never mount MfeProvider.'
+    );
+  }
 
-  // @cpt-begin:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-return-property-value
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      bridge.subscribeToProperty(propertyTypeId, () => {
+        onStoreChange();
+      }),
+    [bridge, propertyTypeId]
+  );
+
   const getSnapshot = useCallback(() => {
-    const property = bridge.getProperty(propertyTypeId);
-    // Type narrowing: caller specifies expected type T (standard React hook pattern)
-    // Similar to useState<T>, useContext<T> - type safety is caller's responsibility
-    return property?.value as T | undefined;
-  }, [bridge, propertyTypeId]);
+    const raw = bridge.getProperty(propertyTypeId)?.value;
+    // `undefined` is the only "not published" sentinel; `null` is a real value.
+    // The caller specifies the expected `T` (as with `useState<T>`/
+    // `useContext<T>`); the host has already validated the value against the
+    // property's schema, so the assertion states the schema, not a hope.
+    return raw === undefined ? fallback : (raw as T);
+  }, [bridge, propertyTypeId, fallback]);
 
-  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-
-  return value;
-  // @cpt-end:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-return-property-value
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
-// @cpt-end:cpt-frontx-flow-react-bindings-use-shared-property:p1:inst-call-shared-property
-// @cpt-end:cpt-frontx-dod-react-bindings-mfe-hooks:p1:inst-call-shared-property

--- a/template-shell/packages/react/src/mfe/index.ts
+++ b/template-shell/packages/react/src/mfe/index.ts
@@ -9,6 +9,7 @@ export { MfeProvider, type MfeProviderProps } from './MfeProvider';
 export {
   useMfeBridge,
   useSharedProperty,
+  type UseSharedPropertyOptions,
   useHostAction,
   useDomainExtensions,
   useMountedExtensions,


### PR DESCRIPTION
Closes #570.

## Why

The React package already ships `useSharedProperty` for reading a host-published property, but it only works inside `MfeProvider` because it takes the bridge from React context. Our MFEs receive the bridge as a plain argument at their entry point and never mount that provider, so they cannot use the shipped hook.

The result is that the template MFEs each carry their own copy of the same logic:

- demo-mfe has `useBridgeProperty` (extracted in #567).
- Both demo-mfe and `_blank-mfe` have a `useScreenTranslations` that subscribes to the bridge by hand.
- `_blank-mfe/HomeScreen` and demo-mfe's `CurrentThemeScreen` do the same subscription inline.

That is one concept written five times, each slightly different, and every copy is stamped into every new project generated from the template. The #567 review flagged this and opened #570.

This PR lets the shipped hook take the bridge directly, plus a fallback for before the host has published anything:

```ts
// before: only this form, needs MfeProvider above it
const theme = useSharedProperty('theme');

// after: also this form, works anywhere you hold a bridge
const theme = useSharedProperty('theme', { bridge, fallback: 'light' });
```

Existing callers are unaffected. Once this lands, the five local copies can be deleted (see Follow-up), leaving one hook, one set of tests, and one place to fix bugs.

## What

`useSharedProperty` in `@gears-frontx/react` (template-shell) gains an options form while keeping the zero-options context form intact:

```ts
useSharedProperty(propertyTypeId)                          // unchanged: bridge from MfeContext, throws outside MfeProvider
useSharedProperty(propertyTypeId, { bridge?, fallback? })
```

- `bridge`: an explicit `ChildMfeBridge` for MFEs that never mount `MfeProvider` (demo-mfe's case). Falls back to context when omitted. `useContext(MfeContext)` is still called unconditionally; only the resolved bridge is used conditionally.
- `fallback`: returned while the host has not published the property yet. The `{ fallback: T }` overload makes the return type non-optional. Only the `undefined` sentinel is substituted; a published `null` is a real value.

There is deliberately no consumer-side `select`/validation option. The host validates every published value against the property's schema before storing or delivering it (`updateSharedProperty` -> `TypeSystemPlugin.register` throws on a mismatch), so a malformed value never reaches an MFE. `T` is the caller's declaration of that schema, as with `useState<T>`. The TSDoc, CLAUDE.md and llms.txt say so.

## Notes for review

- **Implementation stays on `useSyncExternalStore`** (bridge as the store, `bridge.getProperty()` as the snapshot). The first render shows the host's current value, a publish between render and commit is caught by React's post-subscribe snapshot re-read, the value is tearing-protected, and a bridge or `propertyTypeId` change is reflected on the same render. `fallback` is only a `getSnapshot` dependency, so passing it inline does not resubscribe.
- **Error text changed**: the no-bridge throw now also names the explicit-`bridge` option.
- **ADR-0033**: template territory. Residual `@cpt-` markers were stripped from the two modified source files (`useSharedProperty.ts`, and `src/index.ts`, touched only to re-export `UseSharedPropertyOptions<T>`). No new markers were added.
- **Version bump**: `@gears-frontx/react` 0.2.0-alpha.6 -> 0.2.0-alpha.7 (new public API), with every exact pin moved in the same commit: template-shell's lockfile self-entry, the four template-mfe fixture manifests (`_blank-mfe`, `demo-mfe`, `widgets-fixture-a`, `widgets-fixture-b`) and their lockfile mirror entries. That is why template-mfe appears in the diff.

## Tests

Eight new cases in `__tests__/mfe/hooks.test.tsx` (package suite 158/158):

- throws outside `MfeProvider` with no explicit bridge
- reads from an explicit bridge without `MfeProvider`
- returns `fallback` while unpublished, then the published value
- resubscribes on bridge-instance swap
- resubscribes on `propertyTypeId` change on the same bridge
- picks up a publish landing between render and subscription
- treats a published `null` as a value, not as unpublished
- does not resubscribe when an inline `fallback` changes identity

Also green: `tsc --noEmit`, repo-root eslint, `policy:template-pin-drift`, `policy:version-check`, `policy:template-lockfile-selflink`, `policy:version-bump-on-change`.

## Follow-up

Once this ships, migrate the hand-rolled copies of the pattern:

- demo-mfe `useBridgeProperty` -> `useSharedProperty(id, { bridge, fallback })`.
- `_blank-mfe/HomeScreen` and both `useScreenTranslations` copies call `getProperty`/`subscribeToProperty` directly; `CurrentThemeScreen` carries the same lazy-init plus bridge-resync logic.

One assumption to verify there: the hook re-reads via `bridge.getProperty()` on notification while `useBridgeProperty` uses the callback payload. These are equivalent because each bridge capability delegates to the single runtime authority (ADR-0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
