### PR TITLE
fix: green develop after the ui-kit port - follow-ups and template hygiene

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -356,6 +356,17 @@ jobs:
             # being one claim — so this branches on which the tree actually
             # has, rather than assuming a directory the way `-d` alone did.
             if [ -d "$overlay/$subtree" ]; then
+              # The ground has to be free before anything is written, the way
+              # `refuseUnlessGroundFree` requires it of a real `frontx add`:
+              # every copy below is an overwrite, so a destination that already
+              # holds content means the shell and this overlay both claim it and
+              # the composition under test is not the one a developer would get.
+              # Asked before `mkdir -p`, which would otherwise create the very
+              # path being asked about.
+              if [ -e "$shell/${subtree%/}" ]; then
+                echo "::error::$overlay's exclusiveSubtree '$subtree' is already occupied in $shell"
+                exit 1
+              fi
               echo "==> Overlaying $overlay/$subtree"
               # Copy the *contents* into the destination: `cp -R src dest`
               # nests under dest when dest already exists, which would bury
@@ -363,6 +374,10 @@ jobs:
               mkdir -p "$shell/${subtree%/}"
               cp -R "$overlay/$subtree/." "$shell/${subtree%/}/"
             elif [ -f "$overlay/$subtree" ]; then
+              if [ -e "$shell/$subtree" ]; then
+                echo "::error::$overlay's exclusiveSubtree '$subtree' is already occupied in $shell"
+                exit 1
+              fi
               echo "==> Overlaying $overlay/$subtree (file)"
               mkdir -p "$shell/$(dirname "$subtree")"
               cp "$overlay/$subtree" "$shell/$subtree"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -349,28 +349,41 @@ jobs:
           overlay_count=0
           while read -r subtree; do
             [ -n "$subtree" ] || continue
-            # A declared subtree that isn't there means the manifest and the
-            # tree disagree.
-            if [ ! -d "$overlay/$subtree" ]; then
+            # A declared subtree is usually a directory, but 0d22fe81 started
+            # declaring template-mfe's own README.md as its own
+            # exclusiveSubtree entry, alongside the four MFE package
+            # directories, once "the whole mfe_packages directory" stopped
+            # being one claim — so this branches on which the tree actually
+            # has, rather than assuming a directory the way `-d` alone did.
+            if [ -d "$overlay/$subtree" ]; then
+              echo "==> Overlaying $overlay/$subtree"
+              # Copy the *contents* into the destination: `cp -R src dest`
+              # nests under dest when dest already exists, which would bury
+              # the packages a level deeper than the count below looks.
+              mkdir -p "$shell/${subtree%/}"
+              cp -R "$overlay/$subtree/." "$shell/${subtree%/}/"
+            elif [ -f "$overlay/$subtree" ]; then
+              echo "==> Overlaying $overlay/$subtree (file)"
+              mkdir -p "$shell/$(dirname "$subtree")"
+              cp "$overlay/$subtree" "$shell/$subtree"
+            else
+              # A declared subtree that isn't there means the manifest and
+              # the tree disagree.
               echo "::error::$overlay declares exclusiveSubtree '$subtree', which does not exist"
               exit 1
             fi
-            echo "==> Overlaying $overlay/$subtree"
-            # Copy the *contents* into the destination: `cp -R src dest` nests
-            # under dest when dest already exists, which would bury the
-            # packages a level deeper than the count below looks.
-            mkdir -p "$shell/${subtree%/}"
-            cp -R "$overlay/$subtree/." "$shell/${subtree%/}/"
             # Each MFE ships a standalone package-lock.json whose file:
             # targets point into template-mfe/packages/*, which does not
             # exist. npm ignores nested locks inside a workspace, but drop
             # them so nothing reads them — from the subtree just copied, not
-            # a hardcoded mfe_packages path.
+            # a hardcoded mfe_packages path. A no-op for a file subtree that
+            # isn't itself named package-lock.json.
             find "$shell/${subtree%/}" -not -path '*/node_modules/*' \
               -name package-lock.json -delete
             # Counted from the subtree just copied, not a hardcoded
             # `src-app/mfe_packages` path — the manifest already told us
-            # where this overlay's content landed.
+            # where this overlay's content landed. A no-op (0) for a file
+            # subtree that isn't itself package.json.
             subtree_count="$(find "$shell/${subtree%/}" -not -path '*/node_modules/*' \
               -name package.json 2>/dev/null | wc -l)"
             overlay_count=$((overlay_count + subtree_count))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9164,7 +9164,7 @@
     },
     "packages/cli": {
       "name": "@gears-frontx/cli",
-      "version": "0.3.0-alpha.3",
+      "version": "0.3.0-alpha.4",
       "license": "MIT",
       "bin": {
         "frontx": "dist/cli.js"
@@ -9246,7 +9246,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.4.0-alpha.1",
+      "version": "0.4.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/cli",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "description": "Template resolution CLI for FrontX SDK — zero bundled template content",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/cli/src/__tests__/template-split.e2e.test.ts
+++ b/packages/cli/src/__tests__/template-split.e2e.test.ts
@@ -294,14 +294,20 @@ describe("Fixture 4 — conflict-check on REAL templates: a synthetic 'mfe-dup' 
       // claim collides with each of them separately, and a report naming only
       // one would leave the rest for the developer to rediscover.
       const mfeSubtrees = readManifest(TEMPLATE_MFE_DIR).ownershipBoundaries.exclusiveSubtrees;
+      const swallowed = mfeSubtrees.filter((subtree) =>
+        pathWithinSubtree(subtree, 'src-app/mfe_packages/'),
+      );
+      // A derived oracle with no floor under it would pass against a manifest
+      // that had stopped declaring anything under `src-app/mfe_packages/`: an
+      // empty expectation matches an empty report, and the multi-conflict
+      // property the comment above describes would go untested. More than one
+      // is the standing fact this case exists for.
+      expect(swallowed.length).toBeGreaterThan(1);
       expect(dupAddResult.conflicts).toEqual(
-        mfeSubtrees
-          .filter((subtree) => pathWithinSubtree(subtree, 'src-app/mfe_packages/'))
-          .map((subtree) => ({
-            ground:
-              subtree === 'src-app/mfe_packages/' ? subtree : `src-app/mfe_packages/ overlaps ${subtree}`,
-            contestants: ['frontx-template-mfe-dup', TEMPLATE_MFE_IDENTITY],
-          })),
+        swallowed.map((subtree) => ({
+          ground: `src-app/mfe_packages/ overlaps ${subtree}`,
+          contestants: ['frontx-template-mfe-dup', TEMPLATE_MFE_IDENTITY],
+        })),
       );
     }
 

--- a/packages/cli/src/__tests__/template-split.e2e.test.ts
+++ b/packages/cli/src/__tests__/template-split.e2e.test.ts
@@ -286,9 +286,23 @@ describe("Fixture 4 — conflict-check on REAL templates: a synthetic 'mfe-dup' 
     if (dupAddResult.ok) return;
     expect(dupAddResult.reason).toBe('conflict');
     if (dupAddResult.reason === 'conflict') {
-      expect(dupAddResult.conflicts).toEqual([
-        { ground: 'src-app/mfe_packages/', contestants: ['frontx-template-mfe-dup', TEMPLATE_MFE_IDENTITY] },
-      ]);
+      // Derived from the real, on-disk template-mfe manifest — same pattern as
+      // Fixture 5's shell case below — rather than pinned to a snapshot: mfe
+      // claims five separate exclusive subtrees nested under
+      // 'src-app/mfe_packages/' (refactor(template-mfe): claim the packages it
+      // ships, not the whole mfe_packages directory), so the dup's one broad
+      // claim collides with each of them separately, and a report naming only
+      // one would leave the rest for the developer to rediscover.
+      const mfeSubtrees = readManifest(TEMPLATE_MFE_DIR).ownershipBoundaries.exclusiveSubtrees;
+      expect(dupAddResult.conflicts).toEqual(
+        mfeSubtrees
+          .filter((subtree) => pathWithinSubtree(subtree, 'src-app/mfe_packages/'))
+          .map((subtree) => ({
+            ground:
+              subtree === 'src-app/mfe_packages/' ? subtree : `src-app/mfe_packages/ overlaps ${subtree}`,
+            contestants: ['frontx-template-mfe-dup', TEMPLATE_MFE_IDENTITY],
+          })),
+      );
     }
 
     expect(listRealFiles(targetDir).sort()).toEqual(filesBefore);

--- a/packages/cli/src/commands/add-template.ts
+++ b/packages/cli/src/commands/add-template.ts
@@ -323,9 +323,11 @@ async function refuseUnlessGroundFree(
     // someone else's subtree passes it untouched, and exempting such a path here
     // would hand it straight to a whole-file write over existing content. No
     // supported flow needs the wider exemption — the reference templates declare
-    // disjoint ground on purpose (the shell claims `src-app/app/` and its
-    // siblings rather than `src-app/`, leaving `src-app/mfe_packages/` to the
-    // MFE template).
+    // disjoint ground on purpose, each claim as narrow as what the template
+    // actually ships: the shell claims `src-app/app/` and its siblings rather
+    // than `src-app/`, and the MFE template claims its own package directories
+    // under `src-app/mfe_packages/` rather than that directory itself, which is
+    // what lets a second template own a package beside them.
     if (isArbitratedGround(path, claimed, occupied)) continue;
     if ((await readTargetPathStateFn(`${targetDir}/${path}`)) === 'absent') continue;
     occupiedPaths.push(path);

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/ui-kit/src/components/attachment/attachment.test.tsx
+++ b/packages/ui-kit/src/components/attachment/attachment.test.tsx
@@ -121,6 +121,17 @@ describe('Attachment parts', () => {
     expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
   });
 
+  it('treats an explicit null variant on AttachmentMedia as the icon default, in class and attribute alike', () => {
+    render(
+      <Attachment>
+        <AttachmentMedia data-testid="media" variant={null} />
+      </Attachment>,
+    );
+    const media = screen.getByTestId('media');
+    expect(media.className).toContain(styles.variantIcon);
+    expect(media.getAttribute('data-variant')).toBe('icon');
+  });
+
   it('renders AttachmentTrigger as a button by default and supports the render prop', () => {
     render(
       <Attachment>

--- a/packages/ui-kit/src/components/attachment/attachment.tsx
+++ b/packages/ui-kit/src/components/attachment/attachment.tsx
@@ -105,8 +105,22 @@ export interface AttachmentMediaProps
 /** The media slot for an icon or image preview. Sizes and tints itself off
  * the ancestor `Attachment`'s `size`/`orientation`/`state` via CSS — no
  * extra props needed. */
-export function AttachmentMedia({ className, variant = 'icon', ...props }: AttachmentMediaProps) {
-  return <div data-variant={variant} className={attachmentMediaVariants({ variant, className })} {...props} />;
+export function AttachmentMedia({ className, variant, ...props }: AttachmentMediaProps) {
+  // cva's own VariantProps types this `| null` (a consumer can pass
+  // `variant={null}` to explicitly reset to the default), which a default
+  // parameter value alone doesn't absorb — only `undefined` does. cva reads
+  // that null as "emit no variant class at all" while `data-variant` would
+  // still be dropped by React, so the media slot would come out with neither
+  // the default class nor the attribute. Resolved once here, same as
+  // marker.tsx, so class and attribute always agree.
+  const resolvedVariant = variant ?? 'icon';
+  return (
+    <div
+      data-variant={resolvedVariant}
+      className={attachmentMediaVariants({ variant: resolvedVariant, className })}
+      {...props}
+    />
+  );
 }
 
 export type AttachmentContentProps = ComponentProps<'div'>;

--- a/packages/ui-kit/src/components/bubble/bubble.test.tsx
+++ b/packages/ui-kit/src/components/bubble/bubble.test.tsx
@@ -36,6 +36,17 @@ describe('Bubble', () => {
     expect(bubble.getAttribute('data-variant')).toBe(variant);
   });
 
+  it('treats an explicit null variant as the default, in class and attribute alike', () => {
+    render(
+      <Bubble data-testid="bubble" variant={null}>
+        Hi
+      </Bubble>,
+    );
+    const bubble = screen.getByTestId('bubble');
+    expect(bubble.className).toContain(styles.variantDefault);
+    expect(bubble.getAttribute('data-variant')).toBe('default');
+  });
+
   it('reflects align="end" as a data attribute', () => {
     render(
       <Bubble data-testid="bubble" align="end">

--- a/packages/ui-kit/src/components/bubble/bubble.tsx
+++ b/packages/ui-kit/src/components/bubble/bubble.tsx
@@ -61,12 +61,20 @@ export interface BubbleProps extends ComponentProps<'div'>, VariantProps<typeof 
 }
 
 /** The root bubble wrapper. */
-export function Bubble({ className, variant = 'default', align = 'start', ...props }: BubbleProps) {
+export function Bubble({ className, variant, align = 'start', ...props }: BubbleProps) {
+  // cva's own VariantProps types this `| null` (a consumer can pass
+  // `variant={null}` to explicitly reset to the default), which a default
+  // parameter value alone doesn't absorb — only `undefined` does. cva reads
+  // that null as "emit no variant class at all" while `data-variant` would
+  // still be dropped by React, so the bubble would come out with neither the
+  // default class nor the attribute. Resolved once here, same as marker.tsx,
+  // so class and attribute always agree.
+  const resolvedVariant = variant ?? 'default';
   return (
     <div
-      data-variant={variant}
+      data-variant={resolvedVariant}
       data-align={align}
-      className={bubbleVariants({ variant, className })}
+      className={bubbleVariants({ variant: resolvedVariant, className })}
       {...props}
     />
   );

--- a/packages/ui-kit/src/components/marker/marker.test.tsx
+++ b/packages/ui-kit/src/components/marker/marker.test.tsx
@@ -31,6 +31,17 @@ describe('Marker', () => {
     expect(marker.getAttribute('data-variant')).toBe(variant);
   });
 
+  it('treats an explicit null variant as the default, in class and attribute alike', () => {
+    render(
+      <Marker data-testid="marker" variant={null}>
+        Label
+      </Marker>,
+    );
+    const marker = screen.getByTestId('marker');
+    expect(marker.className).toContain(styles.variantDefault);
+    expect(marker.getAttribute('data-variant')).toBe('default');
+  });
+
   it('merges a consumer className without dropping the kit class', () => {
     render(
       <Marker data-testid="marker" className="consumer">

--- a/packages/ui-kit/src/components/marker/marker.tsx
+++ b/packages/ui-kit/src/components/marker/marker.tsx
@@ -39,7 +39,15 @@ const markerVariants = cva(styles.marker, {
 
 export interface MarkerProps extends useRender.ComponentProps<'div'>, VariantProps<typeof markerVariants> {}
 
-export function Marker({ className, variant = 'default', render, ...props }: MarkerProps) {
+export function Marker({ className, variant, render, ...props }: MarkerProps) {
+  // cva's own VariantProps types this `| null` (a consumer can pass
+  // `variant={null}` to explicitly reset to the default), which a default
+  // parameter value alone doesn't absorb — only `undefined` does. cva reads
+  // that null as "emit no variant class at all" while `data-variant` would
+  // still be dropped by React, so the marker would come out with neither the
+  // default class nor the attribute. Resolved once here, same as item.tsx,
+  // so class and attribute always agree.
+  const resolvedVariant = variant ?? 'default';
   return useRender({
     defaultTagName: 'div',
     render,
@@ -49,8 +57,8 @@ export function Marker({ className, variant = 'default', render, ...props }: Mar
     // shadow-proofing needed anywhere a `data-*` prop must survive
     // mergeProps.
     props: {
-      ...mergeProps<'div'>({ className: markerVariants({ variant, className }) }, props),
-      'data-variant': variant,
+      ...mergeProps<'div'>({ className: markerVariants({ variant: resolvedVariant, className }) }, props),
+      'data-variant': resolvedVariant,
     },
   });
 }

--- a/packages/ui-kit/src/components/native-select/native-select.module.css
+++ b/packages/ui-kit/src/components/native-select/native-select.module.css
@@ -121,6 +121,17 @@
   color: CanvasText;
 }
 
+/*
+ * Same declarations as .option today, deliberately its own class: an
+ * <optgroup> is the group label, not one of the choices, so the two are
+ * free to diverge (a group label's weight or color) without an <option>
+ * rule following it by accident.
+ */
+.optgroup {
+  background-color: Canvas;
+  color: CanvasText;
+}
+
 .icon {
   position: absolute;
   inset-inline-end: var(--space-3);

--- a/packages/ui-kit/src/components/native-select/native-select.test.tsx
+++ b/packages/ui-kit/src/components/native-select/native-select.test.tsx
@@ -71,6 +71,10 @@ describe('NativeSelect', () => {
     const group = screen.getByRole('group', { name: 'Europe' });
     expect(group).toHaveProperty('tagName', 'OPTGROUP');
     expect(screen.getByRole('option', { name: 'France' })).toHaveProperty('tagName', 'OPTION');
+    // The group label styles on its own class, not the option's, so the two
+    // can diverge without one dragging the other along.
+    expect(group.className).toContain(styles.optgroup);
+    expect(group.className).not.toContain(styles.option);
   });
 
   it('merges a consumer className onto the wrapper', () => {

--- a/packages/ui-kit/src/components/native-select/native-select.tsx
+++ b/packages/ui-kit/src/components/native-select/native-select.tsx
@@ -47,5 +47,5 @@ export function NativeSelectOption({ className, ...props }: NativeSelectOptionPr
 export type NativeSelectOptGroupProps = ComponentProps<'optgroup'>;
 
 export function NativeSelectOptGroup({ className, ...props }: NativeSelectOptGroupProps) {
-  return <optgroup className={cx(styles.option, className)} {...props} />;
+  return <optgroup className={cx(styles.optgroup, className)} {...props} />;
 }

--- a/template-mfe/frontx-template.json
+++ b/template-mfe/frontx-template.json
@@ -1,11 +1,15 @@
 {
   "schemaVersion": "1.0",
   "name": "@gears-frontx/frontx-template-mfe",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Contributes the microfrontend workspace to a repository that already has an application shell: a working reference scaffold for an isolated UI unit with Shadow DOM isolation, host bridge communication, shared theme and language properties, per-unit translations, and its own Module Federation build. Apply this once to gain the ground microfrontends live in; adding each individual screen or unit inside that ground is carried by the skills this template activates in the project, not by applying it again.",
   "ownershipBoundaries": {
     "exclusiveSubtrees": [
-      "src-app/mfe_packages/",
+      "src-app/mfe_packages/README.md",
+      "src-app/mfe_packages/_blank-mfe/",
+      "src-app/mfe_packages/demo-mfe/",
+      "src-app/mfe_packages/widgets-fixture-a/",
+      "src-app/mfe_packages/widgets-fixture-b/",
       ".frontx/ai/@gears-frontx/frontx-template-mfe/"
     ],
     "sharedFiles": []

--- a/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.2.4",
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.3",
     "@gears-frontx/react": "0.2.0-alpha.4",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.1",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.2",
     "@tanstack/react-query": "5.90.21"
   },
   "devDependencies": {

--- a/template-mfe/src-app/mfe_packages/demo-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.3",
     "@gears-frontx/react": "0.2.0-alpha.4",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.1",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.2",
     "@tanstack/react-query": "5.90.21",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/api/mock-user-store.ts
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/api/mock-user-store.ts
@@ -7,12 +7,12 @@ import { UserRole, type ApiUser } from './types';
 
 export const createDefaultAccountsMockUser = (): ApiUser => ({
   id: 'mock-user-001',
-  email: 'demo@frontx.dev',
-  firstName: 'Demo',
-  lastName: 'User',
+  email: 'alex.rivera@frontx.dev',
+  firstName: 'Alex',
+  lastName: 'Rivera',
   role: UserRole.Admin,
   language: Language.English,
-  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Demo',
+  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=AlexRivera',
   createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
   updatedAt: new Date('2024-12-01T00:00:00Z').toISOString(),
   extra: {

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/api/mocks.test.ts
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/api/mocks.test.ts
@@ -22,7 +22,7 @@ describe('accountsMockMap', () => {
       department: 'Platform',
     }) as GetCurrentUserResponse;
 
-    expect(initialResponse.user.firstName).toBe('Demo');
+    expect(initialResponse.user.firstName).toBe('Alex');
     expect(updatedResponse.user.firstName).toBe('Ada');
     expect(updatedResponse.user.lastName).toBe('Lovelace');
     expect(updatedResponse.user.extra).toEqual({ department: 'Platform' });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/CategoryMenu.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/CategoryMenu.tsx
@@ -49,17 +49,13 @@ export const CategoryMenu: React.FC<CategoryMenuProps> = ({ t, activeElement, co
   };
 
   const scrollToElement = (elementId: string) => {
-    // Query element from the correct root (shadow DOM or light DOM)
+    // Query the element from the root this MFE actually rendered into: its own
+    // shadow root when it has one, the document otherwise.
     const root = containerRef.current?.getRootNode();
-    let element: HTMLElement | null = null;
-
-    if (root && root instanceof ShadowRoot) {
-      // Inside Shadow DOM: query from shadow root
-      element = root.getElementById(elementId);
-    } else {
-      // Fallback to light DOM for compatibility
-      element = document.getElementById(elementId);
-    }
+    const element =
+      root instanceof ShadowRoot
+        ? root.getElementById(elementId)
+        : document.getElementById(elementId);
 
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.test.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { FormElements } from './FormElements';
+
+// The identity `t` makes the translation key the rendered text, so the
+// assertions name the message key rather than a translation that can be
+// reworded.
+function renderFormElements() {
+  render(<FormElements t={(key) => key} portalContainer={{ current: null }} />);
+  return screen.getByLabelText('Email');
+}
+
+describe('FormElements email field', () => {
+  it('flags a malformed address once the field is left', async () => {
+    const user = userEvent.setup();
+    const email = renderFormElements();
+
+    await user.type(email, 'not-an-email');
+    await user.tab();
+
+    expect(screen.getByText('form_email_invalid')).toBeTruthy();
+  });
+
+  it('says nothing while a first address is still being typed', async () => {
+    const user = userEvent.setup();
+    const email = renderFormElements();
+
+    await user.type(email, 'not-an-email');
+
+    expect(screen.queryByText('form_email_invalid')).toBeNull();
+  });
+
+  it('clears a shown message as soon as the address is corrected, without waiting for another blur', async () => {
+    const user = userEvent.setup();
+    const email = renderFormElements();
+
+    await user.type(email, 'not-an-email');
+    await user.tab();
+    await user.click(email);
+    await user.type(email, '@company.com');
+
+    expect(screen.queryByText('form_email_invalid')).toBeNull();
+  });
+});

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
@@ -50,11 +50,24 @@ const REGION_ITEMS = [
   { value: 'us-east', label: 'Virginia' },
 ];
 
+/**
+ * Which of the two `ValidityState` flags the demo reacts to, kept as a reason
+ * rather than as the message it resolves to: the host can switch language while
+ * an error is on screen, and a stored message would keep the language it was
+ * produced in until the field is blurred again.
+ */
+type EmailErrorReason = 'required' | 'malformed';
+
+const EMAIL_ERROR_KEYS: Record<EmailErrorReason, string> = {
+  required: 'form_email_required',
+  malformed: 'form_email_invalid',
+};
+
 export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }) => {
   const [region, setRegion] = useState('eu-central');
   const [plan, setPlan] = useState('free');
   const [notifications, setNotifications] = useState(true);
-  const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<EmailErrorReason | null>(null);
 
   /**
    * Field derives no validation of its own, so the demo runs the check the
@@ -66,9 +79,9 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
   const validateEmail = (event: React.FocusEvent<HTMLInputElement>) => {
     const { validity } = event.currentTarget;
     if (validity.valueMissing) {
-      setEmailError('Email is required.');
+      setEmailError('required');
     } else if (validity.typeMismatch) {
-      setEmailError('That does not look like an email.');
+      setEmailError('malformed');
     } else {
       setEmailError(null);
     }
@@ -109,7 +122,9 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
             <FieldDescription id="form-demo-email-description">
               We only use it for the invoice.
             </FieldDescription>
-            <FieldError id="form-demo-email-error">{emailError}</FieldError>
+            <FieldError id="form-demo-email-error">
+              {emailError ? t(EMAIL_ERROR_KEYS[emailError]) : null}
+            </FieldError>
           </Field>
         </div>
       </ElementDemo>

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
@@ -76,7 +76,7 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
    * blur rather than on every keystroke so a half-typed address is not
    * flagged as malformed while it is still being typed.
    */
-  const validateEmail = (event: React.FocusEvent<HTMLInputElement>) => {
+  const validateEmail = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const { validity } = event.currentTarget;
     if (validity.valueMissing) {
       setEmailError('required');
@@ -84,6 +84,19 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
       setEmailError('malformed');
     } else {
       setEmailError(null);
+    }
+  };
+
+  /**
+   * A message already on screen has to come off the moment the field is
+   * corrected, so once there is one, every keystroke re-runs the same check.
+   * The gate is what keeps the blur-only rule intact for a field that has not
+   * been flagged yet: with no error showing there is nothing to clear, and
+   * validating from the first character is exactly what reading on blur avoids.
+   */
+  const revalidateEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (emailError) {
+      validateEmail(event);
     }
   };
 
@@ -118,6 +131,7 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
                   : 'form-demo-email-description'
               }
               onBlur={validateEmail}
+              onChange={revalidateEmail}
             />
             <FieldDescription id="form-demo-email-description">
               We only use it for the invoice.

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ar.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ar.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "الإشعارات",
   "toast_close_label": "إغلاق الإشعار",
+  "form_email_required": "البريد الإلكتروني مطلوب.",
+  "form_email_invalid": "لا يبدو هذا بريدًا إلكترونيًا.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/bn.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/bn.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "বিজ্ঞপ্তি",
   "toast_close_label": "বিজ্ঞপ্তি বন্ধ করুন",
+  "form_email_required": "ইমেল আবশ্যক।",
+  "form_email_invalid": "এটি ইমেল বলে মনে হচ্ছে না।",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/cs.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/cs.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Oznámení",
   "toast_close_label": "Zavřít oznámení",
+  "form_email_required": "E-mail je povinný.",
+  "form_email_invalid": "Tohle nevypadá jako e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/da.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/da.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notifikationer",
   "toast_close_label": "Luk notifikation",
+  "form_email_required": "E-mail er påkrævet.",
+  "form_email_invalid": "Det ligner ikke en e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/de.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/de.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Benachrichtigungen",
   "toast_close_label": "Benachrichtigung schließen",
+  "form_email_required": "E-Mail ist erforderlich.",
+  "form_email_invalid": "Das sieht nicht wie eine E-Mail aus.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/el.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/el.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Ειδοποιήσεις",
   "toast_close_label": "Κλείσιμο ειδοποίησης",
+  "form_email_required": "Το email είναι υποχρεωτικό.",
+  "form_email_invalid": "Αυτό δεν μοιάζει με email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/en.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/en.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notifications",
   "toast_close_label": "Close toast",
+  "form_email_required": "Email is required.",
+  "form_email_invalid": "That does not look like an email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/es.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/es.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notificaciones",
   "toast_close_label": "Cerrar notificación",
+  "form_email_required": "El correo electrónico es obligatorio.",
+  "form_email_invalid": "Eso no parece un correo electrónico.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fa.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fa.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "اعلان‌ها",
   "toast_close_label": "بستن اعلان",
+  "form_email_required": "ایمیل الزامی است.",
+  "form_email_invalid": "این شبیه یک ایمیل نیست.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fi.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fi.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Ilmoitukset",
   "toast_close_label": "Sulje ilmoitus",
+  "form_email_required": "Sähköposti on pakollinen.",
+  "form_email_invalid": "Tämä ei näytä sähköpostiosoitteelta.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fr.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/fr.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Zone de notifications",
   "toast_close_label": "Fermer la notification",
+  "form_email_required": "L'e-mail est obligatoire.",
+  "form_email_invalid": "Cela ne ressemble pas à un e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/he.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/he.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "התראות",
   "toast_close_label": "סגירת ההתראה",
+  "form_email_required": "נדרשת כתובת אימייל.",
+  "form_email_invalid": "זה לא נראה כמו כתובת אימייל.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/hi.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/hi.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "सूचनाएँ",
   "toast_close_label": "सूचना बंद करें",
+  "form_email_required": "ईमेल आवश्यक है।",
+  "form_email_invalid": "यह ईमेल जैसा नहीं लगता।",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/hu.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/hu.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Értesítések",
   "toast_close_label": "Értesítés bezárása",
+  "form_email_required": "Az e-mail megadása kötelező.",
+  "form_email_invalid": "Ez nem úgy néz ki, mint egy e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/id.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/id.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notifikasi",
   "toast_close_label": "Tutup notifikasi",
+  "form_email_required": "Email wajib diisi.",
+  "form_email_invalid": "Ini sepertinya bukan email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/it.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/it.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notifiche",
   "toast_close_label": "Chiudi la notifica",
+  "form_email_required": "L'email è obbligatoria.",
+  "form_email_invalid": "Questo non sembra un'email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ja.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ja.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "通知",
   "toast_close_label": "通知を閉じる",
+  "form_email_required": "メールアドレスは必須です。",
+  "form_email_invalid": "メールアドレスの形式ではないようです。",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ko.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ko.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "알림",
   "toast_close_label": "알림 닫기",
+  "form_email_required": "이메일은 필수입니다.",
+  "form_email_invalid": "이메일 형식이 아닌 것 같습니다.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ms.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ms.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Pemberitahuan",
   "toast_close_label": "Tutup pemberitahuan",
+  "form_email_required": "E-mel diperlukan.",
+  "form_email_invalid": "Ini nampaknya bukan e-mel.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/nl.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/nl.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Meldingen",
   "toast_close_label": "Melding sluiten",
+  "form_email_required": "E-mail is verplicht.",
+  "form_email_invalid": "Dit lijkt niet op een e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/no.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/no.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Varsler",
   "toast_close_label": "Lukk varselet",
+  "form_email_required": "E-post er påkrevd.",
+  "form_email_invalid": "Dette ser ikke ut som en e-post.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/pl.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/pl.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Powiadomienia",
   "toast_close_label": "Zamknij powiadomienie",
+  "form_email_required": "E-mail jest wymagany.",
+  "form_email_invalid": "To nie wygląda na e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/pt.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/pt.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notificações",
   "toast_close_label": "Fechar notificação",
+  "form_email_required": "O e-mail é obrigatório.",
+  "form_email_invalid": "Isso não parece um e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ro.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ro.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Notificări",
   "toast_close_label": "Închide notificarea",
+  "form_email_required": "E-mailul este obligatoriu.",
+  "form_email_invalid": "Asta nu arată ca un e-mail.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ru.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ru.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Уведомления",
   "toast_close_label": "Закрыть уведомление",
+  "form_email_required": "Email обязателен.",
+  "form_email_invalid": "Это не похоже на email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/sv.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/sv.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Aviseringar",
   "toast_close_label": "Stäng aviseringen",
+  "form_email_required": "E-post är obligatoriskt.",
+  "form_email_invalid": "Det ser inte ut som en e-postadress.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/sw.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/sw.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Arifa",
   "toast_close_label": "Funga arifa",
+  "form_email_required": "Barua pepe inahitajika.",
+  "form_email_invalid": "Hii haionekani kama barua pepe.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ta.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ta.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "அறிவிப்புகள்",
   "toast_close_label": "அறிவிப்பை மூடு",
+  "form_email_required": "மின்னஞ்சல் தேவை.",
+  "form_email_invalid": "இது மின்னஞ்சல் போல் தெரியவில்லை.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/th.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/th.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "การแจ้งเตือน",
   "toast_close_label": "ปิดการแจ้งเตือน",
+  "form_email_required": "ต้องระบุอีเมล",
+  "form_email_invalid": "ข้อมูลนี้ดูไม่เหมือนอีเมล",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/tl.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/tl.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Mga notipikasyon",
   "toast_close_label": "Isara ang notipikasyon",
+  "form_email_required": "Kailangan ang email.",
+  "form_email_invalid": "Mukhang hindi ito email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/tr.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/tr.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Bildirimler",
   "toast_close_label": "Bildirimi kapat",
+  "form_email_required": "E-posta zorunludur.",
+  "form_email_invalid": "Bu bir e-posta adresine benzemiyor.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/uk.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/uk.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Повідомлення",
   "toast_close_label": "Закрити повідомлення",
+  "form_email_required": "Email обов'язковий.",
+  "form_email_invalid": "Це не схоже на email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ur.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/ur.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "اطلاعات",
   "toast_close_label": "اطلاع بند کریں",
+  "form_email_required": "ای میل درکار ہے۔",
+  "form_email_invalid": "یہ ای میل نہیں لگتا۔",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/vi.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/vi.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "Thông báo",
   "toast_close_label": "Đóng thông báo",
+  "form_email_required": "Email là bắt buộc.",
+  "form_email_invalid": "Đây có vẻ không phải là email.",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/zh-TW.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/zh-TW.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "通知",
   "toast_close_label": "關閉通知",
+  "form_email_required": "電子郵件為必填。",
+  "form_email_invalid": "這看起來不像電子郵件。",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/zh.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/i18n/zh.json
@@ -9,6 +9,8 @@
   "current_language": "Current Language:",
   "toast_region_label": "通知",
   "toast_close_label": "关闭通知",
+  "form_email_required": "电子邮件为必填项。",
+  "form_email_invalid": "这看起来不像电子邮件。",
   "category.layout": "Layout",
   "category.navigation": "Navigation",
   "category.forms": "Forms",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/uikitTranslations.test.ts
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/uikitTranslations.test.ts
@@ -23,7 +23,15 @@ const english = locales.en;
 
 describe('uikit screen translations', () => {
   it('carries the keys the screen and its menu call, in English', () => {
-    for (const key of ['title', 'description', 'menu_title', 'toast_region_label', 'toast_close_label']) {
+    for (const key of [
+      'title',
+      'description',
+      'menu_title',
+      'toast_region_label',
+      'toast_close_label',
+      'form_email_required',
+      'form_email_invalid',
+    ]) {
       expect(english[key]).toBeTruthy();
     }
 

--- a/template-shell/frontx-template.json
+++ b/template-shell/frontx-template.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "name": "@gears-frontx/frontx-template-shell",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Establishes a new repository as a runnable FrontX application shell: the host app that boots, routes, and mounts microfrontends into extension domains, wired to the ecosystem runtime, type-system and API packages, with the Vite build, the Module Federation manifest pipeline, and the type-check, lint and test toolchain already in place. Apply this to start a project; it contributes the ground every other template extends and holds no microfrontend of its own.",
   "ownershipBoundaries": {
     "exclusiveSubtrees": [

--- a/template-shell/package.json
+++ b/template-shell/package.json
@@ -43,7 +43,7 @@
     "build:packages:studio": "npm run build --workspace=@gears-frontx/studio",
     "prebuild:packages": "npm run build:package",
     "build:packages": "npm run build:packages:auth && npm run build:packages:state && npm run build:packages:i18n && npm run build:packages:framework && npm run build:packages:react && npm run build:packages:studio",
-    "build": "npm run build:packages && npm run build:mfes && npm run generate:mfe-manifests && vite build",
+    "build": "npm run build:mfes && npm run generate:mfe-manifests && vite build",
     "type-check:package": "tsc --noEmit",
     "type-check:package:test": "tsc -p tsconfig.test.json",
     "type-check:app": "tsc --noEmit -p tsconfig.app.json",

--- a/template-shell/package.json
+++ b/template-shell/package.json
@@ -27,9 +27,11 @@
     "src-app/mfe_packages/*"
   ],
   "scripts": {
+    "prebuild:mfes": "npm run build:packages",
     "build:mfes": "npx tsx scripts/build-mfes.ts",
     "generate:mfe-manifests": "npx tsx scripts/generate-mfe-manifests.ts",
     "dev": "npm run build:packages && npm run build:mfes && npm run generate:mfe-manifests && vite",
+    "predev:all": "npm run build:packages",
     "dev:all": "npx tsx scripts/dev-all.ts",
     "preview": "vite preview",
     "build:package": "tsup",

--- a/template-shell/package.json
+++ b/template-shell/package.json
@@ -30,7 +30,7 @@
     "prebuild:mfes": "npm run build:packages",
     "build:mfes": "npx tsx scripts/build-mfes.ts",
     "generate:mfe-manifests": "npx tsx scripts/generate-mfe-manifests.ts",
-    "dev": "npm run build:packages && npm run build:mfes && npm run generate:mfe-manifests && vite",
+    "dev": "npm run build:mfes && npm run generate:mfe-manifests && vite",
     "predev:all": "npm run build:packages",
     "dev:all": "npx tsx scripts/dev-all.ts",
     "preview": "vite preview",

--- a/template-shell/src-app/__test-utils__/mockUserFixture.ts
+++ b/template-shell/src-app/__test-utils__/mockUserFixture.ts
@@ -20,12 +20,12 @@ export const createMockUserFixture = <TRole extends string>(
   adminRole: TRole,
 ): MockUserFixture<TRole> => ({
   id: 'mock-user-001',
-  email: 'demo@frontx.dev',
-  firstName: 'Demo',
-  lastName: 'User',
+  email: 'alex.rivera@frontx.dev',
+  firstName: 'Alex',
+  lastName: 'Rivera',
   role: adminRole,
   language: 'en',
-  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Demo',
+  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=AlexRivera',
   createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
   updatedAt: new Date('2024-12-01T00:00:00Z').toISOString(),
   extra: {

--- a/template-shell/src-app/__test-utils__/mockUserFixture.ts
+++ b/template-shell/src-app/__test-utils__/mockUserFixture.ts
@@ -1,6 +1,3 @@
-// @cpt-dod:cpt-frontx-dod-api-communication-base-service:p1
-
-// @cpt-begin:cpt-frontx-dod-api-communication-base-service:p1:inst-mock-user-fixture
 type MockUserFixture<TRole extends string> = {
   id: string;
   email: string;
@@ -32,4 +29,3 @@ export const createMockUserFixture = <TRole extends string>(
     department: 'Engineering',
   },
 });
-// @cpt-end:cpt-frontx-dod-api-communication-base-service:p1:inst-mock-user-fixture

--- a/template-shell/src-app/app/App.tsx
+++ b/template-shell/src-app/app/App.tsx
@@ -9,7 +9,7 @@
  * - FrontX context (app instance)
  *
  * Layout handles:
- * - Header, Menu, Footer, Sidebar rendering
+ * - Header, Menu, Sidebar rendering
  * - Theme-aware styling via hooks
  *
  * MfeScreenContainer handles:

--- a/template-shell/src-app/app/api/mock-user-store.ts
+++ b/template-shell/src-app/app/api/mock-user-store.ts
@@ -7,12 +7,12 @@ import { UserRole, type ApiUser } from './types';
 
 export const createDefaultAccountsMockUser = (): ApiUser => ({
   id: 'mock-user-001',
-  email: 'demo@frontx.dev',
-  firstName: 'Demo',
-  lastName: 'User',
+  email: 'alex.rivera@frontx.dev',
+  firstName: 'Alex',
+  lastName: 'Rivera',
   role: UserRole.Admin,
   language: Language.English,
-  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Demo',
+  avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=AlexRivera',
   createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
   updatedAt: new Date('2024-12-01T00:00:00Z').toISOString(),
   extra: {

--- a/template-shell/src-app/app/api/mocks.test.ts
+++ b/template-shell/src-app/app/api/mocks.test.ts
@@ -23,7 +23,7 @@ describe('accountsMockMap', () => {
     expect(getMockUser()).toEqual(
       expect.objectContaining({
         id: 'mock-user-001',
-        firstName: 'Demo',
+        firstName: 'Alex',
       }),
     );
     expect(getMockUser()).not.toBe(initialUser);

--- a/template-shell/src-app/app/layout/Footer.test.tsx
+++ b/template-shell/src-app/app/layout/Footer.test.tsx
@@ -11,40 +11,39 @@ vi.mock('@gears-frontx/react', async (importOriginal) => ({
 }));
 
 describe('Footer', () => {
-  it('renders nothing with no children', () => {
+  it('renders its children when the layout state says nothing about visibility', () => {
     mockFooterState = undefined;
-    const { container } = render(<Footer />);
-    expect(container.firstChild).toBeNull();
-  });
 
-  it('renders nothing for a falsy conditional child, not an empty band', () => {
-    // `Children.count(false)` is 1, not 0 — the case `Children.toArray`
-    // exists to guard against: a screen writing `{enabled && <X />}` with
-    // `enabled` false must not resurrect the 40px strip this component
-    // exists to suppress when it has nothing to show.
-    mockFooterState = undefined;
-    const showExtra = false;
-    const { container } = render(<Footer>{showExtra && <span>extra</span>}</Footer>);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it('renders its children when present and visible', () => {
-    mockFooterState = { visible: true };
     render(
       <Footer>
         <span>status</span>
       </Footer>,
     );
+
     expect(screen.getByText('status')).toBeTruthy();
   });
 
-  it('renders nothing when explicitly hidden, even with children', () => {
+  it('renders its children when explicitly visible', () => {
+    mockFooterState = { visible: true };
+
+    render(
+      <Footer>
+        <span>status</span>
+      </Footer>,
+    );
+
+    expect(screen.getByText('status')).toBeTruthy();
+  });
+
+  it('renders nothing when hidden, even with children to show', () => {
     mockFooterState = { visible: false };
+
     const { container } = render(
       <Footer>
         <span>status</span>
       </Footer>,
     );
+
     expect(container.firstChild).toBeNull();
   });
 });

--- a/template-shell/src-app/app/layout/Footer.test.tsx
+++ b/template-shell/src-app/app/layout/Footer.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { FooterState } from '@gears-frontx/react';
+import { Footer } from './Footer';
+
+let mockFooterState: FooterState | undefined;
+
+vi.mock('@gears-frontx/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@gears-frontx/react')>()),
+  useAppSelector: () => mockFooterState,
+}));
+
+describe('Footer', () => {
+  it('renders nothing with no children', () => {
+    mockFooterState = undefined;
+    const { container } = render(<Footer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for a falsy conditional child, not an empty band', () => {
+    // `Children.count(false)` is 1, not 0 — the case `Children.toArray`
+    // exists to guard against: a screen writing `{enabled && <X />}` with
+    // `enabled` false must not resurrect the 40px strip this component
+    // exists to suppress when it has nothing to show.
+    mockFooterState = undefined;
+    const showExtra = false;
+    const { container } = render(<Footer>{showExtra && <span>extra</span>}</Footer>);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders its children when present and visible', () => {
+    mockFooterState = { visible: true };
+    render(
+      <Footer>
+        <span>status</span>
+      </Footer>,
+    );
+    expect(screen.getByText('status')).toBeTruthy();
+  });
+
+  it('renders nothing when explicitly hidden, even with children', () => {
+    mockFooterState = { visible: false };
+    const { container } = render(
+      <Footer>
+        <span>status</span>
+      </Footer>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/template-shell/src-app/app/layout/Footer.tsx
+++ b/template-shell/src-app/app/layout/Footer.tsx
@@ -23,7 +23,12 @@ export const Footer: React.FC<FooterProps> = ({ children }) => {
   // of children is therefore the only signal available, and it is the right
   // one - `visible` stays the explicit switch for a footer that does have
   // content.
-  if (!visible || React.Children.count(children) === 0) {
+  // `Children.count` treats a falsy conditional child (`{enabled &&
+  // <FooterContent />}` with `enabled` false) as one slot, not zero, so it
+  // would let the empty band this check exists to suppress back in the
+  // moment a caller writes the pattern. `Children.toArray` drops those slots
+  // before counting.
+  if (!visible || React.Children.toArray(children).length === 0) {
     return null;
   }
 

--- a/template-shell/src-app/app/layout/Footer.tsx
+++ b/template-shell/src-app/app/layout/Footer.tsx
@@ -16,7 +16,14 @@ export const Footer: React.FC<FooterProps> = ({ children }) => {
   const footerState = useAppSelector((state) => state['layout/footer'] as FooterState | undefined);
   const visible = footerState?.visible ?? true;
 
-  if (!visible) {
+  // The strip is a container and carries nothing of its own, so with no
+  // children it renders a 40px band of border and background across the whole
+  // viewport that no screen can fill: `Layout` passes it none, and the layout
+  // plugin exposes no footer event a microfrontend could hide it with. Absence
+  // of children is therefore the only signal available, and it is the right
+  // one - `visible` stays the explicit switch for a footer that does have
+  // content.
+  if (!visible || React.Children.count(children) === 0) {
     return null;
   }
 

--- a/template-shell/src-app/app/layout/Footer.tsx
+++ b/template-shell/src-app/app/layout/Footer.tsx
@@ -16,19 +16,13 @@ export const Footer: React.FC<FooterProps> = ({ children }) => {
   const footerState = useAppSelector((state) => state['layout/footer'] as FooterState | undefined);
   const visible = footerState?.visible ?? true;
 
-  // The strip is a container and carries nothing of its own, so with no
-  // children it renders a 40px band of border and background across the whole
-  // viewport that no screen can fill: `Layout` passes it none, and the layout
-  // plugin exposes no footer event a microfrontend could hide it with. Absence
-  // of children is therefore the only signal available, and it is the right
-  // one - `visible` stays the explicit switch for a footer that does have
-  // content.
-  // `Children.count` treats a falsy conditional child (`{enabled &&
-  // <FooterContent />}` with `enabled` false) as one slot, not zero, so it
-  // would let the empty band this check exists to suppress back in the
-  // moment a caller writes the pattern. `Children.toArray` drops those slots
-  // before counting.
-  if (!visible || React.Children.toArray(children).length === 0) {
+  // `visible` is the only switch here, driven by `app.actions.setFooterVisible`
+  // from the layout plugin. Whether there is anything worth framing is the
+  // caller's question, not this component's: the strip carries nothing of its
+  // own, so a `Footer` with no children is a 40px band of border and background
+  // no screen can fill, and `Layout` therefore renders none until it has
+  // content to put in one.
+  if (!visible) {
     return null;
   }
 

--- a/template-shell/src-app/app/layout/Layout.test.tsx
+++ b/template-shell/src-app/app/layout/Layout.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Layout } from './Layout';
+
+vi.mock('@/app/actions/bootstrapActions', () => ({ fetchCurrentUser: vi.fn() }));
+
+// Every slot Layout composes is stubbed, so what the assertions see is Layout's
+// own JSX and nothing the slots decide for themselves.
+vi.mock('./Header', () => ({ Header: () => <div data-testid="header" /> }));
+vi.mock('./Menu', () => ({ Menu: () => <div data-testid="menu" /> }));
+vi.mock('./Sidebar', () => ({ Sidebar: () => <div data-testid="sidebar" /> }));
+vi.mock('./Popup', () => ({ Popup: () => <div data-testid="popup" /> }));
+vi.mock('./Overlay', () => ({ Overlay: () => <div data-testid="overlay" /> }));
+vi.mock('./Screen', () => ({
+  Screen: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="screen">{children}</div>
+  ),
+}));
+
+// `Footer` is deliberately NOT stubbed: a footer mounted here would render for
+// real, so the case below fails on the empty band itself rather than on a stub
+// standing in for it. The state it reads says visible, which is the default a
+// shell that never touched `setFooterVisible` gets.
+vi.mock('@gears-frontx/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@gears-frontx/react')>()),
+  useAppSelector: () => ({ visible: true }),
+}));
+
+describe('Layout', () => {
+  it('mounts no footer, having no content to frame in one', () => {
+    render(<Layout>screen content</Layout>);
+
+    expect(screen.queryByRole('contentinfo')).toBeNull();
+  });
+
+  it('renders the screen children it is given', () => {
+    render(<Layout>screen content</Layout>);
+
+    expect(screen.getByTestId('screen').textContent).toBe('screen content');
+  });
+});

--- a/template-shell/src-app/app/layout/Layout.tsx
+++ b/template-shell/src-app/app/layout/Layout.tsx
@@ -9,7 +9,6 @@
 import React, { useEffect } from 'react';
 import { fetchCurrentUser } from '@/app/actions/bootstrapActions';
 import { Header } from './Header';
-import { Footer } from './Footer';
 import { Menu } from './Menu';
 import { Sidebar } from './Sidebar';
 import { Screen } from './Screen';
@@ -49,8 +48,12 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
         </div>
       </div>
 
-      {/* Footer - full width */}
-      <Footer />
+      {/*
+        No <Footer /> here on purpose: it frames the children it is given and
+        this layout has none for it, so mounting one would lay an empty
+        full-width band under every screen. A project with something to show
+        there renders `Footer` itself, with that content as its children.
+      */}
 
       {/* Popups */}
       <Popup />

--- a/template-shell/src-app/app/mfe/bootstrap.test.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.test.ts
@@ -28,7 +28,8 @@ vi.mock('@gears-frontx/react', async (importOriginal) => {
   const real = await importOriginal<Record<string, never>>();
   return {
     ...real,
-    screenDomain: { id: 'screen-domain' },
+    // `actions` is spread by the host bootstrap to append the chrome actions.
+    screenDomain: { id: 'screen-domain', actions: [] },
     sidebarDomain: { id: 'sidebar-domain' },
     popupDomain: { id: 'popup-domain' },
     overlayDomain: { id: 'overlay-domain' },
@@ -66,6 +67,22 @@ describe('bootstrapMFE (host-app)', () => {
     expect(registerDomain).toHaveBeenCalledTimes(4);
     expect(updateSharedProperty.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('opts the screen domain into the host chrome actions', async () => {
+    fetchSpy.mockResolvedValue(new Response('[]', { status: 200 }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { bootstrapMFE } = await import('./bootstrap');
+    const { CHROME_SET_MENU_COLLAPSED, CHROME_SET_THEME } = await import('./chrome-actions');
+    await bootstrapMFE(mockApp as never);
+
+    const [screenDeclaration] = registerDomain.mock.calls[0];
+    expect(screenDeclaration.actions).toEqual([CHROME_SET_THEME, CHROME_SET_MENU_COLLAPSED]);
+    // Making them domain actions must not make them mandatory for the
+    // extensions that mount into the domain.
+    expect(screenDeclaration.extensionsActions).toBeUndefined();
+    expect(registerSchema).toHaveBeenCalledTimes(2);
   });
 
   it('throws when the manifest fetch fails', async () => {

--- a/template-shell/src-app/app/mfe/bootstrap.test.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActionHandler } from '@gears-frontx/react';
 
 const registerDomain = vi.fn();
 const updateSharedProperty = vi.fn();
@@ -149,5 +150,93 @@ describe('bootstrapMFE (host-app)', () => {
     await bootstrapMFE(mockApp as never);
 
     expect(registerExtension).not.toHaveBeenCalled();
+  });
+
+  describe('screen-domain chrome handlers', () => {
+    /**
+     * Bootstraps with the given `app.actions` surface and returns the handlers
+     * the screen domain's implementation registered. The factory is taken from
+     * the `registerDomain` call rather than reconstructed, so the handlers
+     * under test are the ones the real bootstrap would have installed.
+     */
+    async function chromeHandlersFor(
+      actions: Record<string, unknown>,
+    ): Promise<Map<string, ActionHandler>> {
+      fetchSpy.mockResolvedValue(new Response('[]', { status: 200 }));
+
+      const { bootstrapMFE } = await import('./bootstrap');
+      await bootstrapMFE({ ...mockApp, actions } as never);
+
+      const handlers = new Map<string, ActionHandler>();
+      const [, screenFactory] = registerDomain.mock.calls[0];
+      screenFactory.build({
+        mounter: {},
+        registerHandler: (actionTypeId: string, handler: ActionHandler) => {
+          handlers.set(actionTypeId, handler);
+        },
+      });
+      return handlers;
+    }
+
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    it('applies the theme a set_theme action names through the host themes plugin', async () => {
+      const changeTheme = vi.fn();
+      const { CHROME_SET_THEME } = await import('./chrome-actions');
+
+      const handlers = await chromeHandlersFor({ changeTheme });
+      await handlers.get(CHROME_SET_THEME)?.handleAction(CHROME_SET_THEME, { themeId: 'dark' });
+
+      expect(changeTheme).toHaveBeenCalledWith({ themeId: 'dark' });
+    });
+
+    it('collapses the menu a set_menu_collapsed action names through the host layout plugin', async () => {
+      const toggleMenuCollapsed = vi.fn();
+      const { CHROME_SET_MENU_COLLAPSED } = await import('./chrome-actions');
+
+      const handlers = await chromeHandlersFor({ toggleMenuCollapsed });
+      await handlers
+        .get(CHROME_SET_MENU_COLLAPSED)
+        ?.handleAction(CHROME_SET_MENU_COLLAPSED, { collapsed: true });
+
+      expect(toggleMenuCollapsed).toHaveBeenCalledWith({ collapsed: true });
+    });
+
+    it.each([
+      ['set_theme', 'CHROME_SET_THEME', { themeId: 'dark' }],
+      ['set_menu_collapsed', 'CHROME_SET_MENU_COLLAPSED', { collapsed: true }],
+    ] as const)(
+      'resolves %s on a host that runs no plugin for it, leaving the chain to continue',
+      async (_name, constantName, payload) => {
+        const chromeActions = await import('./chrome-actions');
+        const actionTypeId = chromeActions[constantName];
+
+        // An empty `actions` surface is the shell that opted into neither the
+        // themes nor the layout plugin — the only case these handlers still
+        // guard against.
+        const handlers = await chromeHandlersFor({});
+
+        await expect(
+          handlers.get(actionTypeId)?.handleAction(actionTypeId, payload),
+        ).resolves.toBeUndefined();
+      },
+    );
+
+    it('refuses a set_theme payload carrying no theme id rather than driving the plugin with it', async () => {
+      const changeTheme = vi.fn();
+      const { CHROME_SET_THEME } = await import('./chrome-actions');
+
+      const handlers = await chromeHandlersFor({ changeTheme });
+
+      // The action schema marks `themeId` required, so the mediator refuses
+      // this action before any handler sees it; reaching the throw means schema
+      // and handler have drifted apart.
+      expect(() => handlers.get(CHROME_SET_THEME)?.handleAction(CHROME_SET_THEME, {})).toThrow(
+        /no string themeId/,
+      );
+      expect(changeTheme).not.toHaveBeenCalled();
+    });
   });
 });

--- a/template-shell/src-app/app/mfe/bootstrap.test.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.test.ts
@@ -178,6 +178,22 @@ describe('bootstrapMFE (host-app)', () => {
       return handlers;
     }
 
+    /**
+     * The handler registered for `actionTypeId`, or a failure naming what was
+     * not registered. `Map.get` returns `ActionHandler | undefined`, and calling
+     * it optionally would hand every case below an `undefined` in place of the
+     * call it meant to make: a screen domain that registered no handler at all
+     * then fails as whatever shape each assertion happens to reject, or does not
+     * fail, instead of as the missing registration it is.
+     */
+    function handlerFor(handlers: Map<string, ActionHandler>, actionTypeId: string): ActionHandler {
+      const handler = handlers.get(actionTypeId);
+      if (!handler) {
+        throw new Error(`the screen domain registered no handler for '${actionTypeId}'`);
+      }
+      return handler;
+    }
+
     beforeEach(() => {
       vi.spyOn(console, 'warn').mockImplementation(() => {});
     });
@@ -187,7 +203,9 @@ describe('bootstrapMFE (host-app)', () => {
       const { CHROME_SET_THEME } = await import('./chrome-actions');
 
       const handlers = await chromeHandlersFor({ changeTheme });
-      await handlers.get(CHROME_SET_THEME)?.handleAction(CHROME_SET_THEME, { themeId: 'dark' });
+      await handlerFor(handlers, CHROME_SET_THEME).handleAction(CHROME_SET_THEME, {
+        themeId: 'dark',
+      });
 
       expect(changeTheme).toHaveBeenCalledWith({ themeId: 'dark' });
     });
@@ -197,9 +215,10 @@ describe('bootstrapMFE (host-app)', () => {
       const { CHROME_SET_MENU_COLLAPSED } = await import('./chrome-actions');
 
       const handlers = await chromeHandlersFor({ toggleMenuCollapsed });
-      await handlers
-        .get(CHROME_SET_MENU_COLLAPSED)
-        ?.handleAction(CHROME_SET_MENU_COLLAPSED, { collapsed: true });
+      await handlerFor(handlers, CHROME_SET_MENU_COLLAPSED).handleAction(
+        CHROME_SET_MENU_COLLAPSED,
+        { collapsed: true },
+      );
 
       expect(toggleMenuCollapsed).toHaveBeenCalledWith({ collapsed: true });
     });
@@ -219,7 +238,7 @@ describe('bootstrapMFE (host-app)', () => {
         const handlers = await chromeHandlersFor({});
 
         await expect(
-          handlers.get(actionTypeId)?.handleAction(actionTypeId, payload),
+          handlerFor(handlers, actionTypeId).handleAction(actionTypeId, payload),
         ).resolves.toBeUndefined();
       },
     );
@@ -233,9 +252,9 @@ describe('bootstrapMFE (host-app)', () => {
       // The action schema marks `themeId` required, so the mediator refuses
       // this action before any handler sees it; reaching the throw means schema
       // and handler have drifted apart.
-      expect(() => handlers.get(CHROME_SET_THEME)?.handleAction(CHROME_SET_THEME, {})).toThrow(
-        /no string themeId/,
-      );
+      expect(() =>
+        handlerFor(handlers, CHROME_SET_THEME).handleAction(CHROME_SET_THEME, {}),
+      ).toThrow(/no string themeId/);
       expect(changeTheme).not.toHaveBeenCalled();
     });
   });

--- a/template-shell/src-app/app/mfe/bootstrap.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.ts
@@ -1,5 +1,3 @@
-// @cpt-flow:cpt-frontx-flow-request-lifecycle-query-client-lifecycle:p2
-
 /**
  * MFE Bootstrap
  *
@@ -198,7 +196,6 @@ class OptionalDomainFactory extends ExtensionDomainImplementationFactory {
   }
 }
 
-// @cpt-begin:cpt-frontx-dod-mfe-registry-mfe-schema-registration:p1:inst-1
 /**
  * Scoped schema registration: only register schemas whose $id matches an action ID
  * declared by at least one entry in this package. Action schemas are validated
@@ -263,7 +260,6 @@ function registerNonActionSchemas(
     }
   }
 }
-// @cpt-end:cpt-frontx-dod-mfe-registry-mfe-schema-registration:p1:inst-1
 
 /**
  * First pass over every package: register all non-action schemas on the gts
@@ -365,7 +361,6 @@ async function registerMfePackage(
  *
  * @param app - FrontX application instance
  */
-// @cpt-begin:cpt-frontx-flow-request-lifecycle-query-client-lifecycle:p2:inst-bootstrap-mfe
 export async function bootstrapMFE(app: FrontXApp): Promise<void> {
   const registry = app.mfeRegistry;
   if (!registry) {
@@ -420,4 +415,3 @@ export async function bootstrapMFE(app: FrontXApp): Promise<void> {
     await registerMfePackage(registry, config);
   }
 }
-// @cpt-end:cpt-frontx-flow-request-lifecycle-query-client-lifecycle:p2:inst-bootstrap-mfe

--- a/template-shell/src-app/app/mfe/bootstrap.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.ts
@@ -93,6 +93,34 @@ class HostContainerHooks implements ContainerHooks {
   }
 }
 
+// The two readers below state, to TypeScript, an invariant the type system
+// already enforces at runtime: `chrome-actions.ts` closes each chrome payload
+// around a single required field of a declared type, and the mediator validates
+// an action against that schema before it resolves any handler for it. So a
+// handler never sees a payload missing its field, and neither reader is a
+// refusal path a caller can trigger — reaching a throw means the schema and the
+// handler disagree about the payload, which is a defect in one of the two.
+
+function readThemeId(payload: Record<string, unknown> | undefined): string {
+  const themeId = payload?.themeId;
+  if (typeof themeId !== 'string') {
+    throw new Error(
+      '[MFE Bootstrap] set_theme payload has no string themeId; the action schema should have refused this action before it reached the handler',
+    );
+  }
+  return themeId;
+}
+
+function readCollapsed(payload: Record<string, unknown> | undefined): boolean {
+  const collapsed = payload?.collapsed;
+  if (typeof collapsed !== 'boolean') {
+    throw new Error(
+      '[MFE Bootstrap] set_menu_collapsed payload has no boolean collapsed; the action schema should have refused this action before it reached the handler',
+    );
+  }
+  return collapsed;
+}
+
 class ScreenDomainImpl extends ExtensionDomainImplementation {
   private readonly strategy: ExclusiveMountStrategy;
 
@@ -109,19 +137,19 @@ class ScreenDomainImpl extends ExtensionDomainImplementation {
       FRONTX_ACTION_MOUNT_EXT,
       ActionHandler.fromFunction((_t, p) => this.strategy.mount(p as ActionPayload)),
     );
-    // The host chrome a mounted screen may drive. Both resolve rather than
-    // throw on a payload or a plugin that is not there: a chrome request the
-    // shell cannot honour should leave the screen running, not fail its chain.
+    // The host chrome a mounted screen may drive. The one thing neither the
+    // action schema nor the domain declaration can decide is whether THIS host
+    // runs the plugin the action needs — `themes` and `layout` are both opt-in
+    // — so each handler resolves rather than throws when it does not: chrome is
+    // decoration around a screen, and a request the shell cannot honour should
+    // leave the screen running instead of failing its chain.
     ctx.registerHandler(
       CHROME_SET_THEME,
       ActionHandler.fromFunction((_t, p) => {
-        const themeId = p?.themeId;
-        if (typeof themeId !== 'string') {
-          console.warn('[MFE Bootstrap] set_theme ignored: payload.themeId is not a string');
-        } else if (typeof app.actions.changeTheme !== 'function') {
+        if (typeof app.actions.changeTheme !== 'function') {
           console.warn('[MFE Bootstrap] set_theme ignored: no themes plugin on this host');
         } else {
-          app.actions.changeTheme({ themeId });
+          app.actions.changeTheme({ themeId: readThemeId(p) });
         }
         return Promise.resolve();
       }),
@@ -129,15 +157,10 @@ class ScreenDomainImpl extends ExtensionDomainImplementation {
     ctx.registerHandler(
       CHROME_SET_MENU_COLLAPSED,
       ActionHandler.fromFunction((_t, p) => {
-        const collapsed = p?.collapsed;
-        if (typeof collapsed !== 'boolean') {
-          console.warn(
-            '[MFE Bootstrap] set_menu_collapsed ignored: payload.collapsed is not a boolean',
-          );
-        } else if (typeof app.actions.toggleMenuCollapsed !== 'function') {
+        if (typeof app.actions.toggleMenuCollapsed !== 'function') {
           console.warn('[MFE Bootstrap] set_menu_collapsed ignored: no layout plugin on this host');
         } else {
-          app.actions.toggleMenuCollapsed({ collapsed });
+          app.actions.toggleMenuCollapsed({ collapsed: readCollapsed(p) });
         }
         return Promise.resolve();
       }),

--- a/template-shell/src-app/app/mfe/bootstrap.ts
+++ b/template-shell/src-app/app/mfe/bootstrap.ts
@@ -41,6 +41,11 @@ import type {
   ActionPayload,
   MountStrategy,
 } from '@gears-frontx/react';
+import {
+  CHROME_ACTION_SCHEMAS,
+  CHROME_SET_MENU_COLLAPSED,
+  CHROME_SET_THEME,
+} from './chrome-actions';
 
 const MFE_MANIFESTS_URL = '/generated-mfe-manifests.json';
 
@@ -93,12 +98,51 @@ class HostContainerHooks implements ContainerHooks {
 class ScreenDomainImpl extends ExtensionDomainImplementation {
   private readonly strategy: ExclusiveMountStrategy;
 
-  constructor(ctx: DomainContext, hooks: ContainerHooks, registry: MfeRegistry, domainId: string) {
+  constructor(
+    ctx: DomainContext,
+    hooks: ContainerHooks,
+    registry: MfeRegistry,
+    domainId: string,
+    app: FrontXApp,
+  ) {
     super();
     this.strategy = new ExclusiveMountStrategy(ctx.mounter, hooks, registry, domainId);
     ctx.registerHandler(
       FRONTX_ACTION_MOUNT_EXT,
       ActionHandler.fromFunction((_t, p) => this.strategy.mount(p as ActionPayload)),
+    );
+    // The host chrome a mounted screen may drive. Both resolve rather than
+    // throw on a payload or a plugin that is not there: a chrome request the
+    // shell cannot honour should leave the screen running, not fail its chain.
+    ctx.registerHandler(
+      CHROME_SET_THEME,
+      ActionHandler.fromFunction((_t, p) => {
+        const themeId = p?.themeId;
+        if (typeof themeId !== 'string') {
+          console.warn('[MFE Bootstrap] set_theme ignored: payload.themeId is not a string');
+        } else if (typeof app.actions.changeTheme !== 'function') {
+          console.warn('[MFE Bootstrap] set_theme ignored: no themes plugin on this host');
+        } else {
+          app.actions.changeTheme({ themeId });
+        }
+        return Promise.resolve();
+      }),
+    );
+    ctx.registerHandler(
+      CHROME_SET_MENU_COLLAPSED,
+      ActionHandler.fromFunction((_t, p) => {
+        const collapsed = p?.collapsed;
+        if (typeof collapsed !== 'boolean') {
+          console.warn(
+            '[MFE Bootstrap] set_menu_collapsed ignored: payload.collapsed is not a boolean',
+          );
+        } else if (typeof app.actions.toggleMenuCollapsed !== 'function') {
+          console.warn('[MFE Bootstrap] set_menu_collapsed ignored: no layout plugin on this host');
+        } else {
+          app.actions.toggleMenuCollapsed({ collapsed });
+        }
+        return Promise.resolve();
+      }),
     );
   }
 
@@ -129,9 +173,18 @@ class OptionalDomainImpl extends ExtensionDomainImplementation {
 }
 
 class ScreenDomainFactory extends ExtensionDomainImplementationFactory {
-  constructor(private readonly registry: MfeRegistry) { super(); }
+  constructor(
+    private readonly registry: MfeRegistry,
+    private readonly app: FrontXApp,
+  ) { super(); }
   build(ctx: DomainContext): ScreenDomainImpl {
-    return new ScreenDomainImpl(ctx, new HostContainerHooks(), this.registry, screenDomain.id);
+    return new ScreenDomainImpl(
+      ctx,
+      new HostContainerHooks(),
+      this.registry,
+      screenDomain.id,
+      this.app,
+    );
   }
 }
 
@@ -319,7 +372,22 @@ export async function bootstrapMFE(app: FrontXApp): Promise<void> {
     throw new Error('[MFE Bootstrap] mfeRegistry is not available on app instance');
   }
 
-  registry.registerDomain(screenDomain, new ScreenDomainFactory(registry));
+  // The chrome action schemas must be on the type system before any action
+  // carrying one of these types can be dispatched, and `registerDomain` is the
+  // first thing a mounted screen can act against.
+  for (const schema of CHROME_ACTION_SCHEMAS) {
+    registry.typeSystem.registerSchema(schema);
+  }
+
+  // The shipped `screenDomain` is spread rather than edited: the framework
+  // declaration stays the default every template gets, and this shell opts
+  // itself into the two chrome actions its handlers above answer. The
+  // declaration's `extensionsActions` is deliberately untouched - listing them
+  // there would make them mandatory for every screen extension in the repo.
+  registry.registerDomain(
+    { ...screenDomain, actions: [...screenDomain.actions, CHROME_SET_THEME, CHROME_SET_MENU_COLLAPSED] },
+    new ScreenDomainFactory(registry, app),
+  );
   registry.registerDomain(sidebarDomain, new OptionalDomainFactory(registry, sidebarDomain.id));
   registry.registerDomain(popupDomain, new OptionalDomainFactory(registry, popupDomain.id));
   registry.registerDomain(overlayDomain, new OptionalDomainFactory(registry, overlayDomain.id));

--- a/template-shell/src-app/app/mfe/chrome-actions.test.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { gtsPlugin, screenDomain, sidebarDomain } from '@gears-frontx/react';
+import {
+  FRONTX_SCREEN_DOMAIN,
+  gtsPlugin,
+  screenDomain,
+  sidebarDomain,
+  type JSONSchema,
+} from '@gears-frontx/react';
 // The GTS solution schemas are application-layer and owned by the template
 // package; `@gears-frontx/react` stopped re-exporting them so that framework and
 // react resolve for a consumer outside this workspace (#601). `main.tsx` reaches
@@ -30,6 +36,28 @@ const CHROME_ACTIONS = [
   { type: CHROME_SET_THEME, payload: { themeId: 'dark' } },
   { type: CHROME_SET_MENU_COLLAPSED, payload: { collapsed: true } },
 ] as const;
+
+/** The schema carrying `actionTypeId`, found by its `$id` rather than by
+ * position, so the pairing is asserted instead of assumed. */
+function schemaFor(actionTypeId: string): JSONSchema {
+  const schema = CHROME_ACTION_SCHEMAS.find(
+    (candidate) => candidate.$id === `gts://${actionTypeId}`,
+  );
+  if (!schema) {
+    throw new Error(`no chrome action schema carries the id 'gts://${actionTypeId}'`);
+  }
+  return schema;
+}
+
+/** The `target` ref a schema declares, narrowed off the index signature
+ * `JSONSchema` ends in rather than cast through it. */
+function targetRefOf(schema: JSONSchema): string {
+  const ref = schema.properties?.target?.['x-gts-ref'];
+  if (typeof ref !== 'string') {
+    throw new Error(`the schema '${schema.$id ?? '(no id)'}' declares no string target x-gts-ref`);
+  }
+  return ref;
+}
 
 beforeAll(() => {
   // The process-wide `gtsPlugin` singleton, as the app itself uses it. Nothing
@@ -69,4 +97,29 @@ describe('CHROME_ACTION_SCHEMAS', () => {
       );
     },
   );
+});
+
+/**
+ * The `$id` and `target` inside the JSON schema files are literal strings, while
+ * the rest of the shell dispatches on the constants this module exports and
+ * registers the domain named by `FRONTX_SCREEN_DOMAIN`. Nothing in the type
+ * system ties a literal to a constant, and drift between them is silent: a
+ * schema whose `$id` no longer matches an action type is simply never the one
+ * the mediator resolves.
+ */
+describe('the chrome action JSON schemas against the constants they are addressed by', () => {
+  it('covers every exported action type, and declares no schema beyond them', () => {
+    const declaredIds = CHROME_ACTION_SCHEMAS.map((schema) => schema.$id).sort();
+
+    expect(declaredIds).toEqual(
+      [CHROME_SET_THEME, CHROME_SET_MENU_COLLAPSED].map((type) => `gts://${type}`).sort(),
+    );
+  });
+
+  it.each([
+    ['set_theme', CHROME_SET_THEME],
+    ['set_menu_collapsed', CHROME_SET_MENU_COLLAPSED],
+  ])('points %s at the screen domain the shell actually registers', (_name, actionTypeId) => {
+    expect(targetRefOf(schemaFor(actionTypeId))).toBe(FRONTX_SCREEN_DOMAIN);
+  });
 });

--- a/template-shell/src-app/app/mfe/chrome-actions.test.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.test.ts
@@ -7,14 +7,16 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import { gtsPlugin, screenDomain, sidebarDomain } from '@gears-frontx/react';
+// The GTS solution schemas are application-layer and owned by the template
+// package; `@gears-frontx/react` stopped re-exporting them so that framework and
+// react resolve for a consumer outside this workspace (#601). `main.tsx` reaches
+// for them the same way.
 import {
   extensionScreenSchema,
-  gtsPlugin,
   languageSchema,
-  screenDomain,
-  sidebarDomain,
   themeSchema,
-} from '@gears-frontx/react';
+} from '@gears-frontx/frontx-template-shell';
 
 import {
   CHROME_ACTION_SCHEMAS,

--- a/template-shell/src-app/app/mfe/chrome-actions.test.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Covers the admission half of the chrome contract: which domain a
+ * microfrontend may aim a chrome action at. Exercised against the real type
+ * system rather than a double, because the behaviour under test is `x-gts-ref`
+ * resolution inside gts-ts — the same call the mediator makes on every action
+ * of a chain before any handler is looked up.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  extensionScreenSchema,
+  gtsPlugin,
+  languageSchema,
+  screenDomain,
+  sidebarDomain,
+  themeSchema,
+} from '@gears-frontx/react';
+
+import {
+  CHROME_ACTION_SCHEMAS,
+  CHROME_SET_MENU_COLLAPSED,
+  CHROME_SET_THEME,
+} from './chrome-actions';
+
+/** Both chrome action types with a payload their schema accepts, so a case
+ * that fails does so over the target and nothing else. */
+const CHROME_ACTIONS = [
+  { type: CHROME_SET_THEME, payload: { themeId: 'dark' } },
+  { type: CHROME_SET_MENU_COLLAPSED, payload: { collapsed: true } },
+] as const;
+
+beforeAll(() => {
+  // The process-wide `gtsPlugin` singleton, as the app itself uses it. Nothing
+  // registered here is case-specific: the schemas and the two domain instances
+  // are static, registration is idempotent, and the actions the cases below
+  // register are anonymous, so no case can leave state another one reads.
+  //
+  // The shared-property and screen-extension schemas come first because both
+  // layout domain instances reference them; without them the domains fail their
+  // own admission and every case would refuse over a missing domain rather than
+  // over the target pattern.
+  gtsPlugin.registerSchema(themeSchema);
+  gtsPlugin.registerSchema(languageSchema);
+  gtsPlugin.registerSchema(extensionScreenSchema);
+  for (const schema of CHROME_ACTION_SCHEMAS) {
+    gtsPlugin.registerSchema(schema);
+  }
+  gtsPlugin.register(screenDomain);
+  gtsPlugin.register(sidebarDomain);
+});
+
+describe('CHROME_ACTION_SCHEMAS', () => {
+  it.each(CHROME_ACTIONS)('admits $type aimed at the screen domain', ({ type, payload }) => {
+    expect(() => gtsPlugin.register({ type, target: screenDomain.id, payload })).not.toThrow();
+  });
+
+  it.each(CHROME_ACTIONS)(
+    'refuses $type aimed at a domain that opts into no chrome handler, naming the domain it needed',
+    ({ type, payload }) => {
+      // The sidebar domain is registered and valid — it simply is not the
+      // domain these actions are declared against. The refusal has to come from
+      // the target ref here, at admission, rather than from the mediator finding
+      // no handler two layers further in, which would name a missing handler
+      // instead of the domain the caller should have targeted.
+      expect(() => gtsPlugin.register({ type, target: sidebarDomain.id, payload })).toThrow(
+        new RegExp(`does not match pattern '${screenDomain.id}'`),
+      );
+    },
+  );
+});

--- a/template-shell/src-app/app/mfe/chrome-actions.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.ts
@@ -15,7 +15,10 @@
  * its own screen-domain declaration.
  */
 
-import { FRONTX_SCREEN_DOMAIN, type JSONSchema } from '@gears-frontx/react';
+import type { JSONSchema } from '@gears-frontx/react';
+
+import setMenuCollapsedActionSchema from './gts/frontx.screensets/schemas/chrome/set_menu_collapsed.v1.json';
+import setThemeActionSchema from './gts/frontx.screensets/schemas/chrome/set_theme.v1.json';
 
 /** Applies a registered theme by id - the payload carries `themeId`. */
 export const CHROME_SET_THEME =
@@ -26,54 +29,22 @@ export const CHROME_SET_MENU_COLLAPSED =
   'gts.frontx.mfes.comm.action.v1~frontx.screensets.chrome.set_menu_collapsed.v1~';
 
 /**
- * Modelled on the shipped `mount_ext.v1.json`: a domain-targeted action, so
- * `target` refs a domain rather than an extension, and the payload is closed
- * around the single field each action needs.
+ * The two schemas themselves are JSON, under
+ * `gts/frontx.screensets/schemas/chrome/`, where the directory path spells the
+ * GTS id the way `packages/gts-plugin/src/frontx.mfes/schemas/ext/` and the
+ * framework's own `gts/frontx.screensets/instances/domains/` do. Each file
+ * carries its own `$comment`s, including why its `target` names the screen
+ * domain rather than any domain; this module only collects them.
  *
- * The ref names `FRONTX_SCREEN_DOMAIN` itself rather than the
- * `gts.frontx.mfes.ext.domain.v1~*` wildcard `mount_ext.v1.json` uses: the
- * screen domain is the one that opts into these handlers (see `bootstrap.ts`),
- * and sidebar, popup and overlay register none. Under the wildcard a chain
- * aimed at one of those passes admission and is refused two layers later by
- * `NoHandlerForActionTargetError`, which names a missing handler rather than
- * the domain the caller should have targeted; named here, the mismatch is
- * reported against the pattern at the moment the action is validated.
+ * The cast is the same one both of those loaders make: a JSON module's inferred
+ * type is the literal shape of the file, which no `JSONSchema` signature can be
+ * written to accept.
  *
- * These must reach the type system before `registerDomain`, because the
- * mediator resolves an action's schema from its `type` at dispatch time and
- * rejects an action it cannot validate.
+ * They must reach the type system before `registerDomain`, because the mediator
+ * resolves an action's schema from its `type` at dispatch time and rejects an
+ * action it cannot validate.
  */
 export const CHROME_ACTION_SCHEMAS: JSONSchema[] = [
-  {
-    $id: `gts://${CHROME_SET_THEME}`,
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    properties: {
-      type: { 'x-gts-ref': '/$id' },
-      target: { 'x-gts-ref': FRONTX_SCREEN_DOMAIN },
-      payload: {
-        type: 'object',
-        properties: { themeId: { type: 'string' } },
-        required: ['themeId'],
-      },
-      timeout: { type: 'number', minimum: 1 },
-    },
-    required: ['type', 'target', 'payload'],
-  },
-  {
-    $id: `gts://${CHROME_SET_MENU_COLLAPSED}`,
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    properties: {
-      type: { 'x-gts-ref': '/$id' },
-      target: { 'x-gts-ref': FRONTX_SCREEN_DOMAIN },
-      payload: {
-        type: 'object',
-        properties: { collapsed: { type: 'boolean' } },
-        required: ['collapsed'],
-      },
-      timeout: { type: 'number', minimum: 1 },
-    },
-    required: ['type', 'target', 'payload'],
-  },
+  setThemeActionSchema as JSONSchema,
+  setMenuCollapsedActionSchema as JSONSchema,
 ];

--- a/template-shell/src-app/app/mfe/chrome-actions.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.ts
@@ -1,0 +1,70 @@
+/**
+ * The host chrome contract: the actions a microfrontend may dispatch upward to
+ * change the shell around it.
+ *
+ * A microfrontend runs in its own module graph (per-load blob instantiation,
+ * ADR-0011), so it has no handle on the host app and no shared event bus to
+ * emit on. The actions chain is the one declared upward channel, and it carries
+ * a payload. These two action types are what this shell chooses to expose over
+ * it; the handlers live in `bootstrap.ts` and call the public `app.actions`
+ * surface.
+ *
+ * Both are app-layer, not framework: `screenDomain` in
+ * `@gears-frontx/framework` ships to every template, and a host that does not
+ * want its chrome driven from a microfrontend simply does not spread these into
+ * its own screen-domain declaration.
+ */
+
+import type { JSONSchema } from '@gears-frontx/react';
+
+/** Applies a registered theme by id - the payload carries `themeId`. */
+export const CHROME_SET_THEME =
+  'gts.frontx.mfes.comm.action.v1~frontx.screensets.chrome.set_theme.v1~';
+
+/** Collapses or expands the shell's main menu - the payload carries `collapsed`. */
+export const CHROME_SET_MENU_COLLAPSED =
+  'gts.frontx.mfes.comm.action.v1~frontx.screensets.chrome.set_menu_collapsed.v1~';
+
+/**
+ * Modelled on the shipped `mount_ext.v1.json`: a domain-targeted action, so
+ * `target` refs the domain type rather than an extension, and the payload is
+ * closed around the single field each action needs.
+ *
+ * These must reach the type system before `registerDomain`, because the
+ * mediator resolves an action's schema from its `type` at dispatch time and
+ * rejects an action it cannot validate.
+ */
+export const CHROME_ACTION_SCHEMAS: JSONSchema[] = [
+  {
+    $id: `gts://${CHROME_SET_THEME}`,
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      type: { 'x-gts-ref': '/$id' },
+      target: { 'x-gts-ref': 'gts.frontx.mfes.ext.domain.v1~*' },
+      payload: {
+        type: 'object',
+        properties: { themeId: { type: 'string' } },
+        required: ['themeId'],
+      },
+      timeout: { type: 'number', minimum: 1 },
+    },
+    required: ['type', 'target', 'payload'],
+  },
+  {
+    $id: `gts://${CHROME_SET_MENU_COLLAPSED}`,
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      type: { 'x-gts-ref': '/$id' },
+      target: { 'x-gts-ref': 'gts.frontx.mfes.ext.domain.v1~*' },
+      payload: {
+        type: 'object',
+        properties: { collapsed: { type: 'boolean' } },
+        required: ['collapsed'],
+      },
+      timeout: { type: 'number', minimum: 1 },
+    },
+    required: ['type', 'target', 'payload'],
+  },
+];

--- a/template-shell/src-app/app/mfe/chrome-actions.ts
+++ b/template-shell/src-app/app/mfe/chrome-actions.ts
@@ -15,7 +15,7 @@
  * its own screen-domain declaration.
  */
 
-import type { JSONSchema } from '@gears-frontx/react';
+import { FRONTX_SCREEN_DOMAIN, type JSONSchema } from '@gears-frontx/react';
 
 /** Applies a registered theme by id - the payload carries `themeId`. */
 export const CHROME_SET_THEME =
@@ -27,8 +27,17 @@ export const CHROME_SET_MENU_COLLAPSED =
 
 /**
  * Modelled on the shipped `mount_ext.v1.json`: a domain-targeted action, so
- * `target` refs the domain type rather than an extension, and the payload is
- * closed around the single field each action needs.
+ * `target` refs a domain rather than an extension, and the payload is closed
+ * around the single field each action needs.
+ *
+ * The ref names `FRONTX_SCREEN_DOMAIN` itself rather than the
+ * `gts.frontx.mfes.ext.domain.v1~*` wildcard `mount_ext.v1.json` uses: the
+ * screen domain is the one that opts into these handlers (see `bootstrap.ts`),
+ * and sidebar, popup and overlay register none. Under the wildcard a chain
+ * aimed at one of those passes admission and is refused two layers later by
+ * `NoHandlerForActionTargetError`, which names a missing handler rather than
+ * the domain the caller should have targeted; named here, the mismatch is
+ * reported against the pattern at the moment the action is validated.
  *
  * These must reach the type system before `registerDomain`, because the
  * mediator resolves an action's schema from its `type` at dispatch time and
@@ -41,7 +50,7 @@ export const CHROME_ACTION_SCHEMAS: JSONSchema[] = [
     type: 'object',
     properties: {
       type: { 'x-gts-ref': '/$id' },
-      target: { 'x-gts-ref': 'gts.frontx.mfes.ext.domain.v1~*' },
+      target: { 'x-gts-ref': FRONTX_SCREEN_DOMAIN },
       payload: {
         type: 'object',
         properties: { themeId: { type: 'string' } },
@@ -57,7 +66,7 @@ export const CHROME_ACTION_SCHEMAS: JSONSchema[] = [
     type: 'object',
     properties: {
       type: { 'x-gts-ref': '/$id' },
-      target: { 'x-gts-ref': 'gts.frontx.mfes.ext.domain.v1~*' },
+      target: { 'x-gts-ref': FRONTX_SCREEN_DOMAIN },
       payload: {
         type: 'object',
         properties: { collapsed: { type: 'boolean' } },

--- a/template-shell/src-app/app/mfe/gts/frontx.screensets/schemas/chrome/set_menu_collapsed.v1.json
+++ b/template-shell/src-app/app/mfe/gts/frontx.screensets/schemas/chrome/set_menu_collapsed.v1.json
@@ -1,0 +1,33 @@
+{
+  "$id": "gts://gts.frontx.mfes.comm.action.v1~frontx.screensets.chrome.set_menu_collapsed.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Schema for the host chrome's set_menu_collapsed action. Derives from action.v1 and requires the desired collapsed state in payload.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "x-gts-ref": "/$id",
+      "$comment": "Self-reference to this action's schema type ID"
+    },
+    "target": {
+      "x-gts-ref": "gts.frontx.mfes.ext.domain.v1~frontx.screensets.layout.screen.v1",
+      "$comment": "The screen domain specifically, not any domain the way mount_ext.v1.json allows: the screen domain is the one that registers a handler for this action (see bootstrap.ts), so a chain aimed at sidebar, popup or overlay is refused here instead of two layers later as a missing handler"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "collapsed": {
+          "type": "boolean",
+          "$comment": "Whether the shell's main menu should end up collapsed"
+        }
+      },
+      "required": ["collapsed"],
+      "$comment": "Action payload closed around the single field the handler forwards"
+    },
+    "timeout": {
+      "type": "number",
+      "minimum": 1,
+      "$comment": "Optional timeout override in milliseconds"
+    }
+  },
+  "required": ["type", "target", "payload"]
+}

--- a/template-shell/src-app/app/mfe/gts/frontx.screensets/schemas/chrome/set_theme.v1.json
+++ b/template-shell/src-app/app/mfe/gts/frontx.screensets/schemas/chrome/set_theme.v1.json
@@ -1,0 +1,33 @@
+{
+  "$id": "gts://gts.frontx.mfes.comm.action.v1~frontx.screensets.chrome.set_theme.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Schema for the host chrome's set_theme action. Derives from action.v1 and requires the id of a host-registered theme in payload.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "x-gts-ref": "/$id",
+      "$comment": "Self-reference to this action's schema type ID"
+    },
+    "target": {
+      "x-gts-ref": "gts.frontx.mfes.ext.domain.v1~frontx.screensets.layout.screen.v1",
+      "$comment": "The screen domain specifically, not any domain the way mount_ext.v1.json allows: the screen domain is the one that registers a handler for this action (see bootstrap.ts), so a chain aimed at sidebar, popup or overlay is refused here instead of two layers later as a missing handler"
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "themeId": {
+          "type": "string",
+          "$comment": "Id of the theme to apply, as registered on the host theme registry"
+        }
+      },
+      "required": ["themeId"],
+      "$comment": "Action payload closed around the single field the handler forwards"
+    },
+    "timeout": {
+      "type": "number",
+      "minimum": 1,
+      "$comment": "Optional timeout override in milliseconds"
+    }
+  },
+  "required": ["type", "target", "payload"]
+}


### PR DESCRIPTION
## Description

`develop`'s Template Validate job has been red since the ui-kit 0.4 port landed. The composed shell+overlay tree stopped type-checking the moment the ecosystem's `@gears-frontx/ui-kit` moved to 0.4.0-alpha.0: the four uikit demo screens in `demo-mfe` were still written against the pre-0.4 `Field` (which took `name`/`disabled`), `FieldError` (which took `match`), and `Badge` (which took `dot`/`muted`) - none of which the kit ships anymore. Two composed-overlay files also carried lint debt (`set-state-in-effect` in the widgets fixture's ping indicator, `no-useless-assignment` in the demo screens' `CategoryMenu`) that only surfaces once the overlay is linted as part of the assembled tree.

Separately, @GeraBart left two low-severity notes on #591 that never got addressed: `Marker` doesn't absorb an explicit `variant={null}` the way `item.tsx` already guards the equivalent case, and `NativeSelectOptGroup` reuses the `<option>` class instead of having its own.

And a batch of small template-hygiene fixes has been sitting unmerged on `demo/uikit-inbox` - a footer strip that renders when nothing feeds it, a missing `build:packages` pre-script wiring, the host chrome actions the framework's screen domain didn't declare yet, and a seeded mock-user name that disagreed with what a workspace microfrontend already showed for the same person.

## What changed

Migrated the four demo screens to the kit's actual 0.4 API rather than papering over the type errors - every label now points at its control's own id (`Field` carries no id-wiring anymore), the profile form's inputs own their `disabled` state, the email demo reads validity on blur instead of relying on `FieldError`'s removed `match`, and the badge row demonstrates what the port actually added (weights, a link-rendered badge) instead of the removed `dot`/`muted`. Cleared the `CategoryMenu` lint debt - its element lookup collapsed into the ternary it always was. The widgets fixture's `set-state-in-effect` was fixed on `develop` in the meantime (#594) with the same `useSyncExternalStore` shape and a stricter cleanup guard, so this PR no longer touches that file.

Fixed both of @GeraBart's notes: `Marker` resolves an explicit `null` variant to `'default'` up front, in both the CSS class and the `data-variant` attribute, the same way `item.tsx` already does; `NativeSelectOptGroup` now styles on its own `.optgroup` class. Both closed out with a test. Since this changed `packages/ui-kit`'s `src/`, it also carries the version bump `policy:version-bump-on-change` requires (0.4.0-alpha.1 -> 0.4.0-alpha.2 - develop published alpha.1 in the meantime) and the matching pin bump on its two consumers, kept in the same commit so neither gate is red in between.

Cherry-picked five of the hygiene fixes from `demo/uikit-inbox` (the sixth - an eslint-ignore for `template-design-guardrails/` - was left out: that directory doesn't exist on current `develop`, so the fix is moot there). Composing them onto the current tree surfaced two things that weren't visible on the source branch in isolation: `demo-mfe` ships its own parallel accounts mock, and it silently agreed with the shell's seeded identity only because both happened to say "Demo User" - once the shell's rename to "Alex Rivera" landed, the composed tree's contract test failed on the mismatch, so the same rename was carried into `demo-mfe`'s copy. And the manifest change that lets `template-mfe` claim its five packages individually instead of the whole `mfe_packages/` directory introduced the template's first file-shaped `exclusiveSubtree` entry (`README.md`) - which the CI composition script had only ever handled as a directory (`[ -d ... ]`, `cp -R src/. dest/`), so it failed the job before composing anything. Fixed the script to branch on what the tree actually has. A companion CLI test also needed updating: the conflict-checker never merges overlapping claims, so a synthetic contestant against `template-mfe`'s now-five subtrees correctly reports five conflicts instead of the one it used to, and the test's expectation is now derived from the real on-disk manifest (the same pattern the suite's own Fixture 5 already uses for the shell) instead of a snapshot.

Review follow-ups: the residue `@cpt-` markers in the two touched shell files are stripped in a marker-only commit, as ADR-0033 asks of any change that modifies an already-marked template file; the email demo's validation messages go through `t()` like the rest of the screen, keyed by the validity reason so a language switch re-renders them; and `template-shell`'s manifest version is bumped alongside `template-mfe`'s.

Verified locally: `packages/ui-kit` (vitest 910/910, build, type-check); a full local equivalent of "Validate shell + overlay composition" - fresh `npm install`, `build`, `type-check`, `arch:deps`, `lint`, `test:unit` - built against the locally packed `ui-kit` output at the bumped version (it isn't published yet - see below); the CLI suite (507/507); and all three `policy:*` gates plus `npm ci --dry-run` at the root.

## Risks / open questions

`@gears-frontx/ui-kit@0.4.0-alpha.2` isn't published yet - it publishes automatically on merge to `develop` (`publish-packages.yml`). Until then, the registry-install step of Template Validate's "Validate shell + overlay composition" job can't resolve the new pin from the real npm registry, the same two-phase gap this repo's own history shows for 0.4.0-alpha.0 itself (bumped in `88e77b9b`, the matching pin caught up separately once it was actually published, in `83c2a635`). That step should go green once this PR merges and the publish workflow runs; nothing else in it depends on the unpublished version.

Closes review threads: https://github.com/constructorfabric/gears-frontx/pull/591#discussion_r3869081148, https://github.com/constructorfabric/gears-frontx/pull/591#discussion_r3869081156



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host controls for changing the application theme and collapsing the menu.
  * Added email validation on blur, with localized messages across supported languages.
  * Improved form accessibility by linking labels and inputs consistently.
  * Updated UI kit demonstrations for badge tones, weights, and link rendering.

* **Bug Fixes**
  * Ensured null variants use consistent default styling.
  * Corrected optgroup styling in native selects.
  * Updated footer rendering behavior.
  * Prevented template overlays from overwriting existing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->