### PR TITLE
fix(test-utils): widen SharedProperty fixture value type to unknown

### DIFF
--- a/template-shell/src-app/__test-utils__/createMfeBridgeFixture.ts
+++ b/template-shell/src-app/__test-utils__/createMfeBridgeFixture.ts
@@ -8,7 +8,7 @@ type PropertyCallback = Parameters<ChildMfeBridge['subscribeToProperty']>[1];
 type CreateMfeBridgeFixtureOptions = {
   domainId: string;
   instanceId: string;
-  initialProperties?: Record<string, string | undefined>;
+  initialProperties?: Record<string, unknown>;
   executeActionsChain?: Mock<ChildMfeBridge['executeActionsChain']>;
   registerActionHandler?: Mock<ChildMfeBridge['registerActionHandler']>;
 };
@@ -24,7 +24,7 @@ export type MfeBridgeFixture = {
   getProperty: Mock<ChildMfeBridge['getProperty']>;
   propertyCallbacks: Map<string, PropertyCallback[]>;
   registerActionHandler: Mock<ChildMfeBridge['registerActionHandler']>;
-  setProperty: (propertyName: string, value: string | undefined) => void;
+  setProperty: (propertyName: string, value: unknown) => void;
   subscribeToProperty: Mock<ChildMfeBridge['subscribeToProperty']>;
   unsubscriptions: RecordedUnsubscribe[];
 };
@@ -36,7 +36,7 @@ export type MfeBridgeFixture = {
 export function createMfeBridgeFixture(
   options: CreateMfeBridgeFixtureOptions
 ): MfeBridgeFixture {
-  const propertyValues = new Map<string, string | undefined>(
+  const propertyValues = new Map<string, unknown>(
     Object.entries(options.initialProperties ?? {})
   );
   const propertyCallbacks = new Map<string, PropertyCallback[]>();
@@ -71,7 +71,7 @@ export function createMfeBridgeFixture(
     }
   );
 
-  const setProperty = (propertyName: string, value: string | undefined) => {
+  const setProperty = (propertyName: string, value: unknown) => {
     propertyValues.set(propertyName, value);
 
     for (const callback of propertyCallbacks.get(propertyName) ?? []) {


### PR DESCRIPTION
Closes #573.

The bridge test fixture (`template-shell/src-app/__test-utils__/createMfeBridgeFixture.ts`) typed shared-property values as `Record<string, string | undefined>`, while production `SharedProperty.value` is `unknown` (`packages/mfes/src/types/index.ts`). Tests therefore could not supply the non-string inputs (numbers, objects) that `typeof` filters like demo-mfe's `useBridgeProperty` / `readBridgeProperty` exist for.

This widens `initialProperties`, the internal value map, and `setProperty` to `unknown`, matching the production contract. Existing string-passing callers are unaffected (input widening only).

Verification:
- `tsc -p template-shell/tsconfig.app.json --noEmit` — clean
- template-shell src-app tests: 6 files / 21 tests passed
- demo-mfe tests against the widened fixture (shell `__test-utils__` + vitest base copied per the local MFE-test flow): 11 files / 35 tests passed

Follow-up for #567: once merged, its `useBridgeProperty` tests can exercise number/object values directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)