### PR TITLE
fix(mfes): add webpackIgnore to the blob-module dynamic import (#504)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -82,7 +82,7 @@ exclude_paths:
   # dynamic import of blob URLs). Every function in it is required by a
   # custom ESLint rule to document its safety argument via `@safety-reviewed`
   # and `@why` JSDoc tags. Editing this file requires security review.
-  - "packages/screensets/src/mfe/handler/mf-dynamic-module-ops.ts"
+  - "packages/mfes/src/handler/mf-dynamic-module-ops.ts"
 
   # Monorepo package manifests.
   #

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,17 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
 
+  // Package-local build scripts (e.g. packages/mfes/scripts/) run under Node,
+  // unlike the root scripts/** which is still ignored pending #483.
+  {
+    files: ['packages/*/scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
   // L0 BASE: Universal rules for all TS/TSX files
   {
     files: ['**/*.{ts,tsx}'],

--- a/packages/mfes/package.json
+++ b/packages/mfes/package.json
@@ -25,7 +25,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/verify-dist-import-pragmas.mjs",
     "type-check": "tsc --noEmit",
     "type-check:test": "tsc -p tsconfig.test.json",
     "test": "npm run test:unit",

--- a/packages/mfes/scripts/verify-dist-import-pragmas.mjs
+++ b/packages/mfes/scripts/verify-dist-import-pragmas.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Verify that the bundler pragmas on the blob-module dynamic import survive
+ * the build into both published dist formats.
+ *
+ * `importBlobModule` (src/handler/mf-dynamic-module-ops.ts) relies on two
+ * inline comments — `webpackIgnore: true` and `@vite-ignore` — to keep its
+ * `import()` native under webpack/rspack/rsbuild and Vite hosts (#504).
+ * Comments are the one part of the source a build step may legally drop:
+ * esbuild's `minify: true` strips them without a diagnostic, and nothing at
+ * runtime notices until an MFE fails to mount under a bundling host with
+ * `Cannot find module 'blob:…'`. Running the code cannot detect the pragma
+ * being stripped, so this script asserts its presence in the artifacts
+ * (same reasoning as scripts/verify-guard-configs.ts at the repo root).
+ *
+ * Wired into `npm run build` after tsup; fails the build if either pragma
+ * is missing from either format.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+const PRAGMAS = ['webpackIgnore: true', '@vite-ignore'];
+const FILES = ['index.js', 'index.cjs'];
+
+const failures = [];
+for (const file of FILES) {
+  const path = join(distDir, file);
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch {
+    failures.push(`${file}: missing (build did not produce it)`);
+    continue;
+  }
+  for (const pragma of PRAGMAS) {
+    if (!content.includes(pragma)) {
+      failures.push(`${file}: pragma "${pragma}" not found`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    'verify-dist-import-pragmas: the blob-import bundler pragmas did not survive the build:',
+  );
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  console.error(
+    'A bundling host will rewrite the dynamic import and MFE mount will fail (#504). Check tsup.config.ts for comment-stripping options (e.g. minify).',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `verify-dist-import-pragmas: OK (${PRAGMAS.join(', ')} present in ${FILES.join(', ')})`,
+);

--- a/packages/mfes/src/handler/mf-dynamic-module-ops.ts
+++ b/packages/mfes/src/handler/mf-dynamic-module-ops.ts
@@ -100,6 +100,19 @@ export function rewriteBareSpecifier(
  *      guard below makes that invariant executable so accidental call
  *      sites that pass a path or `http:`/`file:` URL fail fast rather than
  *      silently loading untrusted code.
+ *
+ *      **BUNDLER PRAGMAS — the two inline comments in the `import()` below
+ *      are load-bearing. Do not remove or reorder them.**
+ *      `webpackIgnore: true` tells webpack/rspack/rsbuild hosts, and
+ *      `@vite-ignore` tells Vite hosts, to leave this dynamic import native
+ *      instead of rewriting it into their chunk-loading runtime. A bundler
+ *      that rewrites it makes MFE mount fail at runtime under that host
+ *      with `Cannot find module 'blob:…'` (#504). The pragmas survive the
+ *      package's current tsup/esbuild build in both output formats, but
+ *      esbuild minification (`minify: true`) strips comments without a
+ *      diagnostic — so the build script runs
+ *      `scripts/verify-dist-import-pragmas.mjs`, which fails the build if
+ *      either pragma is missing from the published dist.
  * @inputs `blobUrl` — a `blob:` URL from `URL.createObjectURL(...)` or a
  *         `data:` URL from the same code path under test mocks.
  */
@@ -117,7 +130,7 @@ export async function importBlobModule(blobUrl: string): Promise<unknown> {
   // @cpt-end:cpt-frontx-algo-mfe-isolation-trust-kernel-import:p1:inst-inspect-scheme
   // @cpt-begin:cpt-frontx-algo-mfe-isolation-trust-kernel-import:p1:inst-exec-import
   // @cpt-begin:cpt-frontx-algo-mfe-isolation-trust-kernel-import:p1:inst-return-module
-  return await import(/* @vite-ignore */ blobUrl);
+  return await import(/* webpackIgnore: true */ /* @vite-ignore */ blobUrl);
   // @cpt-end:cpt-frontx-algo-mfe-isolation-trust-kernel-import:p1:inst-return-module
   // @cpt-end:cpt-frontx-algo-mfe-isolation-trust-kernel-import:p1:inst-exec-import
 }


### PR DESCRIPTION
## Summary
Fixes #504.

`importBlobModule` in `packages/mfes/src/handler/mf-dynamic-module-ops.ts` annotated its dynamic import only with `/* @vite-ignore */`. webpack does not honor that comment: it compiles `import(<variable>)` into a dynamic context module, the minted `blob:` URL is not in the context map, and webpack's runtime throws `Cannot find module 'blob:…'` at mount time — so no MFE can load under a webpack/rsbuild host. Adding `/* webpackIgnore: true */` alongside the existing Vite comment keeps the import native under every bundler.

This is the only dynamic import in the package, so one line covers all occurrences. The `__frontx_lazy` stub is emitted as a blob source string and never processed by the host bundler, so it needs no annotation.

## Verification
- `npm run build` in `packages/mfes`: the `webpackIgnore` comment survives tsup/esbuild into both `dist/index.js` and `dist/index.cjs` (esbuild preserves comments inside `import()` arguments).
- `npm run type-check`: clean.
- `npm test`: 10 files, 68 tests passed.
- Vite/Rolldown behavior unchanged — `@vite-ignore` remains in place.
- The webpack-host acceptance path (rsbuild-built adapter mounting an MFE end to end) was confirmed by the issue reporter with this exact patch applied to the installed copy; no webpack toolchain exists in this repo to automate it.

No FEATURE/ADR change needed: the covering instruction (`inst-exec-import` in `packages/mfes/architecture/features/mfe-isolation/FEATURE.md`) is bundler-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)