### PR TITLE
feat(policy): add version-bump-on-change CI gate (#575)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,12 @@ jobs:
       uses: actions/checkout@v5
       with:
         persist-credentials: false
+        # #575: policy:version-bump-on-change needs a merge base with the
+        # PR's target branch, and a shallow (depth-1) checkout has no history
+        # to compute one from. Full history costs little here — this repo is
+        # small — and matches the same choice already made in docs.yml and
+        # publish-packages.yml for the same reason.
+        fetch-depth: 0
 
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v5
@@ -122,6 +128,25 @@ jobs:
     # files directly, not the built CLI.
     - name: Check template ecosystem pin-drift
       run: npm run policy:template-pin-drift
+
+    # #575, follow-up from #574 review: #574 changed `@gears-frontx/react`'s
+    # public API and shipped with no version bump, and neither policy check
+    # above would have caught it — both are CONSISTENCY checks (does the
+    # semver line make sense, do pins match the disk), not CHANGE checks (did
+    # a package with substantive changes bump). This diffs the PR branch
+    # against its merge base with the target branch and fails for any
+    # governed package — every `packages/*` artifact, plus `template-shell`
+    # itself and every `template-shell/packages/*` member (any non-`private`
+    # `@gears-frontx`-scoped package; `template-mfe` and its fixture apps are
+    # `private` and exempt) — whose `src/` (or package.json dependencies)
+    # changed without its own `version` changing — comparing actual ref
+    # content rather than the diff, so a version bumped then reverted within
+    # the same PR still fails. Pull-request-only: the merge base it needs is
+    # the PR's base branch, which only exists as `GITHUB_BASE_REF` on
+    # `pull_request` events.
+    - name: Check version bump on substantive package change
+      if: github.event_name == 'pull_request'
+      run: npm run policy:version-bump-on-change
 
     # #524: `npm install` reconciling an out-of-sync template lockfile drops
     # the template's `file:.` self-link entry, writing a lockfile its own

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ The project is **pre-1.0** — backward compatibility is not guaranteed.
 - **Patch bump** (`0.1.0` → `0.1.1`) — non-breaking fixes/features
 - **Alpha increment** (`alpha.0` → `alpha.1`) — each merge to develop
 
+A PR that changes non-documentation source under `src/`, or the dependency fields of `package.json`, for a governed package (non-private `@gears-frontx`-scoped packages: `packages/*`, `template-shell`, and `template-shell/packages/*`) must bump that package's own `version` in the same PR — and update every exact pin on it (see `policy:template-pin-drift`). CI (`policy:version-bump-on-change`, pull requests only) compares the version at the PR's merge base against the version at its head, so a bump that is later reverted within the same PR does not count. Packages the PR itself adds or removes are exempt, as are private packages (e.g. the `template-mfe` fixture apps), which are pinned consumers rather than published sources.
+
 ## Publishing
 
 Publishing is automated via CI/CD. On push to a publishing branch, CI detects version changes and publishes affected packages.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:deps": "node scripts/check-test-dependency-versions.mjs",
     "lint": "npm run lint:deps && eslint . --max-warnings 0",
     "policy:version-check": "node scripts/ecosystem-version-policy.mjs",
+    "policy:version-bump-on-change": "node scripts/version-bump-on-change-check.mjs",
     "policy:template-pin-drift": "node scripts/template-pin-drift-check.mjs",
     "policy:template-lockfile-selflink": "node scripts/template-lockfile-selflink-check.mjs",
     "validate:templates": "node scripts/validate-templates.mjs",

--- a/scripts/template-ecosystem-packages.mjs
+++ b/scripts/template-ecosystem-packages.mjs
@@ -66,10 +66,15 @@
  * the string `@gears-frontx` is written down here.
  *
  * Consumers: `template-pin-drift-check.mjs` (compares every pin site against
- * the truth map) and `link-template-ecosystem.mjs` (repoints exactly the
+ * the truth map); `link-template-ecosystem.mjs` (repoints exactly the
  * `packages/*` directories the template pins at their local builds - template
  * contributions never enter that linker, since a template's own workspace
- * member already resolves locally with nothing published to shadow it).
+ * member already resolves locally with nothing published to shadow it); and
+ * `version-bump-on-change-check.mjs` (reuses `readTemplateEcosystemPackages`
+ * directly, on top of the same `packages/*` walk, to enumerate the package
+ * ROOTS its CI gate governs - narrowed further there to the non-`private`
+ * ones, since a template's own scope-qualified fixture apps are pinned
+ * consumers rather than publishable sources).
  */
 import fs from 'node:fs';
 import path from 'node:path';

--- a/scripts/version-bump-on-change-check.mjs
+++ b/scripts/version-bump-on-change-check.mjs
@@ -1,0 +1,506 @@
+/**
+ * Version-Bump-On-Change CI Gate (#575, follow-up from #574 review).
+ *
+ * #574 changed `@gears-frontx/react`'s public API and shipped with no version
+ * bump, and nothing caught it. The two existing `policy:*` guards could not
+ * have caught it either, because both are CONSISTENCY checks, not CHANGE
+ * checks: `policy:version-check` validates the ecosystem packages' semver
+ * lines and the mfes->gts-plugin coupling edge in isolation, and
+ * `policy:template-pin-drift` verifies a pinned dependency range matches
+ * whatever version is on disk RIGHT NOW. A PR that edits `src/` and bumps
+ * nothing passes both: the pins still "match" the stale version, and the
+ * semver line is still internally consistent - just unchanged.
+ *
+ * This guard asks the one question neither of those does: did a package with
+ * substantive changes in this PR ALSO change its own `version`? It diffs the
+ * PR branch against the merge base with its target branch, groups the changed
+ * files by owning package directory, and fails for any package whose
+ * substantive changes were not accompanied by a version bump.
+ *
+ * ## Which directories are "a package" here
+ *
+ * A governed package is any non-`private` package whose own name is in the
+ * ecosystem's npm scope (`@gears-frontx/*`), discovered by REUSING
+ * `template-ecosystem-packages.mjs`'s existing structural discovery
+ * (`readEcosystemPackages` for `packages/*`, `readTemplateEcosystemPackages`
+ * for every template's own root identity AND every one of its workspace
+ * members - see that module's docblock for why re-deriving either walk here
+ * would be the duplicated-knowledge bug its own predecessor was rewritten to
+ * remove) rather than a second, narrower copy of it. Concretely, today:
+ *
+ *  - every `packages/*` directory (this repo's own published ecosystem
+ *    artifacts);
+ *  - `template-shell` ITSELF (`@gears-frontx/frontx-template-shell`) - it
+ *    publishes `dist-lib`, built from its own `src/`, and is exact-pinned by
+ *    four `template-mfe` fixture manifests, exactly the #574 shape this gate
+ *    exists for;
+ *  - every `template-shell/packages/*` workspace member (react, auth,
+ *    framework, i18n, state, studio - ADR-0033 relocated `@gears-frontx/react`'s
+ *    source there, and #574 is the concrete case that skipped a bump).
+ *
+ * `template-mfe` and its four `src-app/mfe_packages/*` fixture apps
+ * (`@gears-frontx/demo-mfe` and friends) ARE in the ecosystem's npm scope -
+ * scope alone does not exclude them - but every one of them declares
+ * `private: true`, and it is exactly that per-package fact, not a heuristic
+ * on `template-mfe`'s own (unscoped) root manifest, that excludes them here:
+ * they pin these packages' PUBLISHED versions rather than being one of them,
+ * and are covered once the source package bumps by
+ * `policy:template-pin-drift`, not by this gate. The same `private: true`
+ * check is what would exempt a future `template-shell/src-app/mfe_packages/*`
+ * member too, should that workspace pattern ever gain one.
+ *
+ * ## What counts as a substantive change
+ *
+ * Per file, relative to its package root:
+ *  - anything under `src/` (excluding a pure-docs file - `*.md` or
+ *    `llms.txt` - even one that happens to live inside `src/`);
+ *  - `package.json` ITSELF, but only when a dependency field
+ *    (`dependencies`/`devDependencies`/`peerDependencies`/
+ *    `optionalDependencies`) actually changed between the merge base and
+ *    HEAD - not merely appearing in the diff (a version-only edit, a
+ *    `scripts` tweak, must not itself force a second bump).
+ *
+ * Everything else - README changes, build config, a `package.json` edit that
+ * touches no dependency field - is out of scope for this gate by
+ * construction: it is simply never classified as substantive. This repo
+ * colocates tests under `src/` (e.g. `src/tokens.test.ts`), so the issue's
+ * open question about test-only changes resolves to "still substantive"
+ * here: a change to only `packages/ui-kit/src/tokens.test.ts` DOES force a
+ * bump, same as any other `src/` file - deliberately, since `src/` is the
+ * one signal this gate trusts, not a second classification of what's
+ * "inside" it.
+ *
+ * ## Why the comparison is merge-base-to-HEAD content, not "did the diff touch
+ * version"
+ *
+ * `versionAt(ref, packageRoot)` reads the actual `package.json` blob at a ref
+ * and pulls `version` out of it - it does not inspect the diff hunk. That is
+ * what makes a bump-then-revert within one PR still fail: if `version` is
+ * edited in an early commit and reverted in a later one, `git diff --name-only`
+ * may not even list `package.json` as changed at the merge base once the
+ * revert lands, and the two blobs compared here are IDENTICAL - so if `src/`
+ * also changed in that PR (a separate file), the substantive check still
+ * trips and the version comparison still correctly reports "unchanged".
+ * Comparing anything other than the two endpoints' actual content would miss
+ * that case.
+ *
+ * A package with no `package.json` at the merge base (introduced by this PR)
+ * is skipped rather than failed: a brand-new package has no prior version to
+ * have bumped FROM. Likewise a package whose `package.json` no longer exists
+ * at HEAD (removed by this PR) is skipped - there is no version left to check.
+ *
+ * CLI entry: `node scripts/version-bump-on-change-check.mjs [--base-ref <ref>]`
+ * (exit 0 on success). `--base-ref` defaults to `VERSION_BUMP_BASE_REF`, then
+ * `origin/${GITHUB_BASE_REF}` (set by GitHub Actions on `pull_request`
+ * events), then `origin/develop`. Core logic is exported for unit tests in
+ * `scripts/version-bump-on-change-check.test.mjs`.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import {
+  DEPENDENCY_FIELDS,
+  ecosystemScopeMatcher,
+  readEcosystemPackages,
+  readPackageManifest,
+  readTemplateEcosystemPackages,
+} from './template-ecosystem-packages.mjs';
+
+/**
+ * @typedef {{
+ *   mergeBase: (baseRef: string) => string;
+ *   listChangedFiles: (mergeBaseSha: string) => string[];
+ *   readTextAtRef: (ref: string, filePath: string) => string | null;
+ * }} GitReader
+ */
+
+/** A pure-docs file never counts as a substantive change, even under `src/`. */
+const DOCS_ONLY_EXTENSIONS = new Set(['.md']);
+const DOCS_ONLY_BASENAMES = new Set(['llms.txt']);
+
+/**
+ * @param {string} filePath repo-root-relative, posix-separated
+ * @returns {boolean}
+ */
+export function isDocsOnlyPath(filePath) {
+  return DOCS_ONLY_EXTENSIONS.has(path.posix.extname(filePath)) || DOCS_ONLY_BASENAMES.has(path.posix.basename(filePath));
+}
+
+/**
+ * Whether the package rooted at `dir` (repo-root-relative) declares
+ * `private: true` in its own manifest - the per-package fact this gate
+ * exempts on, rather than any heuristic about its parent template (see
+ * module docblock). A directory with no manifest at all governs nothing
+ * either, though every `dir` passed in here comes from
+ * `readEcosystemPackages`/`readTemplateEcosystemPackages`, both of which
+ * already guarantee the manifest they named exists and parses.
+ *
+ * @param {string} rootDir monorepo root
+ * @param {string} dir repo-root-relative
+ * @returns {boolean}
+ */
+function isPrivatePackage(rootDir, dir) {
+  const manifestPath = path.join(rootDir, dir, 'package.json');
+  if (!fs.existsSync(manifestPath)) return true;
+  return readPackageManifest(manifestPath)['private'] === true;
+}
+
+/**
+ * Every package root this gate governs, repo-root-relative and posix-joined
+ * (`packages/api`, `template-shell`, `template-shell/packages/react`, ...).
+ * See the module docblock for what qualifies and why.
+ *
+ * @param {string} rootDir monorepo root
+ * @returns {string[]} sorted
+ */
+export function discoverPackageRoots(rootDir) {
+  const ecosystem = readEcosystemPackages(rootDir);
+  const isEcosystemScopeName = ecosystemScopeMatcher(ecosystem.map(({ name }) => name));
+
+  /** @type {string[]} */
+  const candidateDirs = [
+    ...ecosystem.map(({ dir }) => `packages/${dir}`),
+    ...readTemplateEcosystemPackages(rootDir, isEcosystemScopeName).map(({ dir }) => dir),
+  ];
+
+  return candidateDirs
+    .filter((dir) => !isPrivatePackage(rootDir, dir))
+    .map((dir) => dir.split(path.sep).join('/'))
+    .sort();
+}
+
+/**
+ * Groups changed files under whichever package root owns them, picking the
+ * LONGEST matching root when more than one is a prefix - e.g.
+ * `template-shell/packages/react/src/x.ts` must attribute to
+ * `template-shell/packages/react`, not to the also-matching parent
+ * `template-shell`, now that both are governed roots (a nested-root
+ * scenario this gate did not have to consider until `template-shell` itself
+ * became one). A file that matches no root (repo tooling, docs at the repo
+ * root, an excluded private fixture tree) is silently dropped - this gate
+ * has nothing to say about it.
+ *
+ * @param {string[]} changedFiles repo-root-relative, posix-separated
+ * @param {string[]} packageRoots from `discoverPackageRoots`
+ * @returns {Map<string, string[]>}
+ */
+export function groupChangedFilesByPackageRoot(changedFiles, packageRoots) {
+  /** @type {Map<string, string[]>} */
+  const grouped = new Map();
+  for (const file of changedFiles) {
+    /** @type {string | undefined} */
+    let bestRoot;
+    for (const candidate of packageRoots) {
+      if (!file.startsWith(`${candidate}/`)) continue;
+      if (bestRoot === undefined || candidate.length > bestRoot.length) bestRoot = candidate;
+    }
+    if (bestRoot === undefined) continue;
+    const bucket = grouped.get(bestRoot);
+    if (bucket) bucket.push(file);
+    else grouped.set(bestRoot, [file]);
+  }
+  return grouped;
+}
+
+/**
+ * @param {unknown} manifest
+ * @returns {Record<string, unknown>}
+ */
+function dependencyFieldsOf(manifest) {
+  /** @type {Record<string, unknown>} */
+  const result = {};
+  if (typeof manifest !== 'object' || manifest === null) return result;
+  for (const field of DEPENDENCY_FIELDS) {
+    const value = /** @type {Record<string, unknown>} */ (manifest)[field];
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue;
+    // Entries sorted by key so the stringify comparison below is key-order
+    // insensitive: `sort-package-json`, `npm pkg fix` and npm itself all
+    // reorder dependency entries without changing their meaning, and a
+    // reorder must not read as a dependency change.
+    result[field] = Object.fromEntries(Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  }
+  return result;
+}
+
+/**
+ * Whether a package.json's dependency declarations differ between two
+ * already-parsed manifests. A `version`, `scripts`, or any other field
+ * changing is NOT what this asks - only the four dependency fields
+ * (`DEPENDENCY_FIELDS`), because a bare version-only edit must never force a
+ * second bump of itself.
+ *
+ * @param {unknown} baseManifest
+ * @param {unknown} headManifest
+ * @returns {boolean}
+ */
+export function dependencyFieldsChanged(baseManifest, headManifest) {
+  return JSON.stringify(dependencyFieldsOf(baseManifest)) !== JSON.stringify(dependencyFieldsOf(headManifest));
+}
+
+/**
+ * @param {string} raw
+ * @param {string} describedPath used only in the thrown message
+ * @returns {unknown}
+ */
+function parseManifestText(raw, describedPath) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`cannot parse ${describedPath} as JSON (${error instanceof Error ? error.message : String(error)}).`);
+  }
+}
+
+/**
+ * Whether ANY file changed under `packageRoot` is a substantive change, per
+ * the rules in the module docblock. Stops at the first match - the exact
+ * classification of every OTHER file is not needed once one substantive file
+ * is found.
+ *
+ * @param {string} packageRoot
+ * @param {string[]} filesInRoot repo-root-relative, posix-separated, already
+ *   filtered to this root
+ * @param {string} baseRef the merge-base sha (or any ref `readTextAtRef`
+ *   accepts) to diff against
+ * @param {GitReader} git
+ * @returns {boolean}
+ */
+export function hasSubstantiveChange(packageRoot, filesInRoot, baseRef, git) {
+  const srcPrefix = `${packageRoot}/src/`;
+  const manifestPath = `${packageRoot}/package.json`;
+
+  for (const file of filesInRoot) {
+    if (file.startsWith(srcPrefix)) {
+      if (!isDocsOnlyPath(file)) return true;
+      continue;
+    }
+    if (file === manifestPath) {
+      const baseRaw = git.readTextAtRef(baseRef, manifestPath);
+      const headRaw = git.readTextAtRef('HEAD', manifestPath);
+      const baseManifest = baseRaw === null ? {} : parseManifestText(baseRaw, `${manifestPath} @ ${baseRef}`);
+      const headManifest = headRaw === null ? {} : parseManifestText(headRaw, `${manifestPath} @ HEAD`);
+      if (dependencyFieldsChanged(baseManifest, headManifest)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The `version` field of `<packageRoot>/package.json` as it reads AT `ref`,
+ * read directly from that ref's blob rather than from a diff - see the
+ * module docblock for why that is what makes bump-then-revert fail.
+ *
+ * @param {string} ref
+ * @param {string} packageRoot
+ * @param {GitReader} git
+ * @returns {string | null} `null` when the manifest does not exist at `ref`,
+ *   or declares no valid `version`
+ */
+export function versionAt(ref, packageRoot, git) {
+  const manifestPath = `${packageRoot}/package.json`;
+  const raw = git.readTextAtRef(ref, manifestPath);
+  if (raw === null) return null;
+  const manifest = parseManifestText(raw, `${manifestPath} @ ${ref}`);
+  if (typeof manifest !== 'object' || manifest === null) return null;
+  const version = /** @type {Record<string, unknown>} */ (manifest)['version'];
+  return typeof version === 'string' && version.trim() !== '' ? version : null;
+}
+
+/**
+ * @typedef {{ packageRoot: string; version: string; files: string[] }} UnbumpedPackage
+ */
+
+/**
+ * @param {{
+ *   rootDir: string;
+ *   baseRef: string;
+ *   git: GitReader;
+ *   log: (line: string) => void;
+ *   logError: (line: string) => void;
+ * }} context
+ * @returns {number}
+ */
+function check({ rootDir, baseRef, git, log, logError }) {
+  /** @type {string} */
+  let mergeBaseSha;
+  try {
+    mergeBaseSha = git.mergeBase(baseRef);
+  } catch (error) {
+    logError(
+      `[version-bump-on-change-check] FAIL: cannot resolve a merge base with "${baseRef}" ` +
+        `(${error instanceof Error ? error.message : String(error)}). The checkout needs enough history to ` +
+        `reach it - fetch the base branch (or check out with full history) before running this check.`,
+    );
+    return 1;
+  }
+
+  const packageRoots = discoverPackageRoots(rootDir);
+  // Zero discovered roots is never a silent pass (same rule as
+  // `template-pin-drift-check.mjs`): this repo always has governed packages,
+  // so an empty result means discovery is broken - and a broken discovery
+  // would otherwise report success in exactly the same voice as a real one.
+  if (packageRoots.length === 0) {
+    logError(
+      `[version-bump-on-change-check] FAIL: discovered no governed packages under ${rootDir} - discovery is ` +
+        `broken (this repo always has at least packages/*), so this gate cannot vouch for anything.`,
+    );
+    return 1;
+  }
+  const changedFiles = git.listChangedFiles(mergeBaseSha);
+  const grouped = groupChangedFilesByPackageRoot(changedFiles, packageRoots);
+
+  /** @type {UnbumpedPackage[]} */
+  const unbumped = [];
+  let substantiveCount = 0;
+
+  for (const [packageRoot, files] of grouped) {
+    if (!hasSubstantiveChange(packageRoot, files, mergeBaseSha, git)) continue;
+    substantiveCount += 1;
+
+    const baseVersion = versionAt(mergeBaseSha, packageRoot, git);
+    // No version at the merge base: this PR introduced the package itself -
+    // there is no prior version it could have bumped FROM.
+    if (baseVersion === null) continue;
+
+    const headVersion = versionAt('HEAD', packageRoot, git);
+    // No version at HEAD: this PR removed the package - nothing left to bump.
+    if (headVersion === null) continue;
+
+    if (baseVersion === headVersion) unbumped.push({ packageRoot, version: headVersion, files });
+  }
+
+  if (unbumped.length > 0) {
+    logError(
+      `[version-bump-on-change-check] FAIL: ${unbumped.length} package(s) have substantive changes but no ` +
+        `version bump:`,
+    );
+    for (const { packageRoot, version, files } of unbumped) {
+      logError(`  ${packageRoot} is still at ${version} despite substantive changes:`);
+      for (const file of files) logError(`    ${file}`);
+    }
+    logError(
+      `\nBump the "version" in each package's package.json above (and any exact pin on it elsewhere - see ` +
+        '`npm run policy:template-pin-drift`), then rerun `npm run policy:version-bump-on-change` to confirm.',
+    );
+    return 1;
+  }
+
+  log(
+    substantiveCount === 0
+      ? `Version-bump-on-change check passed: none of ${packageRoots.length} governed package(s) had ` +
+          `substantive changes since ${baseRef} (merge base ${mergeBaseSha}).`
+      : `Version-bump-on-change check passed: every one of ${substantiveCount} package(s) with substantive ` +
+          `changes since ${baseRef} (merge base ${mergeBaseSha}) also bumped its version.`,
+  );
+  return 0;
+}
+
+/**
+ * @param {string} rootDir
+ * @returns {GitReader}
+ */
+function realGitReader(rootDir) {
+  // stderr piped rather than inherited (execFileSync's default) for every git
+  // invocation here, not only `readTextAtRef`'s: a resolvable-but-noisy
+  // command (this repo's own CI has none today, but a caller passing an
+  // unresolvable `--base-ref` does) must not spill git's own "fatal: ..."
+  // line into an otherwise-passing run's output. `error.message` on a thrown
+  // failure still carries the piped stderr - Node appends a captured
+  // stdio[2] to the Error it throws - so the caller-facing message in
+  // `check()` loses nothing.
+  /** @param {string[]} args */
+  const run = (args) => execFileSync('git', args, { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return {
+    mergeBase(baseRef) {
+      return run(['merge-base', baseRef, 'HEAD']).trim();
+    },
+    listChangedFiles(mergeBaseSha) {
+      // --no-renames: rename detection would list only the destination path,
+      // so a file moved from one package to another would never name the
+      // package that LOST it (nor a move out of src/ within one package).
+      // Listing both sides asks both packages to bump.
+      return run(['diff', '--name-only', '--no-renames', `${mergeBaseSha}..HEAD`])
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    },
+    readTextAtRef(ref, filePath) {
+      try {
+        // git show's path separator is always `/`, matching the posix-joined
+        // paths this module works in throughout, regardless of host OS.
+        // stdio for stderr is piped (not inherited) so the very common
+        // "path exists on disk, but not in <ref>" case - a brand-new or
+        // removed package, handled deliberately below - never spams a
+        // passing CI run's log.
+        return execFileSync('git', ['show', `${ref}:${filePath}`], { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      } catch {
+        // Cannot distinguish "file does not exist at this ref" from "some
+        // other git failure" without parsing stderr, and every caller here
+        // treats both the same way: no content to compare, not a hard abort.
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * @param {string[]} argv `process.argv.slice(2)`
+ * @returns {string | undefined}
+ */
+function baseRefFromArgv(argv) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--base-ref') return argv[i + 1];
+    if (arg.startsWith('--base-ref=')) return arg.slice('--base-ref='.length);
+  }
+  return undefined;
+}
+
+/**
+ * CI entry point. Wired into `npm run policy:version-bump-on-change` and
+ * `.github/workflows/main.yml`.
+ *
+ * @param {{
+ *   rootDir?: string;
+ *   baseRef?: string;
+ *   git?: GitReader;
+ *   argv?: string[];
+ *   env?: Record<string, string | undefined>;
+ *   log?: (line: string) => void;
+ *   logError?: (line: string) => void;
+ * }} [options]
+ * @returns {number} 0 on success, 1 on failure.
+ */
+export function runCli(options = {}) {
+  const rootDir = options.rootDir ?? process.cwd();
+  const log = options.log ?? console.log;
+  const logError = options.logError ?? console.error;
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv.slice(2);
+
+  const baseRef =
+    options.baseRef ??
+    baseRefFromArgv(argv) ??
+    env.VERSION_BUMP_BASE_REF ??
+    (env.GITHUB_BASE_REF ? `origin/${env.GITHUB_BASE_REF}` : undefined) ??
+    'origin/develop';
+
+  const git = options.git ?? realGitReader(rootDir);
+
+  try {
+    return check({ rootDir, baseRef, git, log, logError });
+  } catch (error) {
+    logError(`[version-bump-on-change-check] FAIL: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+const isEntryPoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntryPoint) {
+  // `process.exitCode` rather than `process.exit()`: the latter can truncate a
+  // still-flushing stdout/stderr write, which for a guard means losing the very
+  // lines that say what failed.
+  process.exitCode = runCli();
+}

--- a/scripts/version-bump-on-change-check.test.mjs
+++ b/scripts/version-bump-on-change-check.test.mjs
@@ -1,0 +1,486 @@
+// @cpt-dod:cpt-frontx-dod-unit-test-generation-and-agent-verification-standard-test-convention:p1
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  dependencyFieldsChanged,
+  discoverPackageRoots,
+  groupChangedFilesByPackageRoot,
+  isDocsOnlyPath,
+  runCli,
+} from './version-bump-on-change-check.mjs';
+
+/** @type {string | undefined} */
+let rootDir;
+
+afterEach(async () => {
+  if (rootDir) await rm(rootDir, { recursive: true, force: true });
+});
+
+/**
+ * @param {string} filePath
+ * @param {unknown} value
+ */
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(value, null, 2));
+}
+
+/**
+ * @param {string} dir
+ * @param {string[]} args
+ */
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+
+/** Builds a fresh git repo with one commit on `develop` carrying the given files. */
+async function makeRepo() {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'frontx-version-bump-'));
+  git(rootDir, ['init', '-q', '-b', 'develop']);
+  git(rootDir, ['config', 'user.email', 'test@example.com']);
+  git(rootDir, ['config', 'user.name', 'Test']);
+  return rootDir;
+}
+
+/**
+ * @param {string} root
+ * @param {string} message
+ */
+function commitAll(root, message) {
+  git(root, ['add', '-A']);
+  git(root, ['commit', '-q', '-m', message]);
+}
+
+/**
+ * Baseline fixture: two ecosystem packages and one template-shell package,
+ * matching this repo's real shape closely enough for `discoverPackageRoots`
+ * to exercise both groups.
+ * @param {string} root
+ */
+async function writeBaselineFixture(root) {
+  await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+    name: '@gears-frontx/api',
+    version: '0.3.0-alpha.0',
+  });
+  await writeJson(path.join(root, 'packages', 'api', 'src', 'index.js'), 'export const x = 1;\n');
+  await writeJson(path.join(root, 'packages', 'mfes', 'package.json'), {
+    name: '@gears-frontx/mfes',
+    version: '0.3.0-alpha.0',
+  });
+  await writeJson(path.join(root, 'template-shell', 'frontx-template.json'), {});
+  await writeJson(path.join(root, 'template-shell', 'package.json'), {
+    name: '@gears-frontx/frontx-template-shell',
+    version: '0.1.0-alpha.1',
+    workspaces: ['packages/*'],
+  });
+  await writeJson(path.join(root, 'template-shell', 'src', 'entry.ts'), 'export {};\n');
+  await writeJson(path.join(root, 'template-shell', 'packages', 'react', 'package.json'), {
+    name: '@gears-frontx/react',
+    version: '0.2.0-alpha.3',
+  });
+  await writeJson(path.join(root, 'template-mfe', 'frontx-template.json'), {});
+  await writeJson(path.join(root, 'template-mfe', 'package.json'), {
+    name: 'frontx-template-mfe-monorepo-harness',
+    private: true,
+    workspaces: ['src-app/mfe_packages/*'],
+  });
+  await writeJson(path.join(root, 'template-mfe', 'src-app', 'mfe_packages', 'demo-mfe', 'package.json'), {
+    name: '@gears-frontx/demo-mfe',
+    private: true,
+    version: '0.1.0-alpha.0',
+    dependencies: { '@gears-frontx/react': '0.2.0-alpha.3' },
+  });
+}
+
+describe('isDocsOnlyPath', () => {
+  it('flags a markdown file', () => {
+    expect(isDocsOnlyPath('packages/api/src/README.md')).toBe(true);
+  });
+
+  it('flags llms.txt regardless of directory', () => {
+    expect(isDocsOnlyPath('packages/api/llms.txt')).toBe(true);
+  });
+
+  it('does not flag a source file', () => {
+    expect(isDocsOnlyPath('packages/api/src/index.ts')).toBe(false);
+  });
+});
+
+describe('discoverPackageRoots', () => {
+  it('finds every packages/* directory plus template-shell itself and template-shell/packages/*, excluding template-mfe and its private fixtures entirely', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+
+    expect(discoverPackageRoots(root)).toEqual([
+      'packages/api',
+      'packages/mfes',
+      'template-shell',
+      'template-shell/packages/react',
+    ]);
+  });
+
+  // The scope check alone would NOT exclude a template-mfe fixture (its name
+  // IS in the @gears-frontx scope) - only its own `private: true` does. This
+  // proves the exemption is the per-package fact, not a heuristic on
+  // template-mfe's (unscoped) root manifest.
+  it('excludes a scope-qualified fixture package specifically because it is private, not because its template root is unscoped', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+
+    const roots = discoverPackageRoots(root);
+    expect(roots).not.toContain('template-mfe/src-app/mfe_packages/demo-mfe');
+  });
+});
+
+describe('groupChangedFilesByPackageRoot', () => {
+  it('buckets each changed file under the package root that owns it, dropping files that match no root', () => {
+    const roots = ['packages/api', 'template-shell/packages/react'];
+    const files = [
+      'packages/api/src/index.js',
+      'packages/api/package.json',
+      'template-shell/packages/react/src/hooks.ts',
+      'README.md',
+      'template-shell/package.json',
+    ];
+
+    const grouped = groupChangedFilesByPackageRoot(files, roots);
+
+    expect(grouped.get('packages/api')).toEqual(['packages/api/src/index.js', 'packages/api/package.json']);
+    expect(grouped.get('template-shell/packages/react')).toEqual(['template-shell/packages/react/src/hooks.ts']);
+    expect(grouped.size).toBe(2);
+  });
+
+  // The nesting scenario change #1 introduces: template-shell is now ALSO a
+  // governed root, so a file under its packages/react subdirectory matches
+  // BOTH `template-shell/` and `template-shell/packages/react/` as prefixes.
+  // The longer (more specific) root must win.
+  it('attributes a nested file to the longer (more specific) root, not the also-matching parent', () => {
+    const roots = ['template-shell', 'template-shell/packages/react'];
+    const files = ['template-shell/packages/react/src/hooks.ts', 'template-shell/src/index.ts'];
+
+    const grouped = groupChangedFilesByPackageRoot(files, roots);
+
+    expect(grouped.get('template-shell/packages/react')).toEqual(['template-shell/packages/react/src/hooks.ts']);
+    expect(grouped.get('template-shell')).toEqual(['template-shell/src/index.ts']);
+  });
+});
+
+describe('dependencyFieldsChanged', () => {
+  it('flags an added dependency', () => {
+    expect(
+      dependencyFieldsChanged({ dependencies: {} }, { dependencies: { '@gears-frontx/mfes': '0.3.0-alpha.0' } }),
+    ).toBe(true);
+  });
+
+  it('does not flag a version-only edit', () => {
+    expect(dependencyFieldsChanged({ version: '0.1.0' }, { version: '0.2.0' })).toBe(false);
+  });
+
+  it('does not flag identical dependency sets', () => {
+    const deps = { dependencies: { '@gears-frontx/mfes': '0.3.0-alpha.0' } };
+    expect(dependencyFieldsChanged(deps, { ...deps })).toBe(false);
+  });
+
+  // sort-package-json, `npm pkg fix` and npm itself all reorder dependency
+  // entries without changing their meaning - a pure reorder must not read as
+  // a dependency change. Built from JSON text (not object spread) so the two
+  // manifests genuinely carry different key orders.
+  it('does not flag a pure reorder of dependency entries', () => {
+    const base = JSON.parse('{"dependencies": {"b": "1.0.0", "a": "2.0.0"}}');
+    const head = JSON.parse('{"dependencies": {"a": "2.0.0", "b": "1.0.0"}}');
+    expect(dependencyFieldsChanged(base, head)).toBe(false);
+  });
+});
+
+describe('hasSubstantiveChange + versionAt (via runCli)', () => {
+  it('passes when nothing changed at all', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    // No changes on the feature branch - an empty commit still exercises the
+    // merge-base -> HEAD diff path with a genuinely empty changed-file set.
+    git(root, ['commit', '-q', '--allow-empty', '-m', 'empty']);
+
+    const { exitCode } = run(root);
+    expect(exitCode).toBe(0);
+  });
+
+  it('fails when a package\'s src/ changed but its version did not', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'src', 'index.js'), 'export const x = 2;\n');
+    commitAll(root, 'change api src without bump');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('packages/api');
+  });
+
+  it('passes when a package\'s src/ changed and its version was bumped', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'src', 'index.js'), 'export const x = 2;\n');
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.1',
+    });
+    commitAll(root, 'change api src with bump');
+
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  // The #574 scenario this gate exists to catch: template-shell/packages/react
+  // is exactly where an ADR-0033-relocated package's source lives.
+  it('fails when template-shell/packages/react changes without a bump, the #574 scenario', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'template-shell', 'packages', 'react', 'src', 'index.ts'), 'export {};\n');
+    commitAll(root, 'change react src without bump');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('template-shell/packages/react');
+  });
+
+  // Change #1: template-shell itself is now governed (it publishes dist-lib
+  // built from its own src/, and is exact-pinned by template-mfe fixtures -
+  // the same #574 shape as its packages/react member).
+  it('fails when template-shell\'s own src/ changes without a bump to template-shell\'s own version', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'template-shell', 'src', 'entry.ts'), 'export const y = 1;\n');
+    commitAll(root, 'change template-shell src without bump');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('template-shell is still at');
+  });
+
+  // The nesting scenario change #1 introduces at the integration level: a
+  // change confined to template-shell/packages/react/src must attribute (and
+  // demand a bump) at that package, never at the also-matching parent
+  // template-shell - the longest-prefix fix in `groupChangedFilesByPackageRoot`
+  // is what this end-to-end test guards.
+  it('attributes a template-shell/packages/react-only change to that package, not to the parent template-shell', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'template-shell', 'packages', 'react', 'src', 'index.ts'), 'export {};\n');
+    await writeJson(path.join(root, 'template-shell', 'packages', 'react', 'package.json'), {
+      name: '@gears-frontx/react',
+      version: '0.2.0-alpha.4',
+    });
+    commitAll(root, 'change and bump react only');
+
+    // react bumped, template-shell itself untouched and unchanged - must pass,
+    // proving the change was never also attributed to (and demanded a bump
+    // from) the parent template-shell root.
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  it('ignores a change inside a template-mfe fixture package entirely - pinned consumers, not this gate\'s concern', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(
+      path.join(root, 'template-mfe', 'src-app', 'mfe_packages', 'demo-mfe', 'src', 'App.tsx'),
+      'export {};\n',
+    );
+    commitAll(root, 'change mfe fixture');
+
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  it('ignores a docs-only change under src/', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'src', 'README.md'), '# notes\n');
+    commitAll(root, 'docs-only under src');
+
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  it('fails when a dependency was added to package.json without a version bump, even with src/ untouched', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.0',
+      dependencies: { '@gears-frontx/mfes': '0.3.0-alpha.0' },
+    });
+    commitAll(root, 'add dependency without bump');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('packages/api');
+  });
+
+  it('does not fail on a package.json change that touches only scripts, not dependencies', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.0',
+      scripts: { build: 'tsc' },
+    });
+    commitAll(root, 'add a script, no dependency change');
+
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  it('skips a brand-new package entirely - nothing to have bumped FROM', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'telemetry', 'package.json'), {
+      name: '@gears-frontx/telemetry',
+      version: '0.1.0-alpha.0',
+    });
+    await writeJson(path.join(root, 'packages', 'telemetry', 'src', 'index.js'), 'export {};\n');
+    commitAll(root, 'introduce a new package');
+
+    expect(run(root).exitCode).toBe(0);
+  });
+
+  // The bump-then-revert case the issue calls out by name: an intermediate
+  // commit bumps the version, a later commit on the SAME branch reverts it -
+  // net diff at HEAD shows the original version again, so this must still fail.
+  it('fails when a version bump is reverted later in the same PR (bump-then-revert)', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'src', 'index.js'), 'export const x = 2;\n');
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.1',
+    });
+    commitAll(root, 'change src and bump');
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.0',
+    });
+    commitAll(root, 'revert the bump');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('packages/api');
+  });
+
+  // Rename detection would list only the destination path, so the package
+  // that LOST the file would never be asked to bump - `--no-renames` makes
+  // git print both sides. The file is moved verbatim (100% similarity) so
+  // git's rename detection, on by default, would otherwise collapse it.
+  it('demands a bump from BOTH packages when a file moves from one to the other unchanged', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await mkdir(path.join(root, 'packages', 'mfes', 'src'), { recursive: true });
+    git(root, ['mv', 'packages/api/src/index.js', 'packages/mfes/src/index.js']);
+    commitAll(root, 'move a module from api to mfes, no bumps');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('packages/api is still at');
+    expect(output).toContain('packages/mfes is still at');
+  });
+
+  // Zero discovered roots is never a silent pass: an empty discovery means
+  // the gate is broken, and "0 governed packages, all fine" is exactly what
+  // a real pass would also print. Same rule as template-pin-drift-check.
+  it('fails when discovery finds no governed packages at all', async () => {
+    const root = await makeRepo();
+    await writeFile(path.join(root, 'notes.txt'), 'no packages here\n');
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeFile(path.join(root, 'notes.txt'), 'still no packages\n');
+    commitAll(root, 'change something');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(1);
+    expect(output).toContain('no governed packages');
+  });
+
+  // The success line must report a measured count: a PR touching nothing
+  // substantive must not claim every governed package "had substantive
+  // changes and bumped".
+  it('reports zero substantive packages, not the full governed count, when nothing substantive changed', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeFile(path.join(root, 'README.md'), '# repo\n');
+    commitAll(root, 'root docs only');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('none of 4 governed package(s) had substantive changes');
+  });
+
+  it('counts only the packages with substantive changes in the success line', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    await writeJson(path.join(root, 'packages', 'api', 'src', 'index.js'), 'export const x = 2;\n');
+    await writeJson(path.join(root, 'packages', 'api', 'package.json'), {
+      name: '@gears-frontx/api',
+      version: '0.3.0-alpha.1',
+    });
+    commitAll(root, 'change and bump api only');
+
+    const { exitCode, output } = run(root);
+    expect(exitCode).toBe(0);
+    expect(output).toContain('every one of 1 package(s) with substantive changes');
+  });
+
+  it('fails loudly, naming the base ref, when the merge base cannot be resolved', async () => {
+    const root = await makeRepo();
+    await writeBaselineFixture(root);
+    commitAll(root, 'base');
+
+    /** @type {string[]} */
+    const lines = [];
+    const exitCode = runCli({
+      rootDir: root,
+      baseRef: 'origin/does-not-exist',
+      log: () => {},
+      logError: (line) => lines.push(line),
+    });
+    expect(exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('origin/does-not-exist');
+  });
+});
+
+/** Runs the guard against a real repo with its output captured. */
+/** @param {string} root */
+function run(root) {
+  /** @type {string[]} */
+  const lines = [];
+  /** @param {string} line */
+  const record = (line) => lines.push(line);
+  const exitCode = runCli({ rootDir: root, baseRef: 'develop', log: record, logError: record });
+  return { exitCode, output: lines.join('\n') };
+}


### PR DESCRIPTION
Closes #575.

Adds a `policy:version-bump-on-change` CI gate that fails a PR when a governed package has substantive changes without a version bump — the change-check counterpart to the existing consistency checks (`policy:version-check`, `policy:template-pin-drift`), which pass a stale version as long as pins still match it (#574).

## What's in here

- `scripts/version-bump-on-change-check.mjs` — the gate, following the pin-drift script pattern (plain `policy:*` script per ADR-0001; no changesets/lerna/semantic-release)
- `scripts/version-bump-on-change-check.test.mjs` — 23 tests against real temp git repos
- `package.json` — `policy:version-bump-on-change` script
- `.github/workflows/main.yml` — PR-only step in the `validate` job; checkout gets `fetch-depth: 0` so the merge base is computable
- `CONTRIBUTING.md` — one-line statement of the rule

## Semantics

- **Governed packages:** every non-private `@gears-frontx`-scoped package — `packages/*`, `template-shell` itself (publishes `dist-lib` from its own `src/`, exact-pinned by four template-mfe fixtures), and `template-shell/packages/*`. Discovery is reused from `scripts/template-ecosystem-packages.mjs`, not re-derived.
- **Exemption:** per-package `private: true` — excludes the `template-mfe` fixture apps (pinned consumers, covered by `policy:template-pin-drift` once the source package bumps) and `internal/*`.
- **Substantive change:** any non-doc file under the package's `src/` (colocated tests included; `*.md`/`llms.txt` excluded), or a change to a dependency field of its `package.json`.
- **Comparison:** the `package.json` version at the PR's merge base vs HEAD (blob content via `git show`), so a bump-then-revert within one PR still fails.
- **Attribution:** longest-matching root, so `template-shell/packages/react/src/*` demands a react bump, not a parent `template-shell` bump.
- Packages added or removed by the PR itself are skipped; the step runs only on `pull_request` events (no base ref on `push`).

## Deliberately out of scope (noted during review)

- `files`-field payloads outside `src/` (e.g. `packages/cyber-pilot-kit-frontx`'s `skills/`/`guidelines/`)
- semver-ordering validation (any version *change* passes, including downgrades)
- an escape-hatch/ignore mechanism for pure-mechanical `src/` changes
- concurrent-PR bump collisions (two in-flight PRs can bump to the same version; surfaces later via pin-drift/publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
