### PR TITLE
feat: adopt the Studio blue rebrand for ui-kit theme tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9324,7 +9324,7 @@
     },
     "packages/ui-kit": {
       "name": "@gears-frontx/ui-kit",
-      "version": "0.4.0-alpha.2",
+      "version": "0.4.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",

--- a/packages/ui-kit/demo/examples/chart.tsx
+++ b/packages/ui-kit/demo/examples/chart.tsx
@@ -37,18 +37,23 @@ import { Row, Section } from '../shared';
  * from the ChartConfig below. The palette entries themselves are kit theme
  * tokens: the kit defines no --chart-1..5 ramp, and a literal hex would only
  * hold for one theme.
+ *
+ * No --info slot: after the rebrand --primary and --info are near-identical
+ * blues in light mode (~1.02:1 apart), so a palette carrying both would let
+ * one chart draw two indistinguishable series. The fifth slot is the
+ * theme's neutral slate instead, which every other slot separates from.
  */
 const PALETTE = {
   brand: 'var(--primary)',
-  blue: 'var(--info)',
+  slate: 'var(--muted-foreground)',
   green: 'var(--success)',
   amber: 'var(--warning)',
   rose: 'var(--destructive)',
 } as const;
 
 const chartConfig = {
-  desktop: { label: 'Desktop', color: 'var(--primary)' },
-  mobile: { label: 'Mobile', color: 'var(--info)' },
+  desktop: { label: 'Desktop', color: PALETTE.brand },
+  mobile: { label: 'Mobile', color: PALETTE.green },
 } satisfies ChartConfig;
 
 const themedChartConfig = {
@@ -69,7 +74,7 @@ const data = [
 /* ------------------------------------------------------------------ */
 
 const stageConfig = {
-  prospect: { label: 'Prospect', color: PALETTE.blue },
+  prospect: { label: 'Prospect', color: PALETTE.slate },
   engaged: { label: 'Engaged', color: PALETTE.green },
   customer: { label: 'Customer', color: PALETTE.amber },
   'at-risk': { label: 'At risk', color: PALETTE.brand },
@@ -149,7 +154,7 @@ function DonutChartExample() {
 /* ------------------------------------------------------------------ */
 
 const resolvedConfig = {
-  chat: { label: 'Chat', color: PALETTE.blue },
+  chat: { label: 'Chat', color: PALETTE.slate },
   mail: { label: 'Mail', color: PALETTE.green },
   tasks: { label: 'Tasks', color: PALETTE.amber },
 } satisfies ChartConfig;
@@ -169,7 +174,7 @@ const resolvedPerDay = [
 /* ------------------------------------------------------------------ */
 
 const recordsConfig = {
-  companies: { label: 'Companies', color: PALETTE.blue },
+  companies: { label: 'Companies', color: PALETTE.slate },
   opportunities: { label: 'Opportunities', color: PALETTE.amber },
   people: { label: 'People', color: PALETTE.green },
 } satisfies ChartConfig;
@@ -188,7 +193,7 @@ const recordsCreated = [
 /* ------------------------------------------------------------------ */
 
 const newContactsConfig = {
-  inbound: { label: 'Inbound', color: PALETTE.blue },
+  inbound: { label: 'Inbound', color: PALETTE.slate },
   total: { label: 'Total', color: PALETTE.brand },
 } satisfies ChartConfig;
 

--- a/packages/ui-kit/demo/examples/chart.tsx
+++ b/packages/ui-kit/demo/examples/chart.tsx
@@ -40,12 +40,16 @@ import { Row, Section } from '../shared';
  *
  * No --info slot: after the rebrand --primary and --info are near-identical
  * blues in light mode (~1.02:1 apart), so a palette carrying both would let
- * one chart draw two indistinguishable series. The fifth slot is the
- * theme's neutral slate instead, which every other slot separates from.
+ * one chart draw two indistinguishable series. The neutral fifth slot is
+ * --foreground, NOT --muted-foreground: the latter is the charts' own
+ * chrome color (axes, ticks, legend and tooltip labels — see
+ * chart.module.css), and a data series in the chrome color reads as
+ * furniture. Ink separates from that chrome in both themes (1.72:1 light /
+ * 2.56:1 dark) and from every other slot.
  */
 const PALETTE = {
   brand: 'var(--primary)',
-  slate: 'var(--muted-foreground)',
+  ink: 'var(--foreground)',
   green: 'var(--success)',
   amber: 'var(--warning)',
   rose: 'var(--destructive)',
@@ -74,7 +78,7 @@ const data = [
 /* ------------------------------------------------------------------ */
 
 const stageConfig = {
-  prospect: { label: 'Prospect', color: PALETTE.slate },
+  prospect: { label: 'Prospect', color: PALETTE.ink },
   engaged: { label: 'Engaged', color: PALETTE.green },
   customer: { label: 'Customer', color: PALETTE.amber },
   'at-risk': { label: 'At risk', color: PALETTE.brand },
@@ -154,7 +158,7 @@ function DonutChartExample() {
 /* ------------------------------------------------------------------ */
 
 const resolvedConfig = {
-  chat: { label: 'Chat', color: PALETTE.slate },
+  chat: { label: 'Chat', color: PALETTE.ink },
   mail: { label: 'Mail', color: PALETTE.green },
   tasks: { label: 'Tasks', color: PALETTE.amber },
 } satisfies ChartConfig;
@@ -174,7 +178,7 @@ const resolvedPerDay = [
 /* ------------------------------------------------------------------ */
 
 const recordsConfig = {
-  companies: { label: 'Companies', color: PALETTE.slate },
+  companies: { label: 'Companies', color: PALETTE.ink },
   opportunities: { label: 'Opportunities', color: PALETTE.amber },
   people: { label: 'People', color: PALETTE.green },
 } satisfies ChartConfig;
@@ -193,7 +197,7 @@ const recordsCreated = [
 /* ------------------------------------------------------------------ */
 
 const newContactsConfig = {
-  inbound: { label: 'Inbound', color: PALETTE.slate },
+  inbound: { label: 'Inbound', color: PALETTE.ink },
   total: { label: 'Total', color: PALETTE.brand },
 } satisfies ChartConfig;
 

--- a/packages/ui-kit/demo/examples/chart.tsx
+++ b/packages/ui-kit/demo/examples/chart.tsx
@@ -39,7 +39,7 @@ import { Row, Section } from '../shared';
  * hold for one theme.
  */
 const PALETTE = {
-  violet: 'var(--primary)',
+  brand: 'var(--primary)',
   blue: 'var(--info)',
   green: 'var(--success)',
   amber: 'var(--warning)',
@@ -72,7 +72,7 @@ const stageConfig = {
   prospect: { label: 'Prospect', color: PALETTE.blue },
   engaged: { label: 'Engaged', color: PALETTE.green },
   customer: { label: 'Customer', color: PALETTE.amber },
-  'at-risk': { label: 'At risk', color: PALETTE.violet },
+  'at-risk': { label: 'At risk', color: PALETTE.brand },
   churned: { label: 'Churned', color: PALETTE.rose },
 } satisfies ChartConfig;
 
@@ -189,7 +189,7 @@ const recordsCreated = [
 
 const newContactsConfig = {
   inbound: { label: 'Inbound', color: PALETTE.blue },
-  total: { label: 'Total', color: PALETTE.violet },
+  total: { label: 'Total', color: PALETTE.brand },
 } satisfies ChartConfig;
 
 const newContacts = [
@@ -255,7 +255,7 @@ function AreaSparkline() {
 /* ------------------------------------------------------------------ */
 
 const trafficConfig = {
-  visits: { label: 'Visits', color: PALETTE.violet },
+  visits: { label: 'Visits', color: PALETTE.brand },
 } satisfies ChartConfig;
 
 const traffic = [

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -540,7 +540,13 @@ Architecture's build bullet).
      caught the light half going stale), restoring the pre-rebrand
      tinted-panel-on-lighter-page relationship; the light active item
      improves (1.07:1 → 1.23:1 vs the panel) and every sidebar text seat
-     re-measures clear. This is a fifth deviation from the
+     re-measures clear. A follow-up review round then caught the knock-on:
+     `--sidebar-border` derived from `--border`, whose light value IS the
+     new panel fill — separators, the menu-sub rail and the floating
+     outline vanished at 1.00:1. The border now derives from
+     `--border-strong` (1.20:1 light / 1.41:1 dark against the panel;
+     dark's collapsed border family already was border-strong), and
+     tokens.test.ts pins the pair alongside the muted guard. This is a fifth deviation from the
      drawn frame — visibility, not WCAG-text, so it sits outside the
      status-token table above — and joins the open designer question on
      whether the drawn collapses are intent.
@@ -550,14 +556,23 @@ Architecture's build bullet).
      failure the Badge fix above removed) and both menus' destructive
      items painted mix-derived text/highlights that landed under 4.5:1
      highlighted in dark. Button now paints `--destructive-hover` like
-     Badge; the menu items paint `--danger` over `--danger-soft`, the
-     token pair the status matrix already guards. Per-file CSS guards
-     added (button.test.tsx, dropdown-menu.test.tsx,
-     context-menu.test.tsx) so a theme-dependent mix cannot come back.
+     Badge; the menu items paint `--danger` text with a popover-anchored
+     12% danger tint as the highlight (first shipped as `--danger-soft`,
+     which the follow-up round measured too faint for the only focus cue —
+     1.10:1/1.05:1 vs the popover against the sibling accent highlight's
+     1.16/1.12; the tint measures 1.20/1.17 with the text clear at
+     5.26/5.68). Unlike the removed recipe the tint is anchored to
+     `--popover`, so its direction never flips with the theme. Per-file
+     CSS guards added (button.test.tsx, dropdown-menu.test.tsx,
+     context-menu.test.tsx) so a foreground-anchored mix cannot come back.
    - **The demo chart palette lost its `--info` slot**: after the rebrand
      `--primary` and `--info` are ~1.02:1 apart in light mode, and two
      demo configs drew both in one chart — two indistinguishable series.
-     The fifth palette slot is the theme's neutral slate now.
+     The neutral fifth slot is `--foreground` (first landed as
+     `--muted-foreground`, which the follow-up round pointed out is the
+     charts' own chrome color — axes, ticks and legend labels — so a
+     series in it read as furniture; ink separates from that chrome at
+     1.72:1 light / 2.56:1 dark).
    - **`--scenario-canvas`/`--artifact-accent-icon` removed** before they
      ever published (added by the rebrand commit, consumed by nothing,
      absent from every released version). The rebrand admitted them

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -91,8 +91,13 @@ the `sidebar` / `data-table` exclusions above intact.
   weight/tracking, `--text-<role>-*` for display/heading-1/heading-2/body/
   label/meta/mono; see step 4 below), light/dark via `data-theme` /
   `prefers-color-scheme`; shadcn-style token structure carrying the Studio
-  palette from the F-mockups Figma file (variable collection "Studio /
-  shadcn"). Component CSS consumes only these variables — the theme file is
+  BLUE palette from the mockups' token spec frame "02 · Tokens, type &
+  elevation" (node 40001232:5254), which superseded the original violet
+  "Studio / shadcn" collection — see the "Studio blue rebrand" entry in
+  step 4 below. The token NAMES stay unprefixed per the shadcn convention
+  even though that frame labels its WEB syntax `var(--color-*)`: renaming
+  the public token surface would break every consumer for zero semantic
+  gain (a standing ruling, recorded in theme.css's header). Component CSS consumes only these variables — the theme file is
   the single seam between kit styles and consumer brand. The theme file
   also paints the page surface itself (`body`/`[data-theme]` background and
   color, plus `color-scheme`), not just the tokens: a bare consumer page
@@ -198,9 +203,11 @@ agent asked to "update <component> from shadcn" follows this):
    and `llms.txt` synced with any contract change.
 
 Hard constraints that always apply: existing theme.css token values are
-frozen (additive only, all theme blocks); no raw values in module.css
-including comments; icons via direct `lucide-react` imports; CSS Modules +
-CVA; Base UI primitives only.
+frozen FOR UPSTREAM SYNCS (additive only, all theme blocks) — an upstream
+shadcn change never moves a token value; only an explicit design-source
+ruling does (the 2026-08-31 Studio blue rebrand is the precedent, see step
+4); no raw values in module.css including comments; icons via direct
+`lucide-react` imports; CSS Modules + CVA; Base UI primitives only.
 
 ## Testing and acceptance
 
@@ -411,6 +418,84 @@ Architecture's build bullet).
      by hand). None replace an existing consumer-facing token; a consumer
      overriding theme.css wholesale (rather than layering on top of it)
      should add these four to stay in sync.
+
+   **Studio blue rebrand (2026-08-31).** The design moved from the violet
+   "Studio / shadcn" collection to the blue Studio palette recorded on the
+   mockups' token spec frame "02 · Tokens, type & elevation" (node
+   40001232:5254). theme.css adopted the frame's semantic color values in
+   both modes wholesale — brand axis onto the blue ramp (primary
+   `#0065e3`, hover/accent-foreground `#2668c5`, accent tint `#e6effa`),
+   the light page onto slate-50 `#f1f5f9`, the dark mode onto the slate
+   ramp (surfaces `#0f172a`, borders `#334155`, foreground pure white) —
+   including two collapses the frame itself draws (dark
+   surface = surface-elevated, dark border = border-strong) and the
+   frame's own resolution of the old `--subtle-foreground` AA question
+   (its new drawn values pass: 10.35:1 light / 6.96:1 dark). Undrawn
+   entries were re-derived per theme.css's `derived:` convention
+   (card/popover mirror surface; secondary stepped one neutral away from
+   the now-page-equal muted in each mode; sidebar/code blocks follow their
+   same-role tokens; ring family and `--link-foreground` from the brand
+   ramp — ratios at each token). `--popover-shadow` adopted the frame's
+   Studio/Elevation/200 geometry (0 8 24 @ 12% foreground); new
+   palette-only entries `--scenario-canvas` (moved into the color/
+   namespace by the rebrand) and `--artifact-accent-icon`.
+
+   Per the user ruling that a drawn value failing WCAG gets corrected in
+   code (the same standing instruction as the accessibility pass above),
+   the rebrand deviates from the frame in exactly four status colors, all
+   12px label text over their own -soft fills (worst-case ratios across
+   soft/card/page):
+
+   | token | drawn | shipped | worst case |
+   |---|---|---|---|
+   | light `--success` | `#059669` (3.43:1) | `#047857` | 5.00:1 |
+   | light `--warning` | `#f59e0b` (1.96:1) | `#b45309` | 4.58:1 |
+   | light `--danger`  | `#e11d48` (4.28:1) | `#be123c` | 5.72:1 |
+   | dark `--danger`   | `#e11d48` (3.63:1) | `#fb7185` | 6.34:1 |
+
+   Light `--info` (`#2563eb`, 4.59:1 worst case) passes as drawn and was
+   kept. `--destructive` tracks the DRAWN red (`#e11d48` both modes — its
+   text is the on-color, 4.70:1, not the token itself), so the one-red
+   alias now diverges from the corrected `--danger` by design. Component
+   fallout, same ruling: Avatar's `solid` treatment labels each status
+   tone with that tone's own `-soft` value instead of the mockup's
+   all-white `--primary-foreground` binding (which fails at ~1.5–2:1 on
+   the light dark-mode tones); Badge's `link` variant moved onto
+   `--link-foreground` (dark `--primary` is 3.72:1 on the page); Badge's
+   tone-label contrast debt (previously "raised for a design decision") is
+   resolved by the token corrections — every pair now clears 4.5:1, per
+   the recomputed table in badge.module.css. Contrast guards
+   (tokens.test.ts floors, button.test.tsx ring cases) recompute from the
+   live CSS and pass.
+
+   **Typography follow-up (same rebrand, second pass).** The frame's
+   "Studio/Type" ramp was adopted onto the existing `--text-*` role names
+   (the roles are the public API; values moved, names didn't): display
+   28/34 → 26/32 (Page Title), body 15/20 → 14/20 (UI Primary Regular),
+   label 13/16 → 12/16 medium (UI Secondary Medium), mono 11/16 → 10/14
+   (System Micro), every role's tracking normalized to the ramp's 0;
+   heading-2 was already Section Title's 16/24 and meta already UI
+   Secondary Regular's 12/16. Evidence, since most first-generation spec
+   frames are already deleted from the design file: the ramp sheet itself,
+   plus the live "Phase 3 / Remaining core controls" frame (40001414:5973)
+   whose drawn Tabs trigger binds UI Secondary Medium, drawn compact
+   Button binds UI Secondary Semi Bold, and drawn Badge sits on UI
+   Secondary Medium — the metrics Badge already had via its
+   meta-size + label-weight mix. Deliberate residue: heading-1 (20/28)
+   kept as a kit interpolation (the new ramp has no slot between 16 and
+   26, and collapsing it into heading-2 would merge two heading levels);
+   Display Metric 36/40, Foundation Hero 56/64 and Avatar Micro 10/14
+   carried nowhere (no kit consumer at those slots); Button stays on
+   label's 500 weight although the drawn compact button's cut is 600 — a
+   per-component weight question for the components pass, since label
+   also dresses menus, tooltips and table headers.
+
+   Still NOT part of the rebrand: the elevation scale beyond the popover
+   shadow (Elevation/100/300/Dock top have no kit consumer yet). Open
+   designer questions: pin AA-passing status values in the Figma file
+   (the four deviations above), confirm the dark surface/border collapses
+   are intent rather than spec-sheet shorthand, and rule the button label
+   weight (500 vs the drawn 600).
 5. The twelve gap components, mockups-first: `popover`, `alert`, `avatar`,
    `empty` are in both the mockups and the `insight-front` set and go first;
    `pagination` and `breadcrumb` are the mockups-only additions;

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -490,6 +490,34 @@ Architecture's build bullet).
    per-component weight question for the components pass, since label
    also dresses menus, tooltips and table headers.
 
+   **Post-review contrast pass (2026-08-31, PR #604 review).** The review
+   found the rebrand audit had measured resting token pairs only; the
+   fixes extend the same WCAG ruling to interactive and foreground seats:
+   - `--destructive` is a FILL token, verified only under
+     `--destructive-foreground` — every component that painted it as
+     TEXT (FieldError, destructive Alert/Bubble/Attachment/Toast icon,
+     QuestionnaireError) moved to the AA-corrected `--danger`;
+   - new `--destructive-hover` token (`#be123c` both modes): Badge's
+     destructive hover previously mixed the fill toward `--foreground`,
+     which darkens in light mode but LIGHTENS in dark (foreground flips
+     to white), dropping the white label to ~3.9:1;
+   - Badge tone hovers underline instead of recoloring the fill — the
+     tone labels sit at 4.5–4.67:1 with almost no headroom, so any
+     darkening mix breaks the floor;
+   - Badge focus gained an outside outline (Button's idiom): light
+     `--ring` equals `--primary`, so the inset-only ring on a default
+     link Badge painted blue over blue and vanished;
+   - the remaining `--primary`-as-text-link hovers
+     (Field/Empty/ItemDescription) moved to `--link-foreground`;
+   - `@gears-frontx/ui-kit` bumped to 0.4.0-alpha.2 with the template
+     pins (the version-bump-on-change CI gate);
+   - guards added so none of this regresses silently: tokens.test.ts now
+     asserts the status-label matrix (each status color vs its -soft
+     fill, page, surface, card, popover), the accent pair, the
+     solid-fill on-colors at rest and hover, and link text on
+     surface/card; badge.test.tsx asserts the outside outline and its
+     3:1 tone, mirroring button.test.tsx.
+
    Still NOT part of the rebrand: the elevation scale beyond the popover
    shadow (Elevation/100/300/Dock top have no kit consumer yet). Open
    designer questions: pin AA-passing status values in the Figma file

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -535,7 +535,12 @@ Architecture's build bullet).
      dark `#0f172a → #1e293b` (1.22:1 vs card). Every text seat re-checked
      (muted-foreground on the new fill 8.40:1 light / 5.71:1 dark);
      tokens.test.ts pins the separation at ≥ 1.1:1 so a later palette move
-     cannot silently re-collapse it. This is a fifth deviation from the
+     cannot silently re-collapse it. `--sidebar` follows per its documented
+     derivation (it carries muted's value in both modes — CodeRabbit
+     caught the light half going stale), restoring the pre-rebrand
+     tinted-panel-on-lighter-page relationship; the light active item
+     improves (1.07:1 → 1.23:1 vs the panel) and every sidebar text seat
+     re-measures clear. This is a fifth deviation from the
      drawn frame — visibility, not WCAG-text, so it sits outside the
      status-token table above — and joins the open designer question on
      whether the drawn collapses are intent.

--- a/packages/ui-kit/design-notes.md
+++ b/packages/ui-kit/design-notes.md
@@ -97,7 +97,8 @@ the `sidebar` / `data-table` exclusions above intact.
   step 4 below. The token NAMES stay unprefixed per the shadcn convention
   even though that frame labels its WEB syntax `var(--color-*)`: renaming
   the public token surface would break every consumer for zero semantic
-  gain (a standing ruling, recorded in theme.css's header). Component CSS consumes only these variables — the theme file is
+  gain (a standing ruling, recorded in theme.css's header). Component CSS
+  consumes only these variables — the theme file is
   the single seam between kit styles and consumer brand. The theme file
   also paints the page surface itself (`body`/`[data-theme]` background and
   color, plus `color-scheme`), not just the tokens: a bare consumer page
@@ -296,7 +297,10 @@ Architecture's build bullet).
    Overlay options' muted/active color language (a component-phase item,
    not a token one).
 
-   **Accessibility + spec-alignment pass.** A pass over the reskin found
+   **Accessibility + spec-alignment pass.** (Predates the Studio blue
+   rebrand below — palette words like "violet" and the measured ratios in
+   this entry describe the pre-rebrand theme; the tests named here
+   recompute against the live values.) A pass over the reskin found
    WCAG failures and undocumented deviations from the drawn spec; all
    resolved as rulings rather than left flagged, per the standing
    instruction that a color failing WCAG gets a new color, not a "kept as
@@ -436,9 +440,10 @@ Architecture's build bullet).
    the now-page-equal muted in each mode; sidebar/code blocks follow their
    same-role tokens; ring family and `--link-foreground` from the brand
    ramp — ratios at each token). `--popover-shadow` adopted the frame's
-   Studio/Elevation/200 geometry (0 8 24 @ 12% foreground); new
-   palette-only entries `--scenario-canvas` (moved into the color/
-   namespace by the rebrand) and `--artifact-accent-icon`.
+   Studio/Elevation/200 geometry (0 8 24 @ 12% foreground). The frame's
+   `color/scenario-canvas` and `color/artifact-accent-icon` entries were
+   briefly carried as new tokens on the namespace argument, then removed
+   before merge — see the inline-review pass below.
 
    Per the user ruling that a drawn value failing WCAG gets corrected in
    code (the same standing instruction as the accessibility pass above),
@@ -502,8 +507,8 @@ Architecture's build bullet).
      which darkens in light mode but LIGHTENS in dark (foreground flips
      to white), dropping the white label to ~3.9:1;
    - Badge tone hovers underline instead of recoloring the fill — the
-     tone labels sit at 4.5–4.67:1 with almost no headroom, so any
-     darkening mix breaks the floor;
+     tightest tone labels sit at 4.59–4.68:1 on their own fills with
+     almost no headroom, so any darkening mix breaks the floor;
    - Badge focus gained an outside outline (Button's idiom): light
      `--ring` equals `--primary`, so the inset-only ring on a default
      link Badge painted blue over blue and vanished;
@@ -518,12 +523,60 @@ Architecture's build bullet).
      surface/card; badge.test.tsx asserts the outside outline and its
      3:1 tone, mirroring button.test.tsx.
 
+   **Inline-review pass (2026-09-01, PR #604 second review).** A reviewer
+   pass over the rebrand diff itself; every numeric claim was re-measured
+   before acting. Two substantive fixes and one demo fix:
+   - **`--muted` stepped off its backdrops.** The frame draws muted AT the
+     light page value and AT the dark card value — a 1.00:1 fill that
+     makes Skeleton, outline/ghost Button hover and the other muted
+     consumers vanish. Same one-step correction --secondary already took;
+     muted now lands ON secondary's value in both modes (upstream shadcn's
+     own default arrangement): light `#f1f5f9 → #e2e8f0` (1.13:1 vs page),
+     dark `#0f172a → #1e293b` (1.22:1 vs card). Every text seat re-checked
+     (muted-foreground on the new fill 8.40:1 light / 5.71:1 dark);
+     tokens.test.ts pins the separation at ≥ 1.1:1 so a later palette move
+     cannot silently re-collapse it. This is a fifth deviation from the
+     drawn frame — visibility, not WCAG-text, so it sits outside the
+     status-token table above — and joins the open designer question on
+     whether the drawn collapses are intent.
+   - **The last two `--destructive`-mix seats moved onto the corrected
+     tokens.** Button's destructive hover still mixed the fill toward
+     `--foreground` (3.90:1 under the white label in dark — the exact
+     failure the Badge fix above removed) and both menus' destructive
+     items painted mix-derived text/highlights that landed under 4.5:1
+     highlighted in dark. Button now paints `--destructive-hover` like
+     Badge; the menu items paint `--danger` over `--danger-soft`, the
+     token pair the status matrix already guards. Per-file CSS guards
+     added (button.test.tsx, dropdown-menu.test.tsx,
+     context-menu.test.tsx) so a theme-dependent mix cannot come back.
+   - **The demo chart palette lost its `--info` slot**: after the rebrand
+     `--primary` and `--info` are ~1.02:1 apart in light mode, and two
+     demo configs drew both in one chart — two indistinguishable series.
+     The fifth palette slot is the theme's neutral slate now.
+   - **`--scenario-canvas`/`--artifact-accent-icon` removed** before they
+     ever published (added by the rebrand commit, consumed by nothing,
+     absent from every released version). The rebrand admitted them
+     because the Figma variables moved into the `color/` namespace; the
+     review challenged that, and the ruling is ownership over namespace:
+     they name one consumer's workflow surfaces (Studio's scenario
+     canvas, its artifact cards), which the FrontX handoff contract
+     classifies as Studio-only — product-domain names do not enter the
+     kit's public token API on a folder move alone. theme.css's header
+     now records the rule.
+   - Doc/comment sync from the same review: badge.md's tone-contrast
+     caveat replaced with the resolution it had already received; stale
+     pre-rebrand ratios refreshed in button/tabs/table/avatar comments;
+     the two pre-rebrand entries above marked as historical; review
+     finding codes (F-00x) replaced with self-contained references, since
+     the offline review file is not in the repo.
+
    Still NOT part of the rebrand: the elevation scale beyond the popover
    shadow (Elevation/100/300/Dock top have no kit consumer yet). Open
    designer questions: pin AA-passing status values in the Figma file
    (the four deviations above), confirm the dark surface/border collapses
-   are intent rather than spec-sheet shorthand, and rule the button label
-   weight (500 vs the drawn 600).
+   are intent rather than spec-sheet shorthand (now also load-bearing for
+   the `--muted` step-off above), and rule the button label weight (500 vs
+   the drawn 600).
 5. The twelve gap components, mockups-first: `popover`, `alert`, `avatar`,
    `empty` are in both the mockups and the `insight-front` set and go first;
    `pagination` and `breadcrumb` are the mockups-only additions;

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/ui-kit",
-  "version": "0.4.0-alpha.2",
+  "version": "0.4.0-alpha.3",
   "description": "Standard React component base for FrontX templates - Base UI behavior, CSS Modules styling on semantic tokens, CVA variants",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/ui-kit/src/components/alert/alert.module.css
+++ b/packages/ui-kit/src/components/alert/alert.module.css
@@ -34,7 +34,12 @@
 
 .variantDestructive {
   background-color: var(--card);
-  color: var(--destructive);
+  /* --danger, not --destructive: this is 14px body text over --card, and
+   * --destructive is only verified as a solid fill under
+   * --destructive-foreground, not as text on --card (3.80:1 dark, under
+   * the 4.5:1 floor) — --danger is the token theme.css corrected for
+   * exactly this seat. */
+  color: var(--danger);
 }
 
 /*

--- a/packages/ui-kit/src/components/attachment/attachment.module.css
+++ b/packages/ui-kit/src/components/attachment/attachment.module.css
@@ -175,7 +175,10 @@
 
 .attachment[data-state='error'] .attachmentMedia {
   background-color: color-mix(in oklab, var(--destructive) 10%, transparent);
-  color: var(--destructive);
+  /* --danger, not --destructive — see attachmentDescription below, the
+   * same foreground-vs-fill distinction theme.css draws between the two
+   * tokens. */
+  color: var(--danger);
 }
 
 /* Deliberately empty — do not delete as dead CSS. Kept so `variant="icon"`
@@ -230,7 +233,16 @@
 }
 
 .attachment[data-state='error'] .attachmentDescription {
-  color: color-mix(in oklab, var(--destructive) 80%, transparent);
+  /*
+   * --danger at full strength, not a color-mix of --destructive toward
+   * transparent: fading an already-marginal red toward whatever backdrop
+   * sits behind it (near-white in light mode) only pulls it CLOSER to that
+   * backdrop, shrinking contrast further below the already-failing 4.29:1
+   * (light) / 3.80:1 (dark) --destructive measures at this 12px size.
+   * --danger is the token theme.css corrected to clear 4.5:1 as label text
+   * over --card and --background in both themes.
+   */
+  color: var(--danger);
 }
 
 .attachmentActions {

--- a/packages/ui-kit/src/components/avatar/avatar.module.css
+++ b/packages/ui-kit/src/components/avatar/avatar.module.css
@@ -119,12 +119,22 @@
  * pair per cell. Its API note names the axes verbatim — "treatment: solid |
  * soft; tone: neutral | accent | info | success | warning | danger".
  *
- * `solid` paints the tone at full strength and labels it with
- * --primary-foreground. That is not a shortcut for a missing per-tone
- * on-color: the mockup binds that one on-primary variable for all six solid
- * tones, so following it keeps the kit off six invented foreground tokens.
- * `soft` inverts the pair — the tone's own -soft surface carries the tone
- * itself as the label color.
+ * `solid` paints the tone at full strength; `soft` inverts the pair — the
+ * tone's own -soft surface carries the tone itself as the label color.
+ *
+ * The solid label DEVIATES from the mockup, which binds --primary-foreground
+ * for all six solid tones: in dark mode the status tones are light tints,
+ * so --primary-foreground initials on them land around 1.5–2:1 — far under
+ * the 4.5:1 AA floor — and per the kit's standing WCAG ruling (theme.css
+ * header) a drawn color failing its floor gets corrected, not footnoted.
+ * The correction invents no tokens: each status tone's solid label is that
+ * tone's own -soft value — the exact inverse of the `soft` treatment below,
+ * and dark ink on light fills / light ink on dark fills by construction in
+ * both themes (worst case 4.59:1, light info; the rest measure
+ * 4.67–10.03:1). `neutral` inverts its borrowed pair the same way (--muted
+ * on --muted-foreground, 11.5:1 light / 6.6:1 dark). `accent` alone keeps
+ * the mockup's binding: --primary-foreground on --primary measures 5.29:1
+ * in both modes, so the drawn pair passes as-is.
  *
  * `neutral` has no --neutral family to draw from and borrows the muted one,
  * which is why neutral+soft resolves to precisely the
@@ -142,7 +152,7 @@
  */
 .variantSolid.toneNeutral {
   background-color: var(--muted-foreground);
-  color: var(--primary-foreground);
+  color: var(--muted);
 }
 
 .variantSolid.toneAccent {
@@ -152,22 +162,22 @@
 
 .variantSolid.toneInfo {
   background-color: var(--info);
-  color: var(--primary-foreground);
+  color: var(--info-soft);
 }
 
 .variantSolid.toneSuccess {
   background-color: var(--success);
-  color: var(--primary-foreground);
+  color: var(--success-soft);
 }
 
 .variantSolid.toneWarning {
   background-color: var(--warning);
-  color: var(--primary-foreground);
+  color: var(--warning-soft);
 }
 
 .variantSolid.toneDanger {
   background-color: var(--danger);
-  color: var(--primary-foreground);
+  color: var(--danger-soft);
 }
 
 .variantSoft.toneNeutral {

--- a/packages/ui-kit/src/components/avatar/avatar.module.css
+++ b/packages/ui-kit/src/components/avatar/avatar.module.css
@@ -132,7 +132,7 @@
  * and dark ink on light fills / light ink on dark fills by construction in
  * both themes (worst case 4.59:1, light info; the rest measure
  * 4.67–10.03:1). `neutral` inverts its borrowed pair the same way (--muted
- * on --muted-foreground, 11.5:1 light / 6.6:1 dark). `accent` alone keeps
+ * on --muted-foreground, 8.40:1 light / 5.71:1 dark). `accent` alone keeps
  * the mockup's binding: --primary-foreground on --primary measures 5.29:1
  * in both modes, so the drawn pair passes as-is.
  *

--- a/packages/ui-kit/src/components/badge/badge.md
+++ b/packages/ui-kit/src/components/badge/badge.md
@@ -27,14 +27,13 @@ are the semantic-ish colors available — pick the one that best matches the
 status, but keep the label text itself explicit; color alone is not a
 substitute for a state machine.
 
-> **Accessibility caveat on tones.** At Badge's 12px/500 label, WCAG 1.4.3
-> asks 4.5:1. Four of the drawn tone pairs currently fall short — light
-> `success` 3.43:1, `warning` 2.90:1, `danger` 4.28:1, `info` 3.73:1, and
-> dark `danger` 3.80:1 — because the shortfall is in the theme's status
-> token pairs, not in this component. Until those pairs are re-pinned, do
-> not let a tone's color be the only thing carrying the meaning: keep the
-> label text itself explicit. `accent` and `secondary` clear AA in both
-> themes, as do `success`, `warning` and `info` in dark.
+> **Accessibility of tones.** At Badge's 12px/500 label, WCAG 1.4.3 asks
+> 4.5:1, and every tone pair now clears it in both themes: the Studio blue
+> rebrand re-pinned the status tokens that used to fall short at the theme
+> level (see theme.css and the "Studio blue rebrand" entry in
+> design-notes.md), and tokens.test.ts holds each status color to the
+> floor against its own soft fill and every surface it sits on. Color is
+> still not a substitute for text: keep the label itself explicit.
 
 ## When to use
 

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -50,6 +50,10 @@
   font-weight: var(--text-label-weight);
   letter-spacing: var(--text-meta-tracking);
   white-space: nowrap;
+  /* One offset for every underline this file draws (link's rest style and
+   * the tone hovers alike), so hover underlines sit at the same height
+   * across variants. */
+  text-underline-offset: 4px;
   /*
    * Colour and box-shadow crossfades only, no transform/geometry — not
    * motion under WCAG 2.3.3, so deliberately left unguarded under
@@ -132,11 +136,11 @@ a.variantSecondary:hover {
 
 /*
  * --destructive-hover, not a color-mix toward --foreground: that recipe
- * (still what button.module.css's own destructive hover uses) darkens
- * correctly in light mode, where --foreground is dark, but LIGHTENS in dark
- * mode instead, since --foreground flips near-white there — against the
- * fixed --destructive-foreground label, that drops dark-mode hover
- * to about 3.91:1. --destructive-hover is a literal, same hex both modes
+ * (which button.module.css's destructive hover shared until the same fix)
+ * darkens correctly in light mode, where --foreground is dark, but LIGHTENS
+ * in dark mode instead, since --foreground flips near-white there — against
+ * the fixed --destructive-foreground label, that drops dark-mode hover
+ * to about 3.90:1. --destructive-hover is a literal, same hex both modes
  * (see theme.css), so the direction never depends on which theme is active.
  */
 a.variantDestructive:hover {
@@ -172,7 +176,6 @@ a.variantGhost:hover {
  */
 .variantLink {
   color: var(--link-foreground);
-  text-underline-offset: 4px;
 }
 
 a.variantLink:hover {
@@ -199,11 +202,12 @@ a.variantLink:hover {
  * --secondary. Nothing here needed a local literal, which is the point of
  * fixing the pair where it is defined.
  *
- * Hover used to mix the fill toward --foreground, the same idiom
- * `a.variantDestructive` uses above — wrong here for a different reason
- * than that one's dark-mode flip: these labels sit on their own tint at a
- * bare 4.5:1–4.67:1 (warning has 0.17 of headroom), so ANY darkening of the
- * fill toward the label's own darker luminance shrinks that margin, and
+ * Hover used to mix the fill toward --foreground, the idiom
+ * `a.variantDestructive` above once used — wrong here for a different
+ * reason than that one's dark-mode flip: the tightest of these labels sit
+ * on their own tint at a bare 4.59:1–4.68:1 (info has 0.09 of headroom,
+ * warning 0.17), so ANY darkening of the fill toward the label's own
+ * darker luminance shrinks that margin, and
  * standard OKLab interpolation puts every one of them under the floor
  * (light success 3.97:1, warning 3.70:1, info 3.65:1, accent 3.72:1) well
  * before the mix reaches 10%. Recoloring the fill on hover isn't safe at

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -69,14 +69,22 @@
 }
 
 /*
- * Focus ring: the same inset idiom as Input/Textarea (border color swap +
- * inset box-shadow, geometry-stable — see input.module.css), not Button's
- * outside outline — Badge is a bordered pill, not Button's shape. Only
- * reachable at all once rendered as a link via `render`; a plain span is
- * never in the tab order.
+ * Focus ring: the inset border/box-shadow idiom Input/Textarea use (color
+ * swap + inset box-shadow, geometry-stable — see input.module.css), PLUS an
+ * outside outline in the same tone, Button's own idiom (see
+ * button.module.css). The inset half alone isn't enough here: it borders
+ * the badge's own FILL, not just the page, and --ring equals --primary in
+ * light mode — a default-variant link Badge's inset ring then paints the
+ * exact color it's already sitting on and disappears. The outline sits
+ * clear of the fill (offset outside the border box), so its only WCAG
+ * 1.4.11 neighbor is ever the page/card background, never the badge's own
+ * color, the same guarantee button.module.css documents for its own ring.
+ * Only reachable at all once rendered as a link via `render`; a plain span
+ * is never in the tab order.
  */
 .badge:focus-visible {
-  outline: none;
+  outline: var(--border-width-focus) solid var(--ring);
+  outline-offset: 2px;
   border-color: var(--ring);
   box-shadow: inset 0 0 0 var(--ring-inset) var(--ring);
 }
@@ -123,13 +131,16 @@ a.variantSecondary:hover {
 }
 
 /*
- * Mixes toward --foreground rather than a flat opacity fade — same
- * reasoning and idiom as button.module.css's destructive hover: fading an
- * already-marginal fill toward the page pulls it *toward* the label it has
- * to contrast with.
+ * --destructive-hover, not a color-mix toward --foreground: that recipe
+ * (still what button.module.css's own destructive hover uses) darkens
+ * correctly in light mode, where --foreground is dark, but LIGHTENS in dark
+ * mode instead, since --foreground flips near-white there — against the
+ * fixed --destructive-foreground label, that drops dark-mode hover
+ * to about 3.91:1. --destructive-hover is a literal, same hex both modes
+ * (see theme.css), so the direction never depends on which theme is active.
  */
 a.variantDestructive:hover {
-  background-color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  background-color: var(--destructive-hover);
 }
 
 .variantOutline {
@@ -188,11 +199,17 @@ a.variantLink:hover {
  * --secondary. Nothing here needed a local literal, which is the point of
  * fixing the pair where it is defined.
  *
- * Hover is the color-mix-toward-foreground idiom `a.variantDestructive`
- * uses above, for the same reason: fading a tint toward transparent pulls
- * it toward the label it has to contrast with. The mockup draws no badge
- * hover state, so this is the file's own existing recipe applied for
- * consistency, not a drawn spec.
+ * Hover used to mix the fill toward --foreground, the same idiom
+ * `a.variantDestructive` uses above — wrong here for a different reason
+ * than that one's dark-mode flip: these labels sit on their own tint at a
+ * bare 4.5:1–4.67:1 (warning has 0.17 of headroom), so ANY darkening of the
+ * fill toward the label's own darker luminance shrinks that margin, and
+ * standard OKLab interpolation puts every one of them under the floor
+ * (light success 3.97:1, warning 3.70:1, info 3.65:1, accent 3.72:1) well
+ * before the mix reaches 10%. Recoloring the fill on hover isn't safe at
+ * this headroom, so hover instead underlines the label — the mockup draws
+ * no badge hover state, and Link's own hover (above) already establishes
+ * underline as this file's affordance for "hover, no color change".
  */
 .variantSuccess {
   background-color: var(--success-soft);
@@ -200,7 +217,7 @@ a.variantLink:hover {
 }
 
 a.variantSuccess:hover {
-  background-color: color-mix(in oklab, var(--success-soft) 90%, var(--foreground) 10%);
+  text-decoration: underline;
 }
 
 .variantWarning {
@@ -209,7 +226,7 @@ a.variantSuccess:hover {
 }
 
 a.variantWarning:hover {
-  background-color: color-mix(in oklab, var(--warning-soft) 90%, var(--foreground) 10%);
+  text-decoration: underline;
 }
 
 .variantDanger {
@@ -218,7 +235,7 @@ a.variantWarning:hover {
 }
 
 a.variantDanger:hover {
-  background-color: color-mix(in oklab, var(--danger-soft) 90%, var(--foreground) 10%);
+  text-decoration: underline;
 }
 
 .variantInfo {
@@ -227,7 +244,7 @@ a.variantDanger:hover {
 }
 
 a.variantInfo:hover {
-  background-color: color-mix(in oklab, var(--info-soft) 90%, var(--foreground) 10%);
+  text-decoration: underline;
 }
 
 .variantAccent {
@@ -236,5 +253,5 @@ a.variantInfo:hover {
 }
 
 a.variantAccent:hover {
-  background-color: color-mix(in oklab, var(--accent) 90%, var(--foreground) 10%);
+  text-decoration: underline;
 }

--- a/packages/ui-kit/src/components/badge/badge.module.css
+++ b/packages/ui-kit/src/components/badge/badge.module.css
@@ -151,8 +151,16 @@ a.variantGhost:hover {
   color: var(--accent-foreground);
 }
 
+/*
+ * --link-foreground, not --primary, for the same reason as Button's link
+ * variant (see button.module.css): this is 12px text sitting directly on
+ * the page/card, and the dark --primary misses the 4.5:1 AA floor there
+ * (3.72:1 against --background) while --link-foreground is the text-safe
+ * token theme.css carries for exactly this seat (4.95:1 light / 7.75:1
+ * dark).
+ */
 .variantLink {
-  color: var(--primary);
+  color: var(--link-foreground);
   text-underline-offset: 4px;
 }
 
@@ -168,14 +176,17 @@ a.variantLink:hover {
  * them". This is that surface. Accent is the same shape over the
  * --accent/--accent-foreground pair, matching the mockup's Accent badge.
  *
- * KNOWN CONTRAST DEBT, not an oversight: at 12px/500 these labels need
- * 4.5:1 (WCAG 1.4.3) and four pairs miss it — light success 3.43:1,
- * warning 2.90:1, danger 4.28:1, info 3.73:1, and dark danger 3.80:1.
- * The shortfall is in the token pairs themselves, which the mockup defines
- * and this file may not redefine, so it is raised for a design decision
- * rather than papered over with a local literal. Every other pair clears
- * AA (light accent 6.02:1, dark success 8.05:1 / warning 9.16:1 /
- * info 8.80:1 / accent 12.83:1), as does Neutral via --secondary.
+ * Contrast: at 12px/500 these labels need 4.5:1 (WCAG 1.4.3). The debt
+ * this comment used to record ("four pairs miss it, raised for a design
+ * decision") was resolved BY that decision, at the token level: the Studio
+ * blue rebrand ruled that a drawn status color failing AA gets a corrected
+ * value in theme.css (see its header and the --success/--warning/--danger
+ * comments there), so every pair this file paints now clears the floor on
+ * its own fill — light success 5.00:1 / warning 4.67:1 / danger 5.72:1 /
+ * info 4.59:1 / accent 4.68:1, dark success 8.05:1 / warning 10.03:1 /
+ * danger 6.34:1 / info 6.62:1 / accent 13.77:1 — as does Neutral via
+ * --secondary. Nothing here needed a local literal, which is the point of
+ * fixing the pair where it is defined.
  *
  * Hover is the color-mix-toward-foreground idiom `a.variantDestructive`
  * uses above, for the same reason: fading a tint toward transparent pulls

--- a/packages/ui-kit/src/components/badge/badge.test.tsx
+++ b/packages/ui-kit/src/components/badge/badge.test.tsx
@@ -1,6 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { contrastRatio } from '../../__test-utils__/contrast';
+import { declarationMap, extractRules } from '../../__test-utils__/css-rules';
+import { readThemeTokens } from '../../__test-utils__/theme-tokens';
 import { Badge } from './badge';
 import styles from './badge.module.css';
 
@@ -66,5 +73,51 @@ describe('Badge', () => {
     expect(link).toHaveProperty('href', expect.stringContaining('/filters/open'));
     expect(link.className).toContain(styles.badge);
     expect(link.className).toContain(styles.variantOutline);
+  });
+});
+
+/*
+ * Guards the fix for the invisible focus ring on a default-variant link
+ * Badge (the PR #604 review's F-005): light --ring equals --primary, and the
+ * inset half of Badge's focus idiom recolors chrome sitting ON the badge's
+ * own fill — on the default variant that painted blue over blue and
+ * vanished. What makes focus visible regardless of the fill is the OUTSIDE
+ * outline half, offset off the border box, whose only WCAG 1.4.11 neighbor
+ * is therefore the page background — the same guarantee button.test.tsx
+ * verifies for Button's ring. Reads the raw module CSS (like that file
+ * does), not the rendered DOM: jsdom computes no styles.
+ */
+describe('Badge focus ring', () => {
+  const css = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), 'badge.module.css'),
+    'utf8',
+  );
+  const focusRule = extractRules(css).find((rule) => rule.selector === '.badge:focus-visible');
+
+  it('draws an outside outline in the kit-wide ring tone, offset off the fill', () => {
+    expect(focusRule, '.badge:focus-visible rule missing from badge.module.css').toBeDefined();
+    const decls = declarationMap(focusRule?.body ?? '');
+    expect(decls.get('outline'), 'outline must carry the ring tone').toContain('var(--ring)');
+    expect(decls.get('outline')).not.toContain('none');
+    // The offset is what keeps the outline clear of the badge's own fill,
+    // so its contrast neighbor is the page, never the variant color.
+    expect(decls.get('outline-offset'), 'outline-offset missing').toBeDefined();
+  });
+
+  it('outline tone clears 3:1 against the page background in both themes', () => {
+    const { light, dark } = readThemeTokens();
+    for (const [themeName, tokens] of [
+      ['light', light],
+      ['dark', dark],
+    ] as const) {
+      const ring = tokens.get('--ring');
+      const background = tokens.get('--background');
+      expect(ring, `--ring missing from the ${themeName} block`).toBeDefined();
+      expect(background, `--background missing from the ${themeName} block`).toBeDefined();
+      expect(
+        contrastRatio(ring as string, background as string),
+        themeName,
+      ).toBeGreaterThanOrEqual(3);
+    }
   });
 });

--- a/packages/ui-kit/src/components/badge/badge.test.tsx
+++ b/packages/ui-kit/src/components/badge/badge.test.tsx
@@ -78,7 +78,8 @@ describe('Badge', () => {
 
 /*
  * Guards the fix for the invisible focus ring on a default-variant link
- * Badge (the PR #604 review's F-005): light --ring equals --primary, and the
+ * Badge (design-notes.md's "Post-review contrast pass" entry records the
+ * finding): light --ring equals --primary, and the
  * inset half of Badge's focus idiom recolors chrome sitting ON the badge's
  * own fill — on the default variant that painted blue over blue and
  * vanished. What makes focus visible regardless of the fill is the OUTSIDE

--- a/packages/ui-kit/src/components/bubble/bubble.module.css
+++ b/packages/ui-kit/src/components/bubble/bubble.module.css
@@ -234,7 +234,11 @@
  */
 .bubble.variantDestructive > .bubbleContent {
   background-color: color-mix(in oklab, var(--destructive) 10%, transparent);
-  color: var(--destructive);
+  /* --danger, not --destructive — the same foreground-vs-fill distinction
+   * theme.css draws between the two tokens; this text sits on a tint of
+   * --destructive close to --card/--background, not under
+   * --destructive-foreground. */
+  color: var(--danger);
 }
 
 .bubble.variantDestructive > .bubbleContent:is(button, a):hover {

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -206,7 +206,7 @@
  * is what promotes it to --foreground) — measured against the page
  * background it actually sits on, since ghost has no fill of its own:
  * 4.55:1 light / 6.62:1 dark, both clearing the 4.5:1 AA floor for this
- * 13px label text, so the alignment carries no WCAG cost.
+ * 12px label text, so the alignment carries no WCAG cost.
  */
 .variantGhost {
   background-color: var(--button-bg, transparent);

--- a/packages/ui-kit/src/components/button/button.module.css
+++ b/packages/ui-kit/src/components/button/button.module.css
@@ -151,17 +151,20 @@
 }
 
 /*
- * Mixes toward --foreground rather than the registry's `destructive/90`
- * fade to transparent. Fading an already-marginal fill toward the page
- * pulls it *toward* the label it has to contrast with — measured 4.57:1 at
- * rest but 4.34:1 on hover in light mode, i.e. the hover state alone fails
- * AA. Mixing with --foreground moves it away from the label in both themes
- * (the token flips with the theme, so light darkens and dark lightens):
- * 5.54:1 light / 7.64:1 dark. Same idiom and reasoning as
- * badge.module.css's destructive variant.
+ * --destructive-hover, not the registry's `destructive/90` fade to
+ * transparent and not the mix-toward---foreground recipe this rule used
+ * to share with Badge. The fade pulls an already-marginal fill toward the
+ * page and fails AA on hover in light mode; the mix darkens correctly in
+ * light but LIGHTENS in dark (where --foreground flips near-white),
+ * dropping the fixed --destructive-foreground label to 3.90:1 under the
+ * rebrand palette.
+ * --destructive-hover is a literal, same hex both modes (see theme.css),
+ * so the direction never depends on the theme — same fix, same reasoning
+ * as badge.module.css's destructive hover, and tokens.test.ts holds the
+ * label ≥ 4.5:1 on it in both themes.
  */
 .variantDestructive:hover {
-  background-color: var(--button-bg-hover, var(--button-bg, color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%)));
+  background-color: var(--button-bg-hover, var(--button-bg, var(--destructive-hover)));
   color: var(--button-fg-hover, var(--button-fg, var(--destructive-foreground)));
 }
 
@@ -205,7 +208,7 @@
  * Rest text is --muted-foreground, per the drawn spec (the hover fill below
  * is what promotes it to --foreground) — measured against the page
  * background it actually sits on, since ghost has no fill of its own:
- * 4.55:1 light / 6.62:1 dark, both clearing the 4.5:1 AA floor for this
+ * 9.45:1 light / 7.68:1 dark, both clearing the 4.5:1 AA floor for this
  * 12px label text, so the alignment carries no WCAG cost.
  */
 .variantGhost {
@@ -223,13 +226,11 @@
 
 /*
  * --link-foreground, not --primary: measured on the page background this
- * borderless variant actually sits on, --primary itself is 4.51:1 light
- * (barely over the 4.5:1 AA floor — 0.005 of headroom) and only 3.78:1
- * dark (a clear fail). Link has no drawn counterpart to match, so
- * --link-foreground is a text-safe token of its own — --primary-hover's
- * value in light (same violet family, real headroom at 4.98:1 instead of a
- * borderline pass), a lighter tint of the same hue in dark (see
- * theme.css).
+ * borderless variant actually sits on, --primary is 4.83:1 light but only
+ * 3.72:1 dark (a clear fail for 12px text). Link has no drawn counterpart
+ * to match, so --link-foreground is a text-safe token of its own —
+ * --primary-hover's value in light (same blue family, 4.95:1), a lighter
+ * tint of the same hue in dark (7.75:1 — see theme.css).
  */
 .variantLink {
   background-color: var(--button-bg, transparent);
@@ -248,7 +249,7 @@
  * above), so it only ever borders the page — the one surface every
  * variant needs to clear WCAG 1.4.11's 3:1 floor against. That single
  * surface is what makes a single tone per variant enough: default and
- * destructive keep a family color of their own (a violet a shade darker/
+ * destructive keep a family color of their own (a blue a shade darker/
  * lighter than --primary would otherwise be, and the destructive red's
  * equivalent — see theme.css's --primary-ring/--destructive-ring), because
  * their own accent reads better against the page than the plain kit-wide

--- a/packages/ui-kit/src/components/button/button.test.tsx
+++ b/packages/ui-kit/src/components/button/button.test.tsx
@@ -359,6 +359,25 @@ describe('Button focus-ring contrast', () => {
 });
 
 /*
+ * Guards the destructive hover fill recipe. The old recipe mixed
+ * --destructive toward --foreground, which darkens in light mode but
+ * LIGHTENS in dark (the token flips near-white there) and dropped the
+ * fixed white label to ~3.90:1 — under the 4.5:1 floor. The fix is the
+ * --destructive-hover token (tokens.test.ts holds the label to 4.5:1 on
+ * it in both themes), so the guard here is that this rule actually paints
+ * the token rather than re-deriving a theme-dependent mix.
+ */
+describe('Button destructive hover fill', () => {
+  it('paints --destructive-hover, not a mix toward --foreground', () => {
+    const hover = rules.find((rule) => rule.selector === '.variantDestructive:hover');
+    expect(hover, '.variantDestructive:hover rule missing').toBeDefined();
+    const background = declarationMap(hover?.body ?? '').get('background-color');
+    expect(background).toContain('var(--destructive-hover)');
+    expect(background).not.toContain('color-mix');
+  });
+});
+
+/*
  * Guards the custom-color override API: every variant's rest and hover
  * colors must route through the documented --button-* hooks (with the
  * variant's own token as the var() fallback), so a consumer class setting

--- a/packages/ui-kit/src/components/context-menu/context-menu.module.css
+++ b/packages/ui-kit/src/components/context-menu/context-menu.module.css
@@ -196,23 +196,20 @@
 }
 
 /*
- * Text mixes a little --foreground in rather than reading --destructive raw,
- * same deviation from the registry (and same reasoning) as
- * badge.module.css's destructive variant. Measured on the highlighted state,
- * where this item is at its worst: --destructive text over its own 10% tint
- * on --popover is 3.97:1 in light mode, under the 4.5:1 floor — the tint
- * pulls the surface toward the text it has to contrast with. The mix moves
- * the text away from it in both themes, since --foreground flips with the
- * theme: 4.82:1 light / 6.09:1 dark highlighted, 5.78:1 / 6.92:1 at rest.
+ * --danger over --danger-soft, not --destructive-based mixes — same seat,
+ * same fix, same reasoning as dropdown-menu.module.css's destructive item
+ * (see the full rationale there): --destructive is the fill red, --danger
+ * the AA-corrected text red, and tokens.test.ts's status matrix guards
+ * --danger against both --danger-soft and --popover in both themes.
  */
 .variantDestructive {
-  color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  color: var(--danger);
 }
 
 .variantDestructive:focus,
 .variantDestructive[data-highlighted] {
-  background-color: color-mix(in oklab, var(--destructive) 10%, transparent);
-  color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  background-color: var(--danger-soft);
+  color: var(--danger);
 }
 
 .checkboxItem,

--- a/packages/ui-kit/src/components/context-menu/context-menu.module.css
+++ b/packages/ui-kit/src/components/context-menu/context-menu.module.css
@@ -196,11 +196,12 @@
 }
 
 /*
- * --danger over --danger-soft, not --destructive-based mixes — same seat,
- * same fix, same reasoning as dropdown-menu.module.css's destructive item
- * (see the full rationale there): --destructive is the fill red, --danger
- * the AA-corrected text red, and tokens.test.ts's status matrix guards
- * --danger against both --danger-soft and --popover in both themes.
+ * --danger text over a 12% --danger tint of --popover — same seat, same
+ * fix, same reasoning and same measured ratios as
+ * dropdown-menu.module.css's destructive item (see the full rationale
+ * there): --destructive is the fill red, --danger the AA-corrected text
+ * red, and the popover-anchored tint is the focus cue --danger-soft was
+ * too faint to carry.
  */
 .variantDestructive {
   color: var(--danger);
@@ -208,7 +209,7 @@
 
 .variantDestructive:focus,
 .variantDestructive[data-highlighted] {
-  background-color: var(--danger-soft);
+  background-color: color-mix(in oklab, var(--danger) 12%, var(--popover));
   color: var(--danger);
 }
 

--- a/packages/ui-kit/src/components/context-menu/context-menu.test.tsx
+++ b/packages/ui-kit/src/components/context-menu/context-menu.test.tsx
@@ -1,5 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { declarationMap, extractRules } from '../../__test-utils__/css-rules';
 
 import {
   ContextMenu,
@@ -237,5 +243,35 @@ describe('ContextMenu', () => {
     expect(screen.getByRole('menuitem', { name: 'More tools' }).getAttribute('data-inset')).toBe(
       'true',
     );
+  });
+});
+
+/*
+ * Guards the destructive item's paint — same seat, same fix and same
+ * reasoning as dropdown-menu.test.tsx's copy of this guard: --danger is
+ * the text red, --danger-soft the highlight fill, both pairs held to
+ * 4.5:1 by tokens.test.ts's status matrix; a --destructive mix must not
+ * come back.
+ */
+describe('ContextMenu destructive item paint', () => {
+  const css = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), 'context-menu.module.css'),
+    'utf8',
+  );
+  const menuRules = extractRules(css);
+
+  it('paints --danger text and a --danger-soft highlight, no destructive mixes', () => {
+    const rest = menuRules.find((rule) => rule.selector === '.variantDestructive');
+    expect(rest, '.variantDestructive rule missing').toBeDefined();
+    expect(declarationMap(rest?.body ?? '').get('color')).toBe('var(--danger)');
+
+    const highlighted = menuRules.find((rule) =>
+      rule.selector.replace(/\s+/g, ' ').includes('.variantDestructive[data-highlighted]'),
+    );
+    expect(highlighted, 'highlighted .variantDestructive rule missing').toBeDefined();
+    const decls = declarationMap(highlighted?.body ?? '');
+    expect(decls.get('background-color')).toBe('var(--danger-soft)');
+    expect(decls.get('color')).toBe('var(--danger)');
+    expect(highlighted?.body).not.toContain('color-mix');
   });
 });

--- a/packages/ui-kit/src/components/context-menu/context-menu.test.tsx
+++ b/packages/ui-kit/src/components/context-menu/context-menu.test.tsx
@@ -249,9 +249,9 @@ describe('ContextMenu', () => {
 /*
  * Guards the destructive item's paint — same seat, same fix and same
  * reasoning as dropdown-menu.test.tsx's copy of this guard: --danger is
- * the text red, --danger-soft the highlight fill, both pairs held to
- * 4.5:1 by tokens.test.ts's status matrix; a --destructive mix must not
- * come back.
+ * the text red (held ≥ 4.5:1 against --popover by tokens.test.ts), the
+ * highlight fill a popover-anchored 12% danger tint; a mix anchored to
+ * --foreground or a raw --destructive must not come back.
  */
 describe('ContextMenu destructive item paint', () => {
   const css = readFileSync(
@@ -260,7 +260,7 @@ describe('ContextMenu destructive item paint', () => {
   );
   const menuRules = extractRules(css);
 
-  it('paints --danger text and a --danger-soft highlight, no destructive mixes', () => {
+  it('paints --danger text and a popover-anchored danger tint, never a foreground mix', () => {
     const rest = menuRules.find((rule) => rule.selector === '.variantDestructive');
     expect(rest, '.variantDestructive rule missing').toBeDefined();
     expect(declarationMap(rest?.body ?? '').get('color')).toBe('var(--danger)');
@@ -270,8 +270,11 @@ describe('ContextMenu destructive item paint', () => {
     );
     expect(highlighted, 'highlighted .variantDestructive rule missing').toBeDefined();
     const decls = declarationMap(highlighted?.body ?? '');
-    expect(decls.get('background-color')).toBe('var(--danger-soft)');
+    expect(decls.get('background-color')).toBe(
+      'color-mix(in oklab, var(--danger) 12%, var(--popover))',
+    );
     expect(decls.get('color')).toBe('var(--danger)');
-    expect(highlighted?.body).not.toContain('color-mix');
+    expect(highlighted?.body).not.toContain('--foreground');
+    expect(highlighted?.body).not.toContain('--destructive');
   });
 });

--- a/packages/ui-kit/src/components/data-table/data-table.module.css
+++ b/packages/ui-kit/src/components/data-table/data-table.module.css
@@ -94,7 +94,7 @@
 }
 
 /* --icon-size-xs, not the sm every other Button icon takes: the frame draws
- * the sort indicator's glyph at 12px, and next to an 11px Mono label a 16px
+ * the sort indicator's glyph at 12px, and next to a 10px Mono label a 16px
  * one both overshoots the drawing and reads as raised — its ink box is
  * taller than the label's, so centering the two boxes leaves the glyph
  * looking lifted off the baseline it should share. */
@@ -132,7 +132,7 @@
 }
 
 /* Meta, matching the cells above it — the frame sets the whole bar in the
- * table's own 12px text, not the 15px page Body the recipe's utilities
+ * table's own 12px text, not the 14px page Body the recipe's utilities
  * left it at. */
 .selectedCount {
   flex: 1;

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.module.css
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.module.css
@@ -168,23 +168,26 @@
 }
 
 /*
- * Text mixes a little --foreground in rather than reading --destructive raw,
- * same deviation from the registry (and same reasoning) as
- * badge.module.css's destructive variant. Measured on the highlighted state,
- * where this item is at its worst: --destructive text over its own 10% tint
- * on --popover is 3.97:1 in light mode, under the 4.5:1 floor — the tint
- * pulls the surface toward the text it has to contrast with. The mix moves
- * the text away from it in both themes, since --foreground flips with the
- * theme: 4.82:1 light / 6.09:1 dark highlighted, 5.78:1 / 6.92:1 at rest.
+ * --danger over --danger-soft, not --destructive-based mixes. This is a
+ * TEXT seat, and --destructive is the kit's fill red, verified only under
+ * --destructive-foreground; the mix-toward---foreground recipe this rule
+ * used to share with the old Badge darkens correctly in light mode but
+ * LIGHTENS in dark (--foreground flips near-white there), landing the
+ * highlighted state under the 4.5:1 floor on the rebrand palette. --danger
+ * is the AA-corrected text red every other destructive TEXT seat already
+ * moved to (FieldError, Alert, Toast — see theme.css), and its -soft fill
+ * is the tint carried for exactly this kind of surface: tokens.test.ts's
+ * status matrix holds --danger ≥ 4.5:1 against --danger-soft AND against
+ * --popover, so both states here are guarded at the token level.
  */
 .variantDestructive {
-  color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  color: var(--danger);
 }
 
 .variantDestructive:focus,
 .variantDestructive[data-highlighted] {
-  background-color: color-mix(in oklab, var(--destructive) 10%, transparent);
-  color: color-mix(in oklab, var(--destructive) 90%, var(--foreground) 10%);
+  background-color: var(--danger-soft);
+  color: var(--danger);
 }
 
 .checkboxItem,

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.module.css
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.module.css
@@ -168,17 +168,25 @@
 }
 
 /*
- * --danger over --danger-soft, not --destructive-based mixes. This is a
- * TEXT seat, and --destructive is the kit's fill red, verified only under
+ * --danger text, not --destructive-based mixes. This is a TEXT seat, and
+ * --destructive is the kit's fill red, verified only under
  * --destructive-foreground; the mix-toward---foreground recipe this rule
  * used to share with the old Badge darkens correctly in light mode but
  * LIGHTENS in dark (--foreground flips near-white there), landing the
  * highlighted state under the 4.5:1 floor on the rebrand palette. --danger
  * is the AA-corrected text red every other destructive TEXT seat already
- * moved to (FieldError, Alert, Toast — see theme.css), and its -soft fill
- * is the tint carried for exactly this kind of surface: tokens.test.ts's
- * status matrix holds --danger ≥ 4.5:1 against --danger-soft AND against
- * --popover, so both states here are guarded at the token level.
+ * moved to (FieldError, Alert, Toast — see theme.css), and tokens.test.ts's
+ * status matrix holds it ≥ 4.5:1 against --popover.
+ *
+ * The highlight fill is a 12% tint of --danger over --popover, NOT
+ * --danger-soft: the text keeps one color at rest and highlighted, so the
+ * fill change is the only focus cue, and --danger-soft sits too close to
+ * the popover for that job (1.10:1 light / 1.05:1 dark — weaker than the
+ * sibling rows' --accent highlight at 1.16/1.12). The 12% tint measures
+ * 1.20:1 light / 1.17:1 dark against --popover, and --danger stays clear
+ * on it (5.26:1 / 5.68:1). Unlike the removed recipe, this mix is anchored
+ * to --popover, not --foreground, so its direction never flips with the
+ * theme.
  */
 .variantDestructive {
   color: var(--danger);
@@ -186,7 +194,7 @@
 
 .variantDestructive:focus,
 .variantDestructive[data-highlighted] {
-  background-color: var(--danger-soft);
+  background-color: color-mix(in oklab, var(--danger) 12%, var(--popover));
   color: var(--danger);
 }
 

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.test.tsx
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.test.tsx
@@ -273,12 +273,13 @@ describe('DropdownMenu', () => {
 /*
  * Guards the destructive item's paint. --destructive is the kit's FILL
  * red, verified only under --destructive-foreground; as menu TEXT it needs
- * the AA-corrected --danger, and the highlighted fill needs --danger-soft —
- * the pair tokens.test.ts's status matrix already holds to 4.5:1 (against
- * each other AND against --popover). The old recipe mixed --destructive
- * toward --foreground, which lightens in dark mode and fell under the
- * floor; this guard notices if a mix ever comes back. Reads the raw module
- * CSS (jsdom computes no styles), same as badge.test.tsx.
+ * the AA-corrected --danger (held ≥ 4.5:1 against --popover by
+ * tokens.test.ts's status matrix). The highlight fill is a 12% tint of
+ * --danger over --popover — anchored to the popover so its direction
+ * never flips with the theme, unlike the removed mix toward --foreground
+ * that fell under the floor in dark mode; this guard notices if a
+ * foreground-anchored mix ever comes back. Reads the raw module CSS
+ * (jsdom computes no styles), same as badge.test.tsx.
  */
 describe('DropdownMenu destructive item paint', () => {
   const css = readFileSync(
@@ -287,7 +288,7 @@ describe('DropdownMenu destructive item paint', () => {
   );
   const menuRules = extractRules(css);
 
-  it('paints --danger text and a --danger-soft highlight, no destructive mixes', () => {
+  it('paints --danger text and a popover-anchored danger tint, never a foreground mix', () => {
     const rest = menuRules.find((rule) => rule.selector === '.variantDestructive');
     expect(rest, '.variantDestructive rule missing').toBeDefined();
     expect(declarationMap(rest?.body ?? '').get('color')).toBe('var(--danger)');
@@ -297,8 +298,11 @@ describe('DropdownMenu destructive item paint', () => {
     );
     expect(highlighted, 'highlighted .variantDestructive rule missing').toBeDefined();
     const decls = declarationMap(highlighted?.body ?? '');
-    expect(decls.get('background-color')).toBe('var(--danger-soft)');
+    expect(decls.get('background-color')).toBe(
+      'color-mix(in oklab, var(--danger) 12%, var(--popover))',
+    );
     expect(decls.get('color')).toBe('var(--danger)');
-    expect(highlighted?.body).not.toContain('color-mix');
+    expect(highlighted?.body).not.toContain('--foreground');
+    expect(highlighted?.body).not.toContain('--destructive');
   });
 });

--- a/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.test.tsx
+++ b/packages/ui-kit/src/components/dropdown-menu/dropdown-menu.test.tsx
@@ -1,5 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { declarationMap, extractRules } from '../../__test-utils__/css-rules';
 
 import {
   DropdownMenu,
@@ -261,5 +267,38 @@ describe('DropdownMenu', () => {
     const menu = screen.getByRole('menu');
     expect(container.contains(menu)).toBe(true);
     container.remove();
+  });
+});
+
+/*
+ * Guards the destructive item's paint. --destructive is the kit's FILL
+ * red, verified only under --destructive-foreground; as menu TEXT it needs
+ * the AA-corrected --danger, and the highlighted fill needs --danger-soft —
+ * the pair tokens.test.ts's status matrix already holds to 4.5:1 (against
+ * each other AND against --popover). The old recipe mixed --destructive
+ * toward --foreground, which lightens in dark mode and fell under the
+ * floor; this guard notices if a mix ever comes back. Reads the raw module
+ * CSS (jsdom computes no styles), same as badge.test.tsx.
+ */
+describe('DropdownMenu destructive item paint', () => {
+  const css = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), 'dropdown-menu.module.css'),
+    'utf8',
+  );
+  const menuRules = extractRules(css);
+
+  it('paints --danger text and a --danger-soft highlight, no destructive mixes', () => {
+    const rest = menuRules.find((rule) => rule.selector === '.variantDestructive');
+    expect(rest, '.variantDestructive rule missing').toBeDefined();
+    expect(declarationMap(rest?.body ?? '').get('color')).toBe('var(--danger)');
+
+    const highlighted = menuRules.find((rule) =>
+      rule.selector.replace(/\s+/g, ' ').includes('.variantDestructive[data-highlighted]'),
+    );
+    expect(highlighted, 'highlighted .variantDestructive rule missing').toBeDefined();
+    const decls = declarationMap(highlighted?.body ?? '');
+    expect(decls.get('background-color')).toBe('var(--danger-soft)');
+    expect(decls.get('color')).toBe('var(--danger)');
+    expect(highlighted?.body).not.toContain('color-mix');
   });
 });

--- a/packages/ui-kit/src/components/empty/empty.module.css
+++ b/packages/ui-kit/src/components/empty/empty.module.css
@@ -99,7 +99,7 @@
 }
 
 .emptyDescription a:hover {
-  color: var(--primary);
+  color: var(--link-foreground);
 }
 
 .emptyContent {

--- a/packages/ui-kit/src/components/field/field.module.css
+++ b/packages/ui-kit/src/components/field/field.module.css
@@ -67,7 +67,12 @@
 }
 
 .field[data-invalid='true'] {
-  color: var(--destructive);
+  /* --danger, not --destructive: this paints TEXT (inherited by
+   * FieldLabel/FieldError alike), and --danger is the status token
+   * theme.css corrected to clear 4.5:1 as label text over --card and
+   * --background in both themes, unlike --destructive, which is only
+   * verified as a solid fill under --destructive-foreground. */
+  color: var(--danger);
 }
 
 .orientationVertical {
@@ -172,7 +177,7 @@
 }
 
 .fieldDescription a:hover {
-  color: var(--primary);
+  color: var(--link-foreground);
 }
 
 .fieldSeparator {
@@ -205,7 +210,10 @@
   line-height: var(--text-label-line-height);
   font-weight: var(--text-body-weight);
   letter-spacing: var(--text-label-tracking);
-  color: var(--destructive);
+  /* --danger, not --destructive — see the --field[data-invalid] comment
+   * above: at this 12px size, --destructive only measures 4.29:1 on the
+   * page / 3.80:1 on --card, both under the 4.5:1 text floor. */
+  color: var(--danger);
 }
 
 .fieldErrorList {

--- a/packages/ui-kit/src/components/item/item.module.css
+++ b/packages/ui-kit/src/components/item/item.module.css
@@ -213,7 +213,7 @@
 }
 
 .itemDescription a:hover {
-  color: var(--primary);
+  color: var(--link-foreground);
 }
 
 .sizeXs .itemDescription {

--- a/packages/ui-kit/src/components/questionnaire/questionnaire.md
+++ b/packages/ui-kit/src/components/questionnaire/questionnaire.md
@@ -179,10 +179,10 @@ Every part carries data attributes you can key CSS off:
   English strings that would need translating.
 - **Token-scale spacing.** The kit's spacing scale has no 10px step, so
   upstream's `gap-2.5`/`py-2.5` inside a choice row land on `--space-2`
-  (8px) here; the shortcut cap uses the kit's 11px `--text-mono-size`
-  rather than upstream's 10px. Every other measurement (44px row,
-  8px radius, 16px indicator, 20px cap, 8px choice gap, 16px item and root
-  gaps) matches upstream exactly.
+  (8px) here; the shortcut cap uses the kit's `--text-mono-size`, which
+  the Studio blue rebrand moved to 10px — the same size upstream draws.
+  Every other measurement (44px row, 8px radius, 16px indicator, 20px cap,
+  8px choice gap, 16px item and root gaps) matches upstream exactly.
 - **Focus is the kit's field ring.** Upstream draws a 3px translucent halo
   outside the row; the kit's field idiom (`input.module.css`) is a
   recolored border plus an inset ring, so the choice row wears that

--- a/packages/ui-kit/src/components/questionnaire/questionnaire.module.css
+++ b/packages/ui-kit/src/components/questionnaire/questionnaire.module.css
@@ -359,7 +359,10 @@
    * is the extra step upstream gives it so a validation message reads as a
    * response to the block above rather than another field in it. */
   margin: var(--space-2) 0 0;
-  color: var(--destructive);
+  /* --danger, not --destructive — see field.module.css's --fieldError
+   * comment: --destructive is only verified as a solid fill under
+   * --destructive-foreground, not as text on the page/card. */
+  color: var(--danger);
   font-size: var(--text-body-size);
   line-height: var(--text-body-line-height);
   font-weight: var(--text-body-weight);

--- a/packages/ui-kit/src/components/sidebar/sidebar.md
+++ b/packages/ui-kit/src/components/sidebar/sidebar.md
@@ -228,8 +228,8 @@ Tailwind utility strings, re-expressed on the kit's token scales
 (`p-2` → `--space-2`, `h-8` → `--control-height-sm`, `w-5` → `--space-5`,
 `size-4` → `--icon-size-sm`). Rows are 28/32/48px for `sm`/`default`/`lg`,
 sub-rows 28px at both sizes, badges and actions 20px squares centred on
-their row. The type ramp is the kit's, so body text is 15px where
-upstream's `text-sm` is 14px.
+their row. The type ramp is the kit's — since the Studio blue rebrand its
+body role is 14/20, which happens to coincide with upstream's `text-sm`.
 
 - **Cookie read happens after mount, not during render.** Upstream's own
   model reads the `sidebar_state` cookie in a Next.js Server Component and

--- a/packages/ui-kit/src/components/table/table.module.css
+++ b/packages/ui-kit/src/components/table/table.module.css
@@ -295,7 +295,7 @@
   /*
    * Source: text-muted-foreground, against --background (a caption sits
    * outside any row tint, so no mixed-tint approximation is needed):
-   * 4.73:1 light, 7.63:1 dark — clears the 4.5:1 AA floor for normal text
+   * 9.45:1 light, 7.68:1 dark — clears the 4.5:1 AA floor for normal text
    * in both themes.
    */
   color: var(--muted-foreground);

--- a/packages/ui-kit/src/components/table/table.module.css
+++ b/packages/ui-kit/src/components/table/table.module.css
@@ -175,10 +175,12 @@
    * Its column labels are the one place the drawn table leaves Inter: they
    * are set in JetBrains Mono, uppercase, at 10/14 regular. That is the
    * Mono role, so the role is applied whole (family/size/line-height/
-   * weight/tracking) and the drawn 10/14 rides up to the ramp's 11/16
-   * under the tokens-win ruling (see theme.css) — the alternative, keeping
-   * Meta's Inter and hand-setting a weight, drops the deliberate mono
-   * column-label voice that runs through every variant of the frame.
+   * weight/tracking) under the tokens-win ruling (see theme.css) — since
+   * the Studio blue rebrand moved the ramp's own Mono step to 10/14, the
+   * drawn spec and the role now coincide exactly, with nothing left to
+   * round. The alternative, keeping Meta's Inter and hand-setting a
+   * weight, drops the deliberate mono column-label voice that runs
+   * through every variant of the frame.
    *
    * The label color stays --subtle-foreground, the token theme.css names
    * for exactly this consumer. The frame draws these labels in its own

--- a/packages/ui-kit/src/components/tabs/tabs.module.css
+++ b/packages/ui-kit/src/components/tabs/tabs.module.css
@@ -2,7 +2,7 @@
  * Tabs styles — structure translated from shadcn/ui (MIT), visuals per the
  * F-mockups' Tabs/Segment spec (Figma frame 196:382, Kind=tab): trackless
  * list, the active tab raised on --surface-elevated, the drawn 13/18
- * medium labels (shipped at the ramp's 13/16 — see .trigger below),
+ * medium labels (shipped at the ramp's 12/16 — see .trigger below),
  * disabled at 0.42. The spec's Kind=segment (bordered items on
  * --border-strong) is NOT a Tabs variant — the design file's own component
  * description says "shadcn Tabs and Toggle Group segment states", i.e. the

--- a/packages/ui-kit/src/components/tabs/tabs.module.css
+++ b/packages/ui-kit/src/components/tabs/tabs.module.css
@@ -105,8 +105,8 @@
   /*
    * The plain token is enough now: with the --muted track gone (see
    * .variantDefault), inactive labels sit on the page surfaces, where
-   * --muted-foreground clears AA in both themes — measured 4.55:1 on
-   * --background / 4.76:1 on --card in light, 6.62:1 / 6.04:1 in dark.
+   * --muted-foreground clears AA in both themes — measured 9.45:1 on
+   * --background / 10.35:1 on --card in light, 7.68:1 / 6.96:1 in dark.
    * The old translation needed a foreground/muted mix here only because
    * its own track was the backdrop; that reasoning left with the track.
    */

--- a/packages/ui-kit/src/components/toast/toast.module.css
+++ b/packages/ui-kit/src/components/toast/toast.module.css
@@ -260,7 +260,10 @@
 }
 
 .iconDestructive {
-  color: var(--destructive);
+  /* --danger, not --destructive — the Toast sits on --popover (== --card
+   * both modes), where --destructive is only verified as a fill under
+   * --destructive-foreground, not as a foreground color itself. */
+  color: var(--danger);
 }
 
 .iconSpin {

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -8,30 +8,46 @@
  * own surface from these same tokens is what makes the rest of the page
  * match. The token structure derives from shadcn/ui (MIT,
  * https://ui.shadcn.com; see the repository NOTICE file for attribution);
- * the values implement the Studio palette from the F-mockups Figma file
- * (variable collection "Studio / shadcn", modes Light + Dark). Figma
- * namespaces the same tokens under a `color/` folder (`color/background`);
- * the CSS names stay unprefixed per the shadcn convention the collection
- * itself is named after. A handful of collection entries are drawn by no
- * mockup node, so their per-mode values are unreadable via the Figma API;
- * those carry a `derived:` comment with the reasoning, and are the ones to
+ * the values implement the Studio BLUE rebrand recorded on the mockups'
+ * token spec frame "02 · Tokens, type & elevation" (node 40001232:5254),
+ * which superseded the violet "Studio / shadcn" collection this file
+ * previously carried. That frame's swatches label their WEB syntax with a
+ * `color/` prefix (`var(--color-background)`); the CSS names here stay
+ * unprefixed per the shadcn convention regardless — renaming the public
+ * token surface would break every consumer for zero semantic gain, and the
+ * `color/<name>` ↔ `--<name>` mapping is 1:1 either way. Entries the frame
+ * does not draw (card, popover, secondary, destructive, the sidebar block)
+ * carry a `derived:` comment with the reasoning, and are the ones to
  * re-check when the design file pins them down.
  *
- * Deliberately not here: the `color/workflow/*` and `color/scenario-canvas`
- * entries from the same collection. Figma itself exports them under its own
- * `--studio-*` namespace, which is the line this file follows — they name
- * one consumer's workflow surfaces rather than any kit semantic, and belong
- * to that app's own stylesheet.
+ * WCAG ruling (2026-08-31, standing): a drawn value that fails its
+ * contrast floor gets a corrected value in code — the deviation is recorded
+ * at the token, never shipped as a "kept as drawn" footnote. This pass
+ * deviates from the frame in exactly four places, all status colors used as
+ * 12px badge/avatar labels over their own -soft fills: light --success
+ * #059669→#047857, light --warning #f59e0b→#b45309, light --danger
+ * #e11d48→#be123c, dark --danger #e11d48→#fb7185 (per-token comments carry
+ * the measured ratios). Open designer question: pin AA-passing status
+ * values in the Figma file.
+ *
+ * Deliberately not here: the `--studio-color-*` entries the same frame
+ * draws (progress-value/track, icon-subtle/icon-selected, and the studio
+ * copy of selection-subtle). Figma exports them under its own `--studio-*`
+ * namespace, which is the line this file follows — they name one consumer's
+ * workflow surfaces rather than any kit semantic, and belong to that app's
+ * own stylesheet. (`scenario-canvas`, previously excluded on the same
+ * ground, moved INTO the `color/` namespace with the rebrand and is now
+ * carried below.)
  *
  * The line is namespace, not "is a component reading it today": a few groups
- * here (Sidebar Navigation, the code pair, --blue, the four *-soft fills)
- * are unread by any current component. They are part of the collection's
- * unprefixed palette and are carried so a consumer painting a page around
- * the kit — or a later kit component — brands them from the same surface as
- * everything else, instead of finding a hole. Each such group says so at its
- * own declaration; app LAYOUT itself stays a non-goal (see design-notes),
- * so the sidebar tokens are colors for a consumer's own chrome, not a
- * promise of a Sidebar component.
+ * here (Sidebar Navigation, the code pair, --blue, --scenario-canvas,
+ * --artifact-accent-icon) are unread by any current component. They are part
+ * of the collection's unprefixed palette and are carried so a consumer
+ * painting a page around the kit — or a later kit component — brands them
+ * from the same surface as everything else, instead of finding a hole. Each
+ * such group says so at its own declaration; app LAYOUT itself stays a
+ * non-goal (see design-notes), so the sidebar tokens are colors for a
+ * consumer's own chrome, not a promise beyond the shipped Sidebar parts.
  *
  * Basic branding happens on the consumer side by overriding these variables.
  * Dark mode: set data-theme="dark" on <html>/<body> for explicit control, or
@@ -61,34 +77,37 @@
 
   /*
    * Popover chrome shared by every card-like popup (Dialog/DropdownMenu/
-   * Select/Toast): a 1px ring plus a two-layer drop shadow, declared once
-   * here rather than hand-duplicated in each module. All
-   * four consumers already paint their surface from the --popover/
+   * Select/Toast): a 1px ring plus a drop shadow, declared once here rather
+   * than hand-duplicated in each module. The geometry and strength follow
+   * the rebrand frame's "Studio/Elevation/200" spec (0 8 24 at a 12% tint
+   * of the light foreground #0F172A1F), which is the elevation the drawn
+   * overlays sit on; the frame's other elevation steps (100/300/Dock top)
+   * have no kit consumer yet and are not carried as tokens until one does.
+   * All four consumers already paint their surface from the --popover/
    * --popover-foreground pair, so this chrome takes the same family name
    * rather than "--overlay-*", which would read as a variant of --overlay
    * above (the modal *scrim*, an unrelated concept — a popover has no
    * backdrop) and reversed word order from it besides. --popover-shadow is
-   * COMPOSED from --popover-border (both its layers are that same color),
-   * not just co-located with it: rebranding the hairline recolors the
-   * shadow along with it, by construction, not as a separate edit anyone
-   * has to remember to make. Same rationale as --overlay above for living
-   * here un-redefined regardless: both are mixed from --foreground, so the
-   * computed value already flips correctly per theme without a separate
-   * light/dark declaration.
+   * COMPOSED from --popover-border (its layer is that same color), not just
+   * co-located with it: rebranding the hairline recolors the shadow along
+   * with it, by construction, not as a separate edit anyone has to remember
+   * to make. Same rationale as --overlay above for living here un-redefined
+   * regardless: both are mixed from --foreground, so the computed value
+   * already flips correctly per theme without a separate light/dark
+   * declaration.
    */
-  --popover-border: color-mix(in oklab, var(--foreground) 10%, transparent);
-  --popover-shadow:
-    0 4px 6px -1px var(--popover-border),
-    0 2px 4px -2px var(--popover-border);
+  --popover-border: color-mix(in oklab, var(--foreground) 12%, transparent);
+  --popover-shadow: 0 8px 24px 0 var(--popover-border);
 
   /*
    * Radius scale. Components consume only the derived steps; consumers
    * rebrand by overriding --radius alone and the whole scale follows. The
-   * offsets place the Studio scale (sm 6 / md 8 / lg 12 / xl 16) on the
-   * 8px base — note md, not lg, sits at the base value, unlike shadcn v4's
-   * derivation. --radius-xs has no Figma counterpart; it predates the
-   * Studio scale and keeps its 4px slot. Corner shape isn't a light/dark
-   * concern, so none of this is redefined per-theme.
+   * offsets place the Studio scale (sm 6 / md 8 / lg 12 / xl 16, unchanged
+   * by the blue rebrand) on the 8px base — note md, not lg, sits at the
+   * base value, unlike shadcn v4's derivation. --radius-xs has no Figma
+   * counterpart; it predates the Studio scale and keeps its 4px slot.
+   * Corner shape isn't a light/dark concern, so none of this is redefined
+   * per-theme.
    */
   --radius: 0.5rem;
   --radius-xs: calc(var(--radius) - 4px);
@@ -112,8 +131,9 @@
    * Heights follow the DRAWN control specimens (32/36/40) — the design
    * file's "Token architecture" text says 32/40/44, but the drawn mockups
    * are the source of truth for that discrepancy (a standing ruling; see
-   * design-notes.md). Buttons sit on sm/md/lg directly; the drawn fields are
-   * 40px (the lg step) and the filter chip 36px (md).
+   * design-notes.md). The rebrand frame's layout panel confirms 32/36/40.
+   * Buttons sit on sm/md/lg directly; the drawn fields are 40px (the lg
+   * step) and the filter chip 36px (md).
    */
   --control-height-sm: 2rem;
   --control-height-md: 2.25rem;
@@ -142,71 +162,104 @@
   --ring-inset: calc(var(--border-width-focus) - var(--border-width));
 
   /*
-   * Typography (Figma "Typography / Specimens", frame 175:371 — the Studio
-   * text styles, recorded verbatim). The kit ships no font FILES: loading
-   * Inter/JetBrains Mono (@font-face, preload, subsetting) is the
-   * consumer's build concern; until they load, the fallback stacks keep
-   * metrics close. "Body Medium"/"Mono Medium" are not separate roles —
-   * the same metrics at weight 500.
+   * Typography — the Studio blue rebrand's "Studio/Type" ramp (the
+   * "02 · Tokens, type & elevation" frame, node 40001232:5254), carried on
+   * the kit's existing role names: the roles are the public API and the
+   * NEW ramp's styles map onto them rather than renaming them —
+   *   display   <- Page Title (26/32 semibold)
+   *   heading-2 <- Section Title (16/24 semibold — same metrics the role
+   *                already had)
+   *   body      <- UI Primary Regular (14/20)
+   *   label     <- UI Secondary Medium (12/16) — the drawn Tabs trigger's
+   *                own binding; Badge (UI Secondary Medium in the spec
+   *                sheet) already sat on exactly these numbers via its
+   *                meta-size + label-weight mix
+   *   meta      <- UI Secondary Regular (12/16 — same metrics as before)
+   *   mono      <- System Micro (10/14, --font-mono)
+   * All Studio/Type styles carry letter-spacing 0, so every role's
+   * tracking is normalized to 0 with them. heading-1 (20/28) has NO
+   * counterpart in the new ramp — the kit keeps it as an interpolated step
+   * between Page Title and Section Title rather than collapsing two
+   * heading roles onto one size. Also deliberately not carried: Display
+   * Metric (36/40), Foundation Hero (56/64) and Avatar Micro (10/14
+   * semibold) — no kit component consumes a role at those slots (Avatar's
+   * sm fallback sits on meta). Open at the component level, not the ramp:
+   * the drawn compact Button binds UI Secondary SEMI BOLD (600) while
+   * Button reads --text-label-weight (500) — a per-component weight
+   * question for the components pass, since label's 500 also dresses
+   * menus, tooltips and table headers.
+   *
+   * The kit ships no font FILES: loading Inter/JetBrains Mono (@font-face,
+   * preload, subsetting) is the consumer's build concern; until they load,
+   * the fallback stacks keep metrics close.
    *
    * The specimens-vs-ramp conflict is settled: the drawn component
-   * specimens hand-set line-heights the ramp doesn't have (13/18, 12/17,
-   * plus a 10px table header with no role at all), and the ruling is that
-   * the token system wins — component text sits on these roles, off-ramp
-   * drawn metrics were normalized to the nearest role, and the same ruling
-   * snapped off-grid spacing onto --space-*. A tokens.test.ts guard enforces
-   * it; design-notes.md records it.
+   * specimens hand-set line-heights the ramp doesn't have, and the ruling
+   * is that the token system wins — component text sits on these roles,
+   * off-ramp drawn metrics were normalized to the nearest role, and the
+   * same ruling snapped off-grid spacing onto --space-*. A tokens.test.ts
+   * guard enforces it; design-notes.md records it.
    */
   --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  /* Display: 28/34 semibold. */
-  --text-display-size: 1.75rem;
-  --text-display-line-height: 2.125rem;
+  /* Display: 26/32 semibold (Studio/Type/Page Title). */
+  --text-display-size: 1.625rem;
+  --text-display-line-height: 2rem;
   --text-display-weight: 600;
-  --text-display-tracking: -0.4px;
-  /* Heading 1: 20/28 semibold. */
+  --text-display-tracking: 0px;
+  /* Heading 1: 20/28 semibold (kit interpolation, no ramp counterpart —
+   * see the header comment above). */
   --text-heading-1-size: 1.25rem;
   --text-heading-1-line-height: 1.75rem;
   --text-heading-1-weight: 600;
-  --text-heading-1-tracking: -0.2px;
-  /* Heading 2: 16/24 semibold. */
+  --text-heading-1-tracking: 0px;
+  /* Heading 2: 16/24 semibold (Studio/Type/Section Title). */
   --text-heading-2-size: 1rem;
   --text-heading-2-line-height: 1.5rem;
   --text-heading-2-weight: 600;
-  --text-heading-2-tracking: -0.1px;
-  /* Body: 15/20 regular (Body Medium = weight 500). */
-  --text-body-size: 0.9375rem;
+  --text-heading-2-tracking: 0px;
+  /* Body: 14/20 regular (Studio/Type/UI Primary Regular; the Medium and
+   * Semi Bold cuts are the same metrics at 500/600). */
+  --text-body-size: 0.875rem;
   --text-body-line-height: 1.25rem;
   --text-body-weight: 400;
   --text-body-tracking: 0px;
-  /* Label: 13/16 medium. */
-  --text-label-size: 0.8125rem;
+  /* Label: 12/16 medium (Studio/Type/UI Secondary Medium). */
+  --text-label-size: 0.75rem;
   --text-label-line-height: 1rem;
   --text-label-weight: 500;
-  --text-label-tracking: 0.1px;
-  /* Meta: 12/16 regular. */
+  --text-label-tracking: 0px;
+  /* Meta: 12/16 regular (Studio/Type/UI Secondary Regular). */
   --text-meta-size: 0.75rem;
   --text-meta-line-height: 1rem;
   --text-meta-weight: 400;
-  --text-meta-tracking: 0.1px;
-  /* Mono: 11/16 regular, --font-mono (Mono Medium = weight 500). */
-  --text-mono-size: 0.6875rem;
-  --text-mono-line-height: 1rem;
+  --text-meta-tracking: 0px;
+  /* Mono: 10/14 regular, --font-mono (Studio/Type/System Micro; System
+   * Micro Medium = the same metrics at 500). */
+  --text-mono-size: 0.625rem;
+  --text-mono-line-height: 0.875rem;
   --text-mono-weight: 400;
   --text-mono-tracking: 0px;
 }
 
 :root,
 [data-theme='light'] {
-  --background: #f8fafc;
+  --background: #f1f5f9;
   --foreground: #0f172a;
 
   /* Flat and raised panel fills. Both are white in light mode — the pair
-   * only separates visually in dark mode — but components must still pick
-   * the semantically right one so the dark theme comes out layered. */
+   * only separates visually against the (now slate-tinted) page behind
+   * them — but components must still pick the semantically right one so a
+   * future re-split of the dark pair comes out layered. The rebrand frame
+   * draws the dark pair COLLAPSED onto one value too (see the dark block);
+   * both entries stay because the seam is the token name, not today's
+   * value. */
   --surface: #ffffff;
   --surface-elevated: #ffffff;
 
+  /* derived: the frame draws no card/* entries; card keeps mirroring
+   * --surface (white over the slate page), with hover one step toward the
+   * page tint. */
   --card: #ffffff;
   --card-hover: #f8fafc;
   --card-foreground: #0f172a;
@@ -216,145 +269,182 @@
   --popover: #ffffff;
   --popover-foreground: #0f172a;
 
-  --primary: #8257e6;
-  /* derived (light only): the dark mode's hover is the light primary, so
-   * the light hover takes the dark primary — one step down the same ramp.
-   * The dark value is Figma's own. */
-  --primary-hover: #7c4fde;
+  /* The Studio brand blue ("blue-bright" in the frame's primitive ramp).
+   * White text on it measures 5.29:1 in both modes (same hex both modes,
+   * per the frame). */
+  --primary: #0065e3;
+  --primary-hover: #2668c5;
   --primary-foreground: #ffffff;
   /* Button default variant's focus-ring tone, measured against
-   * --background: 6.79:1 light / 7.23:1 dark (the dark values below carry
-   * no comment of their own — per this file's convention, a token's
-   * comment lives in the light block only). Literal hexes, not var()
-   * aliases, because the contrast tests parse hex directly (see
-   * src/__test-utils__/contrast.ts). A dedicated token, not --primary
-   * itself: the ring is drawn OUTSIDE the button (see button.module.css),
-   * so it only ever borders the page, and a violet a shade darker than
-   * --primary reads more clearly there than --primary's own value would. */
-  --primary-ring: #6d28d9;
-  --secondary: #f1f5f9;
+   * --background: 4.95:1 light / 7.75:1 dark against the 3:1 floor (the
+   * dark values below carry no comment of their own — per this file's
+   * convention, a token's comment lives in the light block only). Literal
+   * hexes, not var() aliases, because the contrast tests parse hex
+   * directly (see src/__test-utils__/contrast.ts). derived: the frame
+   * draws no ring-family entries beyond --ring itself; light takes the
+   * brand ramp's next step down (--primary-hover's own hex, duplicated as
+   * a literal on purpose), dark the ramp's light "blue-sky" tint — the
+   * ring is drawn OUTSIDE the button (see button.module.css), so it only
+   * ever borders the page. */
+  --primary-ring: #2668c5;
+  /* derived: the old light secondary equalled --muted, but the rebrand
+   * moved --background onto that same slate-50 — a secondary fill equal to
+   * the page would vanish. One step down the frame's neutral ramp
+   * (neutral-100) keeps it a visible fill (1.13:1 against the page) the
+   * way the old value was against the old page. Dark mirrors the move one
+   * step the OTHER way from its (also page-equal) muted — see the dark
+   * block. */
+  --secondary: #e2e8f0;
   --secondary-foreground: #0f172a;
-  /* derived (dark only): light muted equals light secondary in the
-   * collection, so dark muted follows dark secondary the same way. */
   --muted: #f1f5f9;
-  --muted-foreground: #64748b;
+  /* The frame collapses muted-foreground, subtle-foreground and
+   * code-foreground onto one slate-600 in light (and one slate-400 in
+   * dark). Adopted as drawn — the collapse is the design's own, and every
+   * pair still clears its floor (see --subtle-foreground below). */
+  --muted-foreground: #334155;
   /*
    * Table's header row is the only consumer (tokens.test.ts's leading-class
    * guard doesn't reach theme.css itself, but a grep confirms it — see
-   * table.module.css). Not the drawn value: each mode's drawn value failed
-   * the 4.5:1 AA floor against the header's own --surface fill (light
-   * #94a3b8 at 2.56:1, dark #667085 at 3.74:1), so both were replaced.
-   * AA leaves this token no room to read lighter than --muted-foreground in
-   * light mode (anything less saturated than ~this value fails against
-   * --surface's near-white), so light converges close to it; dark keeps a
-   * visibly dimmer, genuinely "subtler" step since --surface is dark enough
-   * to leave headroom. The ratios and the open designer question — pin
-   * AA-passing values in the Figma file — are in design-notes.md.
+   * table.module.css). The previous design's drawn values failed the 4.5:1
+   * AA floor against the header's own --surface fill and were replaced in
+   * code; the rebrand frame resolved that open question itself — its drawn
+   * values measure 10.35:1 light / 6.96:1 dark against --surface, so both
+   * modes are the frame's own again (they happen to converge with
+   * --muted-foreground; that collapse is the design's, see above).
    */
-  --subtle-foreground: #5f6f88;
-  --accent: #f3e8ff;
-  --accent-foreground: #6d28d9;
+  --subtle-foreground: #334155;
+  /* The brand-tinted fill+text pair (menus' hover/active rows, Badge's
+   * accent tone, Bubble). The drawn pair measures 4.68:1 light / 13.77:1
+   * dark — clears the 4.5:1 AA floor as drawn. */
+  --accent: #e6effa;
+  --accent-foreground: #2668c5;
   /*
    * The tint a row carries while it is selected. Table's row-state hooks
    * are the only consumer (see table.module.css). Its own token rather
    * than --muted or --accent because the Studio Data Table frame
-   * (40001455:6353) draws selection in neither: --accent is the violet
-   * brand tint, and --muted is a neutral slate the drawn value is visibly
+   * (40001455:6353) draws selection in neither: --accent is the brand
+   * tint, and --muted is a neutral slate the drawn value is visibly
    * bluer and one step stronger than — selection has to read as a state at
    * a glance across a column of rows, which a fill that close to the
    * page's own neutrals does not.
-   * Light is the frame's own drawn value. derived (dark only): the frame
-   * has no dark specimen, so dark takes the same hue and saturation at the
-   * lightness that puts it one clear step above --card-hover, the fill it
-   * has to stay distinguishable from. --foreground clears AA on both
-   * (14.2:1 light, 13.1:1 dark).
+   * Both modes are now drawn values: light from the Data Table frame, dark
+   * from the rebrand frame's studio-namespaced copy of the same token
+   * (--studio-color-selection-subtle — the only place a dark specimen
+   * exists; the kit-side name stays unprefixed like everything else).
+   * --foreground clears AA on both (14.2:1 light, 12.0:1 dark).
    */
   --selection-subtle: #dce7f2;
 
-  /* derived: no mockup node draws with destructive/*, so it aliases danger —
-   * one red, two names, both overridable separately. White text clears AA
-   * on both modes' reds (4.7:1 light, 4.6:1 dark). */
+  /* derived: no mockup node draws with destructive/*, so it aliases the
+   * frame's danger red — one red, two names, both overridable separately.
+   * The alias tracks the DRAWN danger (#e11d48 both modes), not the
+   * AA-corrected --danger below: destructive is a solid fill under white
+   * text (4.70:1, passes in both modes), so the label-driven correction
+   * that moved --danger does not apply to it. */
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
   /* Button destructive variant's focus-ring tone, measured against
-   * --background: 6.01:1 light / 7.89:1 dark. Literal hexes, not var()
+   * --background: 5.74:1 light / 7.89:1 dark. Literal hexes, not var()
    * aliases, for the same reason as --primary-ring above: the contrast
    * tests parse hex directly (see src/__test-utils__/contrast.ts). The
    * ring is drawn outside the button, so it only ever borders the page. */
   --destructive-ring: #be123c;
 
   /*
-   * Link text token — Button's `link` variant, which has no drawn
-   * counterpart to align to: the mockups' Button panel draws no borderless
-   * text variant, so there is no specimen color to take. --primary itself
-   * measured 4.51:1 light
-   * (barely over the 4.5:1 AA floor for this 13px text — 0.005 of headroom,
-   * so close that a future one-step nudge to --background could silently
-   * fail it again) and 3.78:1 dark (a clear fail) against the page
-   * background the borderless variant sits on. derived: light takes
-   * --primary-hover's value instead of --primary's own (still the same
-   * violet family, one step darker) for real headroom — 4.98:1, not a
-   * borderline pass; dark takes a lighter tint of the same hue.
+   * Link text token — Button's `link` variant and Badge's, which have no
+   * drawn counterpart to align to. --primary itself passes the 4.5:1 AA
+   * floor against the page in light (4.83:1) but the convention set when
+   * this token was introduced stands: take the ramp's next step for real
+   * headroom rather than ride a value that a one-step nudge to
+   * --background could push under the floor. derived: light duplicates
+   * --primary-hover's hex (4.95:1) as a literal (the contrast tests parse
+   * hex, see above); dark takes the ramp's light "blue-sky" tint
+   * (7.75:1).
    */
-  --link-foreground: #7c4fde;
+  --link-foreground: #2668c5;
 
   /* Status colors with their -soft fills. The status colors themselves are
-   * consumed — Badge's dot and label text, Table's stale/restricted row
-   * rings; the four -soft fills are read by Badge's tone variants
-   * (success/warning/danger/info backgrounds, badge.module.css) and by
-   * Avatar's tone-by-variant fill matrix (avatar.module.css) - both paint a
-   * tinted surface: the -soft fill as background, the base status token as
-   * foreground text. Dark warning-soft and info-soft are corroborated by
-   * the workflow aliases that resolve to the same values; dark danger-soft
-   * and light warning-soft are drawn nowhere — derived: chosen to sit in
-   * the same tint family as their corroborated siblings, not from one
-   * reproducible mix recipe (the four -soft values don't share a single
-   * formula against their base hue). */
-  --success: #059669;
+   * consumed as 12px label text over the -soft fills (Badge's tone
+   * variants, Avatar's soft treatment) and as solid Avatar fills; the
+   * -soft fills also carry Table's stale/restricted row tints. Because
+   * they are label text, each base value must clear 4.5:1 over its own
+   * -soft fill, --card and --background — and four drawn values don't,
+   * which is where this file's WCAG ruling (see header) deviates from the
+   * frame:
+   *   - light success: drawn #059669 is 3.43:1 on its soft fill →
+   *     #047857, one step down the same green ramp (5.00/5.48/5.01 on
+   *     soft/card/bg);
+   *   - light warning: drawn #f59e0b is 1.96–2.15:1 everywhere → #b45309
+   *     (4.67/5.02/4.58) — amber simply has no AA-passing tone brighter
+   *     than this over near-white fills;
+   *   - light danger: drawn #e11d48 is 4.28:1 on its soft fill → #be123c
+   *     (5.72/6.29/5.74), the same hex the destructive ring already
+   *     carries;
+   *   - light info: drawn #2563eb PASSES (4.59:1 worst case) and is kept
+   *     as drawn — the floor is met, though with little headroom;
+   *   - dark: success #34d399, warning #f6c453 and info #60a5fa all pass
+   *     as drawn (8.05/10.03/6.62 worst case); danger #e11d48 fails
+   *     (3.63:1 on its soft fill) → #fb7185, the light rose tint one step
+   *     up (6.34:1 worst case).
+   * The -soft fills are the frame's own in both modes. */
+  --success: #047857;
   --success-soft: #e8f8f1;
-  --warning: #d97706;
-  --warning-soft: #fdf3e2;
-  --danger: #e11d48;
+  --warning: #b45309;
+  --warning-soft: #fff7d6;
+  --danger: #be123c;
   --danger-soft: #fff1f2;
-  --info: #0284c7;
-  --info-soft: #eaf6ff;
+  --info: #2563eb;
+  --info-soft: #eaf2ff;
   /* A palette entry, not a semantic: --info is the token a component reaches
    * for, and nothing in the kit reads this one. Kept because the collection
-   * names it separately from --info.
-   * derived (light only): dark is Figma's blue-400; light takes the same
-   * Tailwind ramp one step down (blue-500). */
-  --blue: #3b82f6;
+   * names it separately from --info; the rebrand pointed it at the brand
+   * ramp's mid blue (the frame's own `--blue` primitive). derived (dark
+   * only): the frame's primitives are mode-invariant, but a mid blue that
+   * reads on white doesn't on near-black, so dark takes the ramp's
+   * "blue-sky" tint, same move as --link-foreground. */
+  --blue: #2668c5;
 
   --border: #e2e8f0;
   --border-strong: #cbd5e1;
-  /* Field-control borders. Not derived: the mockups' Field set (frame
-   * 193:433) strokes every input/textarea/select with the border-strong
-   * value, so input carries it in both modes. */
+  /* Field-control borders. Not derived: the mockups' Field set strokes
+   * every input/textarea/select with the border-strong value, so input
+   * carries it in both modes (the rebrand frame collapses the dark border
+   * pair — see the dark block). */
   --input: #cbd5e1;
-  /* Focus color. Light from the MVP Foundations frame; dark is drawn by
-   * the Field focus specimens (frame 193:383 strokes focus with the dark
-   * primary value), so neither mode is derived. */
-  --ring: #8b5cf6;
+  /* Focus color, per the rebrand frame: the brand blue in light, the
+   * "blue-sky" tint in dark. 4.83:1 / 7.75:1 against the page — clears the
+   * 3:1 non-text floor the shared focus rings need. */
+  --ring: #0065e3;
 
-  /* Sidebar Navigation block. Palette only — no kit component reads these
-   * (app layout is a non-goal; see design-notes), they brand a consumer's
-   * own navigation chrome from the same surface as the rest.
-   * --sidebar/--sidebar-accent are each drawn by their own dark-mode mockup
-   * node; the other three are not — named individually below, per this
-   * file's derived-marker convention. */
+  /* Sidebar Navigation block. Read by the kit's Sidebar parts and offered
+   * for a consumer's own navigation chrome alike. The rebrand frame draws
+   * no sidebar entries, so the whole block is derived from the same-role
+   * tokens above: sidebar follows --muted, its foreground follows
+   * --muted-foreground, the active-item fill takes --surface (light) /
+   * --selection-subtle's value (dark), its foreground follows --foreground,
+   * and the border follows --border. */
   --sidebar: #f1f5f9;
-  /* derived (dark only): follows dark --muted-foreground. */
-  --sidebar-foreground: #64748b;
+  --sidebar-foreground: #334155;
   --sidebar-accent: #ffffff;
-  /* derived (dark only): follows dark --foreground. */
   --sidebar-accent-foreground: #0f172a;
-  /* derived (dark only): follows dark --border. */
   --sidebar-border: #e2e8f0;
 
   /* Also palette-only: the kit ships no code/pre component, so these exist
-   * for a consumer rendering code blocks beside kit parts. */
+   * for a consumer rendering code blocks beside kit parts. The foreground
+   * is the frame's own (the light collapse onto slate-600, see
+   * --muted-foreground); derived (both modes): the fill takes the page
+   * --background value, which reads one step darker than any surface a
+   * code block sits on. */
   --code-background: #f1f5f9;
   --code-foreground: #334155;
+
+  /* Palette-only, new with the rebrand (no kit consumer yet): the workflow
+   * scenario canvas fill — previously a `--studio-*` export, moved into
+   * the collection's color/ namespace by the rebrand, which is the line
+   * that admits it here (see header) — and the accent tone artifact cards
+   * draw their icon with. */
+  --scenario-canvas: #e2e8f0;
+  --artifact-accent-icon: #2668c5;
 
   /*
    * Hands UA-owned surfaces (scrollbar, spellcheck underline, <input>
@@ -367,50 +457,57 @@
 
 [data-theme='dark'] {
   --background: #090b10;
-  --foreground: #f6f7f9;
-  --surface: #0f131b;
-  --surface-elevated: #131824;
-  --card: #111722;
-  --card-hover: #151c29;
-  --card-foreground: #f6f7f9;
-  --popover: #131824;
-  --popover-foreground: #f6f7f9;
-  --primary: #7c4fde;
-  --primary-hover: #8257e6;
+  --foreground: #ffffff;
+  /* The rebrand frame draws surface and surface-elevated COLLAPSED onto
+   * one slate-900 (overlays separate via --popover-border/-shadow, not
+   * fill) — adopted as drawn; see the light block's comment. */
+  --surface: #0f172a;
+  --surface-elevated: #0f172a;
+  --card: #0f172a;
+  --card-hover: #182338;
+  --card-foreground: #ffffff;
+  --popover: #0f172a;
+  --popover-foreground: #ffffff;
+  --primary: #0065e3;
+  --primary-hover: #2668c5;
   --primary-foreground: #ffffff;
-  --primary-ring: #a78bfa;
+  --primary-ring: #6ba5f0;
   --secondary: #1e293b;
-  --secondary-foreground: #f8fafc;
-  --muted: #1e293b;
-  --muted-foreground: #8d96a8;
-  --subtle-foreground: #7a8396;
-  --accent: #2e1065;
-  --accent-foreground: #ede9fe;
-  --selection-subtle: #1c2d3f;
-  --destructive: #d63853;
+  --secondary-foreground: #ffffff;
+  --muted: #0f172a;
+  --muted-foreground: #94a3b8;
+  --subtle-foreground: #94a3b8;
+  --accent: #00204d;
+  --accent-foreground: #e6effa;
+  --selection-subtle: #26384b;
+  --destructive: #e11d48;
   --destructive-foreground: #ffffff;
   --destructive-ring: #f87f8f;
-  --link-foreground: #a78bfa;
+  --link-foreground: #6ba5f0;
   --success: #34d399;
   --success-soft: #0d2921;
-  --warning: #fbbf24;
-  --warning-soft: #2e240a;
-  --danger: #d63853;
-  --danger-soft: #2b1119;
-  --info: #22d3ee;
-  --info-soft: #06262b;
-  --blue: #60a5fa;
-  --border: #222a38;
-  --border-strong: #303a4d;
-  --input: #303a4d;
-  --ring: #7c4fde;
-  --sidebar: #0c0f15;
-  --sidebar-foreground: #8d96a8;
-  --sidebar-accent: #172033;
-  --sidebar-accent-foreground: #f6f7f9;
-  --sidebar-border: #222a38;
-  --code-background: #0b1220;
+  --warning: #f6c453;
+  --warning-soft: #2b1e04;
+  --danger: #fb7185;
+  --danger-soft: #32111b;
+  --info: #60a5fa;
+  --info-soft: #111e2d;
+  --blue: #6ba5f0;
+  /* The frame draws border and border-strong collapsed onto one slate-600
+   * in dark; --input follows border-strong as in light. */
+  --border: #334155;
+  --border-strong: #334155;
+  --input: #334155;
+  --ring: #6ba5f0;
+  --sidebar: #0f172a;
+  --sidebar-foreground: #94a3b8;
+  --sidebar-accent: #26384b;
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: #334155;
+  --code-background: #090b10;
   --code-foreground: #e2e8f0;
+  --scenario-canvas: #0f172a;
+  --artifact-accent-icon: #6ba5f0;
 
   /* See the light block's color-scheme comment above for why this exists. */
   color-scheme: dark;
@@ -419,50 +516,52 @@
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {
     --background: #090b10;
-    --foreground: #f6f7f9;
-    --surface: #0f131b;
-    --surface-elevated: #131824;
-    --card: #111722;
-    --card-hover: #151c29;
-    --card-foreground: #f6f7f9;
-    --popover: #131824;
-    --popover-foreground: #f6f7f9;
-    --primary: #7c4fde;
-    --primary-hover: #8257e6;
+    --foreground: #ffffff;
+    --surface: #0f172a;
+    --surface-elevated: #0f172a;
+    --card: #0f172a;
+    --card-hover: #182338;
+    --card-foreground: #ffffff;
+    --popover: #0f172a;
+    --popover-foreground: #ffffff;
+    --primary: #0065e3;
+    --primary-hover: #2668c5;
     --primary-foreground: #ffffff;
-    --primary-ring: #a78bfa;
+    --primary-ring: #6ba5f0;
     --secondary: #1e293b;
-    --secondary-foreground: #f8fafc;
-    --muted: #1e293b;
-    --muted-foreground: #8d96a8;
-    --subtle-foreground: #7a8396;
-    --accent: #2e1065;
-    --accent-foreground: #ede9fe;
-    --selection-subtle: #1c2d3f;
-    --destructive: #d63853;
+    --secondary-foreground: #ffffff;
+    --muted: #0f172a;
+    --muted-foreground: #94a3b8;
+    --subtle-foreground: #94a3b8;
+    --accent: #00204d;
+    --accent-foreground: #e6effa;
+    --selection-subtle: #26384b;
+    --destructive: #e11d48;
     --destructive-foreground: #ffffff;
     --destructive-ring: #f87f8f;
-    --link-foreground: #a78bfa;
+    --link-foreground: #6ba5f0;
     --success: #34d399;
     --success-soft: #0d2921;
-    --warning: #fbbf24;
-    --warning-soft: #2e240a;
-    --danger: #d63853;
-    --danger-soft: #2b1119;
-    --info: #22d3ee;
-    --info-soft: #06262b;
-    --blue: #60a5fa;
-    --border: #222a38;
-    --border-strong: #303a4d;
-    --input: #303a4d;
-    --ring: #7c4fde;
-    --sidebar: #0c0f15;
-    --sidebar-foreground: #8d96a8;
-    --sidebar-accent: #172033;
-    --sidebar-accent-foreground: #f6f7f9;
-    --sidebar-border: #222a38;
-    --code-background: #0b1220;
+    --warning: #f6c453;
+    --warning-soft: #2b1e04;
+    --danger: #fb7185;
+    --danger-soft: #32111b;
+    --info: #60a5fa;
+    --info-soft: #111e2d;
+    --blue: #6ba5f0;
+    --border: #334155;
+    --border-strong: #334155;
+    --input: #334155;
+    --ring: #6ba5f0;
+    --sidebar: #0f172a;
+    --sidebar-foreground: #94a3b8;
+    --sidebar-accent: #26384b;
+    --sidebar-accent-foreground: #ffffff;
+    --sidebar-border: #334155;
+    --code-background: #090b10;
     --code-foreground: #e2e8f0;
+    --scenario-canvas: #0f172a;
+    --artifact-accent-icon: #6ba5f0;
 
     /* See the light block's color-scheme comment above for why this exists. */
     color-scheme: dark;

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -447,7 +447,7 @@
    * --muted-foreground, the active-item fill takes --surface (light) /
    * --selection-subtle's value (dark), its foreground follows --foreground,
    * and the border follows --border. */
-  --sidebar: #f1f5f9;
+  --sidebar: #e2e8f0;
   --sidebar-foreground: #334155;
   --sidebar-accent: #ffffff;
   --sidebar-accent-foreground: #0f172a;
@@ -516,7 +516,7 @@
   --border-strong: #334155;
   --input: #334155;
   --ring: #6ba5f0;
-  --sidebar: #0f172a;
+  --sidebar: #1e293b;
   --sidebar-foreground: #94a3b8;
   --sidebar-accent: #26384b;
   --sidebar-accent-foreground: #ffffff;
@@ -569,7 +569,7 @@
     --border-strong: #334155;
     --input: #334155;
     --ring: #6ba5f0;
-    --sidebar: #0f172a;
+    --sidebar: #1e293b;
     --sidebar-foreground: #94a3b8;
     --sidebar-accent: #26384b;
     --sidebar-accent-foreground: #ffffff;

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -32,19 +32,21 @@
  *
  * Deliberately not here: the `--studio-color-*` entries the same frame
  * draws (progress-value/track, icon-subtle/icon-selected, and the studio
- * copy of selection-subtle). Figma exports them under its own `--studio-*`
- * namespace, which is the line this file follows — they name one consumer's
- * workflow surfaces rather than any kit semantic, and belong to that app's
- * own stylesheet. (`scenario-canvas`, previously excluded on the same
- * ground, moved INTO the `color/` namespace with the rebrand and is now
- * carried below.)
+ * copy of selection-subtle), plus `scenario-canvas` and
+ * `artifact-accent-icon`. The first group Figma exports under its own
+ * `--studio-*` namespace; the last two sit in the `color/` namespace since
+ * the rebrand, but all of them name one consumer's workflow surfaces
+ * (Studio's scenario canvas, its artifact cards) rather than any kit
+ * semantic, and belong to that app's own stylesheet. Ownership, not
+ * namespace, is what admits a token here — a Figma folder move alone does
+ * not put a product-domain name into the kit's public API.
  *
- * The line is namespace, not "is a component reading it today": a few groups
- * here (the code pair, --blue, --scenario-canvas, --artifact-accent-icon)
- * are unread by any current component. They are part of the collection's
- * unprefixed palette and are carried so a consumer painting a page around
- * the kit — or a later kit component — brands them from the same surface as
- * everything else, instead of finding a hole. Each such group says so at
+ * Being unread is NOT what excludes them, though: a few groups here (the
+ * code pair, --blue) are unread by any current component. They are part of
+ * the collection's unprefixed palette, carry kit-generic names, and are
+ * kept so a consumer painting a page around the kit — or a later kit
+ * component — brands them from the same surface as everything else,
+ * instead of finding a hole. Each such group says so at
  * its own declaration. The Sidebar Navigation block is NOT one of them:
  * sidebar.module.css consumes all five --sidebar-* tokens, so that group is
  * component-consumed like any other pair — it merely doubles as the
@@ -293,11 +295,23 @@
    * the page would vanish. One step down the frame's neutral ramp
    * (neutral-100) keeps it a visible fill (1.13:1 against the page) the
    * way the old value was against the old page. Dark mirrors the move one
-   * step the OTHER way from its (also page-equal) muted — see the dark
+   * step the OTHER way from its (card-equal) drawn muted — see the dark
    * block. */
   --secondary: #e2e8f0;
   --secondary-foreground: #0f172a;
-  --muted: #f1f5f9;
+  /* derived: the frame draws muted at slate-50 — the exact value the
+   * rebrand made the page itself — and its dark muted at the card surface.
+   * Muted is the kit's workhorse FILL (Skeleton, outline/ghost Button
+   * hover, Calendar's outside days, a dozen more), and a fill equal to its
+   * own backdrop vanishes: the same argument --secondary above already
+   * applies, so muted takes the same one-step correction and lands ON
+   * secondary's value — which is also upstream shadcn's own arrangement
+   * (its default theme ships muted == secondary). 1.13:1 against the page
+   * / 1.23:1 against the card in light, 1.22 / 1.35 in dark; every text
+   * seat stays clear (--muted-foreground on this fill is 8.40:1 light /
+   * 5.71:1 dark). tokens.test.ts pins the separation so a later value
+   * move cannot silently re-collapse it. */
+  --muted: #e2e8f0;
   /* The frame collapses muted-foreground, subtle-foreground and
    * code-foreground onto one slate-600 in light (and one slate-400 in
    * dark). Adopted as drawn — the collapse is the design's own, and every
@@ -448,14 +462,6 @@
   --code-background: #f1f5f9;
   --code-foreground: #334155;
 
-  /* Palette-only, new with the rebrand (no kit consumer yet): the workflow
-   * scenario canvas fill — previously a `--studio-*` export, moved into
-   * the collection's color/ namespace by the rebrand, which is the line
-   * that admits it here (see header) — and the accent tone artifact cards
-   * draw their icon with. */
-  --scenario-canvas: #e2e8f0;
-  --artifact-accent-icon: #2668c5;
-
   /*
    * Hands UA-owned surfaces (scrollbar, spellcheck underline, <input>
    * autofill, form-control chrome) the light palette. The dark blocks below
@@ -484,7 +490,7 @@
   --primary-ring: #6ba5f0;
   --secondary: #1e293b;
   --secondary-foreground: #ffffff;
-  --muted: #0f172a;
+  --muted: #1e293b;
   --muted-foreground: #94a3b8;
   --subtle-foreground: #94a3b8;
   --accent: #00204d;
@@ -517,8 +523,6 @@
   --sidebar-border: #334155;
   --code-background: #090b10;
   --code-foreground: #e2e8f0;
-  --scenario-canvas: #0f172a;
-  --artifact-accent-icon: #6ba5f0;
 
   /* See the light block's color-scheme comment above for why this exists. */
   color-scheme: dark;
@@ -541,7 +545,7 @@
     --primary-ring: #6ba5f0;
     --secondary: #1e293b;
     --secondary-foreground: #ffffff;
-    --muted: #0f172a;
+    --muted: #1e293b;
     --muted-foreground: #94a3b8;
     --subtle-foreground: #94a3b8;
     --accent: #00204d;
@@ -572,8 +576,6 @@
     --sidebar-border: #334155;
     --code-background: #090b10;
     --code-foreground: #e2e8f0;
-    --scenario-canvas: #0f172a;
-    --artifact-accent-icon: #6ba5f0;
 
     /* See the light block's color-scheme comment above for why this exists. */
     color-scheme: dark;

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -40,14 +40,15 @@
  * carried below.)
  *
  * The line is namespace, not "is a component reading it today": a few groups
- * here (Sidebar Navigation, the code pair, --blue, --scenario-canvas,
- * --artifact-accent-icon) are unread by any current component. They are part
- * of the collection's unprefixed palette and are carried so a consumer
- * painting a page around the kit — or a later kit component — brands them
- * from the same surface as everything else, instead of finding a hole. Each
- * such group says so at its own declaration; app LAYOUT itself stays a
- * non-goal (see design-notes), so the sidebar tokens are colors for a
- * consumer's own chrome, not a promise beyond the shipped Sidebar parts.
+ * here (the code pair, --blue, --scenario-canvas, --artifact-accent-icon)
+ * are unread by any current component. They are part of the collection's
+ * unprefixed palette and are carried so a consumer painting a page around
+ * the kit — or a later kit component — brands them from the same surface as
+ * everything else, instead of finding a hole. Each such group says so at
+ * its own declaration. The Sidebar Navigation block is NOT one of them:
+ * sidebar.module.css consumes all five --sidebar-* tokens, so that group is
+ * component-consumed like any other pair — it merely doubles as the
+ * branding surface for a consumer's own navigation chrome.
  *
  * Basic branding happens on the consumer side by overriding these variables.
  * Dark mode: set data-theme="dark" on <html>/<body> for explicit control, or
@@ -343,6 +344,15 @@
    * that moved --danger does not apply to it. */
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
+  /* Badge's destructive-variant hover tone (see badge.module.css) — darker
+   * than --destructive so white text never drops under 4.5:1 on hover. Same
+   * hex both modes on purpose: a hover recipe that darkens by mixing toward
+   * --foreground works in light (foreground is dark) but LIGHTENS in dark
+   * mode instead (foreground flips to white there), so this token sidesteps
+   * that by not depending on --foreground at all. #be123c is the same
+   * literal --destructive-ring/--danger already carry — white on it
+   * measures 6.29:1 in both modes. */
+  --destructive-hover: #be123c;
   /* Button destructive variant's focus-ring tone, measured against
    * --background: 5.74:1 light / 7.89:1 dark. Literal hexes, not var()
    * aliases, for the same reason as --primary-ring above: the contrast
@@ -482,6 +492,7 @@
   --selection-subtle: #26384b;
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
+  --destructive-hover: #be123c;
   --destructive-ring: #f87f8f;
   --link-foreground: #6ba5f0;
   --success: #34d399;
@@ -538,6 +549,7 @@
     --selection-subtle: #26384b;
     --destructive: #e11d48;
     --destructive-foreground: #ffffff;
+    --destructive-hover: #be123c;
     --destructive-ring: #f87f8f;
     --link-foreground: #6ba5f0;
     --success: #34d399;

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -446,12 +446,16 @@
    * tokens above: sidebar follows --muted, its foreground follows
    * --muted-foreground, the active-item fill takes --surface (light) /
    * --selection-subtle's value (dark), its foreground follows --foreground,
-   * and the border follows --border. */
+   * and the border follows --border-strong — NOT --border, whose light
+   * value is the panel fill itself, which would erase SidebarSeparator,
+   * the menu-sub rail and the floating variant's outline (1.20:1 against
+   * the panel instead; dark's collapsed border family is border-strong
+   * already). tokens.test.ts pins the border/panel separation. */
   --sidebar: #e2e8f0;
   --sidebar-foreground: #334155;
   --sidebar-accent: #ffffff;
   --sidebar-accent-foreground: #0f172a;
-  --sidebar-border: #e2e8f0;
+  --sidebar-border: #cbd5e1;
 
   /* Also palette-only: the kit ships no code/pre component, so these exist
    * for a consumer rendering code blocks beside kit parts. The foreground

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -575,6 +575,92 @@ describe('theme tokens', () => {
           ).toBeGreaterThanOrEqual(4.5);
         }
       });
+
+      // The status tokens are 12px label text in the kit — Badge's tone
+      // variants and Avatar's soft treatment paint them over their own
+      // -soft fill, and Field/Alert/Toast/Attachment/Bubble/Questionnaire
+      // error text paints --danger over whatever page/card/panel the
+      // component sits on — so each status color must clear the 4.5:1 AA
+      // floor against ALL of those backdrops, not only the one a single
+      // component happens to test. This is the guard the original Studio
+      // values shipped without (the PR #604 review's F-002/F-004): a hue
+      // that only works as a dot or solid fill can no longer pass for a
+      // text color. (--popover is included even though it currently equals
+      // --card in both modes: Toast paints its error icon on --popover, and
+      // the two tokens are free to diverge later.)
+      it('status label text clears 4.5:1 on its soft fill and every surface it sits on', () => {
+        for (const [themeName, tokens] of themes) {
+          for (const status of ['--success', '--warning', '--danger', '--info']) {
+            const label = token(tokens, status);
+            for (const backdrop of [
+              `${status}-soft`,
+              '--background',
+              '--surface',
+              '--card',
+              '--popover',
+            ]) {
+              expect(
+                contrastRatio(label, token(tokens, backdrop)),
+                `${themeName} ${status} on ${backdrop}`,
+              ).toBeGreaterThanOrEqual(4.5);
+            }
+          }
+        }
+      });
+
+      // The brand-tinted pair: menus' hover/active rows, Badge's accent
+      // tone and Bubble all paint --accent-foreground as label text over
+      // the --accent fill.
+      it('accent-foreground clears 4.5:1 on the accent fill', () => {
+        for (const [themeName, tokens] of themes) {
+          expect(
+            contrastRatio(token(tokens, '--accent-foreground'), token(tokens, '--accent')),
+            themeName,
+          ).toBeGreaterThanOrEqual(4.5);
+        }
+      });
+
+      // Solid-fill on-colors, at rest AND on the hover fills: Button and
+      // Badge keep the same fixed label while swapping the fill under it
+      // on hover (--primary -> --primary-hover; --destructive ->
+      // --destructive-hover on Badge), so the hover fill needs the same
+      // 4.5:1 the resting fill does — the exact case the old
+      // mix-toward-foreground hover recipe failed in dark mode (see
+      // badge.module.css's destructive-hover comment).
+      it('solid-fill labels clear 4.5:1 at rest and on the hover fills', () => {
+        const pairs: Array<[string, string[]]> = [
+          ['--primary-foreground', ['--primary', '--primary-hover']],
+          ['--destructive-foreground', ['--destructive', '--destructive-hover']],
+        ];
+        for (const [themeName, tokens] of themes) {
+          for (const [label, fills] of pairs) {
+            for (const fill of fills) {
+              expect(
+                contrastRatio(token(tokens, label), token(tokens, fill)),
+                `${themeName} ${label} on ${fill}`,
+              ).toBeGreaterThanOrEqual(4.5);
+            }
+          }
+        }
+      });
+
+      // Link text away from the bare page: FieldDescription, EmptyDescription
+      // and ItemDescription links (and Badge's link variant on a card) sit on
+      // --surface/--card rather than --background, which the link-button case
+      // above already covers. Widened deliberately when those consumers moved
+      // onto --link-foreground (the PR #604 review's F-003) — the button-only
+      // scoping note on that case still holds for BUTTON, but the token now
+      // has seats on every panel fill.
+      it('link text clears 4.5:1 against surface and card', () => {
+        for (const [themeName, tokens] of themes) {
+          for (const backdrop of ['--surface', '--card']) {
+            expect(
+              contrastRatio(token(tokens, '--link-foreground'), token(tokens, backdrop)),
+              `${themeName} --link-foreground on ${backdrop}`,
+            ).toBeGreaterThanOrEqual(4.5);
+          }
+        }
+      });
     });
   });
 });

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -583,7 +583,9 @@ describe('theme tokens', () => {
       // component sits on — so each status color must clear the 4.5:1 AA
       // floor against ALL of those backdrops, not only the one a single
       // component happens to test. This is the guard the original Studio
-      // values shipped without (the PR #604 review's F-002/F-004): a hue
+      // values shipped without: they cleared their own -soft fills but not
+      // every page/panel seat, and --destructive doubled as a text color
+      // (see design-notes.md's "Post-review contrast pass" entry) — a hue
       // that only works as a dot or solid fill can no longer pass for a
       // text color. (--popover is included even though it currently equals
       // --card in both modes: Toast paints its error icon on --popover, and
@@ -648,9 +650,10 @@ describe('theme tokens', () => {
       // and ItemDescription links (and Badge's link variant on a card) sit on
       // --surface/--card rather than --background, which the link-button case
       // above already covers. Widened deliberately when those consumers moved
-      // onto --link-foreground (the PR #604 review's F-003) — the button-only
-      // scoping note on that case still holds for BUTTON, but the token now
-      // has seats on every panel fill.
+      // off --primary (whose dark value fails AA as text) onto
+      // --link-foreground (design-notes.md's "Post-review contrast pass") —
+      // the button-only scoping note on that case still holds for BUTTON,
+      // but the token now has seats on every panel fill.
       it('link text clears 4.5:1 against surface and card', () => {
         for (const [themeName, tokens] of themes) {
           for (const backdrop of ['--surface', '--card']) {
@@ -658,6 +661,26 @@ describe('theme tokens', () => {
               contrastRatio(token(tokens, '--link-foreground'), token(tokens, backdrop)),
               `${themeName} --link-foreground on ${backdrop}`,
             ).toBeGreaterThanOrEqual(4.5);
+          }
+        }
+      });
+
+      // Not a WCAG floor — a visibility floor. --muted is the kit's
+      // workhorse fill (Skeleton, outline/ghost Button hover, Calendar's
+      // outside days, …) and the rebrand frame draws it AT the light page
+      // value and AT the dark card value, which makes every one of those
+      // fills vanish against its own backdrop; theme.css steps it off
+      // deliberately (see --muted's comment there). 1.1 is below the
+      // shipped separations (1.13 light page / 1.22 dark card are the
+      // tightest) but far above the ~1.0 a re-collapse would produce, so
+      // this pins the intent without hard-coding the palette.
+      it('the muted fill stays visibly separate from the page and card it fills on', () => {
+        for (const [themeName, tokens] of themes) {
+          for (const backdrop of ['--background', '--card']) {
+            expect(
+              contrastRatio(token(tokens, '--muted'), token(tokens, backdrop)),
+              `${themeName} --muted on ${backdrop}`,
+            ).toBeGreaterThanOrEqual(1.1);
           }
         }
       });

--- a/packages/ui-kit/src/tokens.test.ts
+++ b/packages/ui-kit/src/tokens.test.ts
@@ -684,6 +684,23 @@ describe('theme tokens', () => {
           }
         }
       });
+
+      // Same visibility floor for the sidebar's own hairline: --sidebar
+      // follows --muted (see theme.css), and the first derivation of the
+      // block put --border's value on --sidebar-border — which is the
+      // panel fill itself in light mode, erasing SidebarSeparator, the
+      // menu-sub rail and the floating variant's outline at 1.00:1. The
+      // border now follows --border-strong (1.20 light / 1.41 dark against
+      // the panel); this pins the pair the way the muted guard above pins
+      // muted against its backdrops.
+      it('the sidebar border stays visibly separate from the sidebar panel', () => {
+        for (const [themeName, tokens] of themes) {
+          expect(
+            contrastRatio(token(tokens, '--sidebar-border'), token(tokens, '--sidebar')),
+            `${themeName} --sidebar-border on --sidebar`,
+          ).toBeGreaterThanOrEqual(1.1);
+        }
+      });
     });
   });
 });

--- a/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/_blank-mfe/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.2.4",
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
     "@gears-frontx/react": "0.2.0-alpha.8",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.2",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.3",
     "@tanstack/react-query": "5.101.4"
   },
   "devDependencies": {

--- a/template-mfe/src-app/mfe_packages/demo-mfe/package.json
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@gears-frontx/frontx-template-shell": "0.1.0-alpha.4",
     "@gears-frontx/react": "0.2.0-alpha.8",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.2",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.3",
     "@tanstack/react-query": "5.101.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/template-shell/package.json
+++ b/template-shell/package.json
@@ -72,7 +72,7 @@
     "@gears-frontx/api": "0.3.0-alpha.2",
     "@gears-frontx/gts-plugin": "0.3.0-alpha.5",
     "@gears-frontx/mfes": "0.3.0-alpha.5",
-    "@gears-frontx/ui-kit": "0.4.0-alpha.2",
+    "@gears-frontx/ui-kit": "0.4.0-alpha.3",
     "@hookform/resolvers": "5.2.2",
     "@iconify/react": "6.0.2",
     "@radix-ui/react-avatar": "1.2.6",


### PR DESCRIPTION
## What

Adopts the **Studio blue rebrand** for the ui-kit theme tokens, from the mockups' token spec frame **"02 · Tokens, type & elevation"** (node `40001232:5254`), which supersedes the violet "Studio / shadcn" collection `theme.css` previously implemented.

### Palette (both themes)

- Brand axis onto the blue ramp: `--primary #0065e3`, `--primary-hover / --accent-foreground #2668c5`, `--accent #e6effa`; light page onto slate-50 `#f1f5f9`; dark mode onto the slate ramp (surfaces `#0f172a`, borders `#334155`, foreground `#ffffff`) — including two collapses the frame draws explicitly (dark `surface == surface-elevated`, `border == border-strong`).
- Entries the frame doesn't draw are re-derived per the file's `derived:` convention (card/popover mirror surface; `secondary` stepped one neutral away from the now-page-equal `muted`; sidebar/code follow their same-role tokens; ring family and `--link-foreground` from the brand ramp — measured ratios at each token).
- `--popover-shadow` adopts the frame's Studio/Elevation/200 geometry (0 8 24 @ 12% foreground); two new palette-only entries: `--scenario-canvas` (moved into the `color/` namespace by the rebrand) and `--artifact-accent-icon`.
- Token **names** stay unprefixed per the shadcn convention even though the frame labels its WEB syntax `var(--color-*)` — renaming the public token surface would break every consumer for zero semantic gain (recorded in the `theme.css` header).

### Typography

The frame's **Studio/Type** ramp, carried on the existing `--text-*` role names (roles are the public API; values moved, names didn't):

| role | was | now | source style |
|---|---|---|---|
| `display` | 28/34 | **26/32** | Page Title |
| `heading-1` | 20/28 | 20/28 (kept) | no ramp counterpart — kit interpolation |
| `heading-2` | 16/24 | 16/24 (already matched) | Section Title |
| `body` | 15/20 | **14/20** | UI Primary Regular |
| `label` | 13/16 · 500 | **12/16 · 500** | UI Secondary Medium |
| `meta` | 12/16 | 12/16 (already matched) | UI Secondary Regular |
| `mono` | 11/16 | **10/14** | System Micro |

All trackings normalized to the ramp's 0. Evidence for the control axis comes from the live "Phase 3 · Remaining core controls" frame (`40001414:5973`): drawn Tabs trigger binds UI Secondary Medium, drawn compact Button binds UI Secondary Semi Bold, drawn Badge sits on the metrics Badge already had.

### WCAG deviations from the drawn values

Standing ruling: a drawn value failing its contrast floor gets a corrected value in code, recorded at the token. Exactly four deviations, all 12px status labels over their own `-soft` fills (worst case across soft/card/page):

| token | drawn | shipped | worst case |
|---|---|---|---|
| light `--success` | `#059669` (3.43:1) | `#047857` | 5.00:1 |
| light `--warning` | `#f59e0b` (1.96:1) | `#b45309` | 4.58:1 |
| light `--danger` | `#e11d48` (4.28:1) | `#be123c` | 5.72:1 |
| dark `--danger` | `#e11d48` (3.63:1) | `#fb7185` | 6.34:1 |

Light `--info` passes as drawn (4.59:1) and is kept. `--destructive` tracks the drawn red (`#e11d48`, its text is the white on-color at 4.70:1) and now deliberately diverges from the corrected `--danger`.

Same ruling applied in components: Avatar's `solid` treatment labels each status tone with the tone's own `-soft` value instead of the mockup's all-white binding (~1.5–2:1 in dark); Badge's `link` variant moved onto `--link-foreground` (dark `--primary` is 3.72:1 on the page); Badge's long-standing tone-label contrast debt is thereby resolved — recomputed table in `badge.module.css`.

### Docs

`design-notes.md` gains the rebrand entry (deviations table, evidence, open designer questions); `sidebar.md`'s stale 15px note updated; demo chart palette key `violet` → `brand`.

## Deliberately out of scope

- Elevation scale beyond the popover shadow (Elevation/100/300/Dock top — no kit consumer yet).
- Button label weight: the drawn compact button binds the **600** cut while Button reads `--text-label-weight` (500), which also dresses menus/tooltips/table headers — per-component question for the components pass.

## Open questions for design

1. Pin AA-passing status values in the Figma file (the four deviations above).
2. Confirm the dark `surface`/`border` collapses are intent rather than spec-sheet shorthand.
3. Rule the button label weight (500 vs the drawn 600).

## Verification

- All **909** unit tests pass — token block parity, AA floors (`--link-foreground`, `--subtle-foreground`) and Button focus-ring contrast recompute from the live CSS.
- Contrast matrix for every changed pair computed with the same WCAG math the tests use.
- Build + demo type-check clean; visual smoke of the kitchen-sink demo (tokens/typography/button/badge/avatar/table pages, both themes) in headless Chrome.

Heads-up for `insight-front`: token **values** changed (no names removed; two added), and type roles `body`/`label`/`mono` are 1–3px smaller — visual change only, no API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed Studio Blue theme colors across light and dark modes, including sidebar styling and chart palettes.
  * Improved destructive-state colors and hover treatments for links, badges, menus, buttons, alerts, and form errors.
  * Added visible keyboard focus rings and refined avatar status colors.

* **Accessibility**
  * Improved contrast for status, link, error, sidebar, and destructive states across themes.

* **Documentation**
  * Updated design guidance and component notes covering branding, typography, chart colors, and accessibility standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->