### PR TITLE
fix: render chart's per-instance style via JSX children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9164,7 +9164,7 @@
     },
     "packages/cli": {
       "name": "@gears-frontx/cli",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0-alpha.3",
       "license": "MIT",
       "bin": {
         "frontx": "dist/cli.js"
@@ -9179,7 +9179,7 @@
     },
     "packages/cyber-pilot-kit-frontx": {
       "name": "@gears-frontx/cyber-pilot-kit-frontx",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "smol-toml": "^1.6.1"
@@ -9246,7 +9246,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.4.0-alpha.0",
+      "version": "0.4.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0-alpha.1",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/ui-kit/src/components/chart/chart.md
+++ b/packages/ui-kit/src/components/chart/chart.md
@@ -127,6 +127,14 @@ plain colour syntax and neither rule is noticeable. If you render
 normalized id on your own `data-chart` attribute or the selector will not
 match it.
 
+`ChartStyle` renders its per-instance CSS as the `<style>` element's JSX
+children (`<style>{css}</style>`) rather than through
+`dangerouslySetInnerHTML`, which is what upstream and most React chart
+implementations use. Children get React's own server-side `</style`
+escaping (so the string can't break out of the tag in SSR output) and are
+rendered client-side as an inert Text node — a stronger guarantee than
+`dangerouslySetInnerHTML` offers, for the same runtime-built string.
+
 ## Examples
 
 ```tsx

--- a/packages/ui-kit/src/components/chart/chart.tsx
+++ b/packages/ui-kit/src/components/chart/chart.tsx
@@ -92,17 +92,17 @@ export type ChartContainerProps = Omit<ComponentProps<'div'>, 'className' | 'chi
 /*
  * Everything ChartStyle interpolates into its <style> tag is
  * consumer-supplied — the chart's `id`, every `ChartConfig` key, every
- * colour string — and none of it is escaped by React, which treats
- * `dangerouslySetInnerHTML` as opaque text. An id of `x] { } body {
- * display: none` would end the selector and start a rule of its own; a
- * colour of `red; } body { … }` does the same one line down; either could
- * carry a literal `</style>` and leave CSS altogether. So the two shapes
- * that reach the stylesheet are constrained rather than trusted:
- * identifiers are reduced to a character set that cannot express any of
- * those, and colour VALUES (which have no such small alphabet — they run
- * from `red` to `color-mix(in oklab, …)`) are checked for the characters
- * that would let one escape its own declaration, and dropped whole if
- * they carry any.
+ * colour string — and React does not parse or validate CSS syntax within
+ * it, whether the string reaches the tag as JSX children or via
+ * `dangerouslySetInnerHTML`. An id of `x] { } body { display: none` would
+ * end the selector and start a rule of its own; a colour of `red; } body {
+ * … }` does the same one line down; either could carry a literal
+ * `</style>` and try to leave CSS altogether. So the two shapes that reach
+ * the stylesheet are constrained rather than trusted: identifiers are
+ * reduced to a character set that cannot express any of those, and colour
+ * VALUES (which have no such small alphabet — they run from `red` to
+ * `color-mix(in oklab, …)`) are checked for the characters that would let
+ * one escape its own declaration, and dropped whole if they carry any.
  */
 const CSS_IDENT_UNSAFE = /[^a-zA-Z0-9_-]/g;
 
@@ -204,9 +204,18 @@ ${darkDeclarations}
 
   // Per-instance, consumer-supplied colors have no other way to reach a
   // scoped CSS custom property — there is no static class this kit's build
-  // could hash for an arbitrary runtime string. Same trade-off upstream
-  // makes with its own dangerouslySetInnerHTML.
-  return <style dangerouslySetInnerHTML={{ __html: css }} />;
+  // could hash for an arbitrary runtime string. Passing `css` as the
+  // `<style>` element's JSX children — rather than through
+  // `dangerouslySetInnerHTML` — gets it React 19's own `</style`-escaping on
+  // the server (so a value containing a literal `</style><script>…` cannot
+  // break out of the tag in SSR output) and, on the client, lands it as a
+  // single inert Text node that is never parsed as markup. Either way it
+  // cannot execute as script. `isSafeCssValue`/`cssIdentifier` above still
+  // matter here even though they're no longer the primary XSS defense: they
+  // keep `<`/`>` out of the string entirely, which is what keeps server and
+  // client output identical (a raw `</style` would escape only on the
+  // server, producing a hydration mismatch).
+  return <style>{css}</style>;
 }
 
 export const ChartTooltip = RechartsPrimitive.Tooltip;

--- a/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
@@ -16,7 +16,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "@gears-frontx/react": "0.2.0-alpha.3",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.0",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.1",
     "@tanstack/react-query": "5.90.21"
   },
   "devDependencies": {

--- a/template-mfe/src-app/mfe_packages/demo-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@gears-frontx/react": "0.2.0-alpha.3",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.0",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.1",
     "@tanstack/react-query": "5.90.21",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved chart styling safeguards by rendering generated CSS through React-managed style content.
  * Preserved sanitization of CSS identifiers and values to help prevent injection risks and hydration mismatches.

* **Documentation**
  * Expanded guidance on CSS injection behavior, server-side escaping, and client-side handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->