### PR TITLE
fix(cli): make upgrade provenance write part of the atomic apply boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9164,7 +9164,7 @@
     },
     "packages/cli": {
       "name": "@gears-frontx/cli",
-      "version": "0.3.0-alpha.4",
+      "version": "0.3.0-alpha.5",
       "license": "MIT",
       "bin": {
         "frontx": "dist/cli.js"

--- a/packages/cli/architecture/features/upgrade-changeset/FEATURE.md
+++ b/packages/cli/architecture/features/upgrade-changeset/FEATURE.md
@@ -140,12 +140,12 @@ Internal system functions and procedures that do not interact with actors direct
 2. [x] - `p1` - **TRY**: - `inst-app-try`
    1. [x] - `p1` - **FOR EACH** clean entry in the change set, in dependency order: - `inst-app-for-each-entry`
       1. [x] - `p1` - Apply the entry to the project root within the template's ownership boundary: for an exclusive subtree, write or remove the whole file; for a `region-union` shared file, rewrite only the template's own marker-delimited region(s) in place, leaving every co-owning template's region byte-for-byte untouched - `inst-app-apply-entry`
-3. [x] - `p1` - **CATCH** application error: - `inst-app-catch`
-   1. [x] - `p1` - Restore `target` all affected files from the pre-upgrade snapshot, leaving the project byte-for-byte unchanged - `inst-app-restore-on-error`
-   2. [x] - `p1` - Report the error and **RETURN** failure without updating provenance - `inst-app-return-failure`
-4. [x] - `p1` - Update `target` the selected applied template's provenance record to the newer version - `inst-app-update-prov`
-5. [x] - `p1` - Retain `target` the pre-upgrade snapshot for rollback until the developer explicitly releases it or a new upgrade cycle begins - `inst-app-retain-snapshot`
-6. [x] - `p1` - **RETURN** success: applied entries, updated provenance, rollback available - `inst-app-return-success`
+   2. [x] - `p1` - Update `target` the selected applied template's provenance record to the newer version, as part of the same atomic application as the project-file writes above — not after it - `inst-app-update-prov`
+3. [x] - `p1` - **CATCH** application error, including a failure writing the updated provenance record: - `inst-app-catch`
+   1. [x] - `p1` - Restore `target` all affected files, including the provenance file, from the pre-upgrade snapshot, leaving the project byte-for-byte unchanged - `inst-app-restore-on-error`
+   2. [x] - `p1` - Report the error and **RETURN** failure without leaving a partially-upgraded repository - `inst-app-return-failure`
+4. [x] - `p1` - Retain `target` the pre-upgrade snapshot for rollback until the developer explicitly releases it or a new upgrade cycle begins - `inst-app-retain-snapshot`
+5. [x] - `p1` - **RETURN** success: applied entries, updated provenance, rollback available - `inst-app-return-success`
 
 ### Rollback an Applied Change Set
 
@@ -206,6 +206,8 @@ The change set for a record admitted on the repository-name match covers that te
 
 The system **MUST** apply the approved change set non-destructively by writing only the approved entries to the repository within the selected template's ownership boundary — rewriting only that template's own marker-delimited region(s) in a shared file and leaving every co-owning template's region untouched — retain a pre-upgrade snapshot for rollback, and update the selected applied template's provenance record to the newer version upon successful application.
 
+The provenance write **MUST** be treated as part of the same atomic application as the project-file writes, not as a step that follows it: if writing the updated provenance fails, the system **MUST** restore every snapshotted project file and the prior provenance bytes to their pre-upgrade state and **RETURN** a typed failure, rather than throwing after project files have already been changed.
+
 **Implements**:
 - `cpt-frontx-flow-upgrade-changeset-review-approval`
 - `cpt-frontx-algo-upgrade-changeset-apply`
@@ -253,3 +255,4 @@ The system **MUST** provide exactly one change-set engine in `cpt-frontx-compone
 - [x] A provenance record written before identity came from the manifest, its recorded identity being the repository name its subtree-less source-spec addresses, still upgrades without a refusal, provided both resolved versions declare one identity.
 - [x] The change set computed for such a record covers that template's exclusive subtrees only: every `region-union` shared file is excluded from it, contributing neither a clean entry nor a conflict whichever identity its markers carry.
 - [x] A provenance record whose identity is neither the identity the resolved versions declare nor the repository its own source-spec addresses causes the engine to refuse rather than assume a match.
+- [x] A provenance-write failure occurring after at least one project file has already been applied restores every changed project file and the prior provenance bytes byte-for-byte, and the engine returns a typed failure rather than throwing.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/cli",
-  "version": "0.3.0-alpha.4",
+  "version": "0.3.0-alpha.5",
   "description": "Template resolution CLI for FrontX SDK — zero bundled template content",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/cli/src/__tests__/upgrade.test.ts
+++ b/packages/cli/src/__tests__/upgrade.test.ts
@@ -417,8 +417,8 @@ describe('upgradeChangeSetReviewApproval (F14 change-set engine flow)', () => {
   // project file is written, returning `{ok:false}` per `ApplyResult`'s
   // contract (ADR-0019 / ADR-0021 Confirmation (d)). A thrown exception at
   // that point would escape past `inst-app-catch`'s restore-on-error, since
-  // that block only wraps the for-each-entry loop — by the time such an
-  // error surfaced, entries could already be on disk with no way back. Both
+  // that block only wraps the apply `try` (the for-each-entry loop plus the
+  // provenance write), not the precondition checks ahead of it. Both
   // cases are asserted BEFORE the loop ever runs: zero writes, zero removes.
   const trivialChangeSet: ChangeSet = {
     templateIdentity: 'my-template',
@@ -484,8 +484,9 @@ describe('upgradeChangeSetReviewApproval (F14 change-set engine flow)', () => {
   // element (e.g. `[null]`) reached `existingRecords.findIndex(record =>
   // record.templateIdentity === ...)` and threw a raw TypeError that escaped
   // `ApplyResult`'s `{ok:true}|{ok:false}` contract entirely — bypassing the
-  // restore-on-error path (which only wraps the for-each-entry loop) even
-  // though nothing had been written yet. Both cases must abort as
+  // restore-on-error path (which only wraps the apply `try`, not the
+  // precondition checks ahead of it) even though nothing had been written
+  // yet. Both cases must abort as
   // `{ok:false}`, before any write, with a message naming the file and which
   // element/field was invalid.
   it('(l) a provenance array element that is null aborts before any project file is written, without throwing', async () => {
@@ -567,5 +568,51 @@ describe('upgradeChangeSetReviewApproval (F14 change-set engine flow)', () => {
     expect(applyResult.message).toMatch(/index 0/);
     expect(writes.size).toBe(0);
     expect(removed.size).toBe(0);
+  });
+
+  // #506: `writeProvenance` used to run AFTER `inst-app-try`'s rollback
+  // boundary, so a filesystem failure there threw past `ApplyResult`'s
+  // `{ok:false}` contract having already written approved project files —
+  // a partially-upgraded repository with no way back. The provenance write
+  // now shares the same try/catch as the project-file loop
+  // (`inst-app-update-prov` nested inside `inst-app-try`), so a
+  // `writeProvenance` failure after a project file has already been
+  // mutated must still restore that file, restore the prior provenance
+  // bytes, and return a typed failure rather than throwing.
+  it('(o) a writeProvenance failure after a project file was already mutated restores that file and the prior provenance bytes, and returns a typed failure', async () => {
+    const provPath = `${PROJ_ROOT}/.frontx/provenance.json`;
+    const appPath = `${PROJ_ROOT}/src/App.tsx`;
+    const originalProvContent = JSON.stringify([BASE_PROVENANCE], null, 2);
+    const originalAppContent = 'v1 content';
+    const files = new Map<string, string>([
+      [provPath, originalProvContent],
+      [appPath, originalAppContent],
+    ]);
+
+    const applyResult = await applyChangeSet(trivialChangeSet, PROJ_ROOT, BASE_PROVENANCE, {
+      readProjectFile: async (p) => files.get(p) ?? null,
+      writeProjectFile: async (p, c) => { files.set(p, c); },
+      removeProjectFile: async (p) => { files.delete(p); },
+      // Mutates `files` BEFORE throwing — a real filesystem write can fail
+      // partway through, after already landing bytes on disk. If the fake
+      // only threw, the byte-for-byte assertion below would pass even
+      // without a genuine restore (the map would simply never have been
+      // touched), so this proves the restore path actually overwrites a
+      // corrupted-in-place provenance file back to the snapshot.
+      writeProvenance: async (p, c) => {
+        files.set(p, `${c}\npartial write`);
+        throw new Error('disk full');
+      },
+    });
+
+    expect(applyResult.ok).toBe(false);
+    if (applyResult.ok) return;
+    expect(applyResult.message).toMatch(/disk full/);
+    // The project-file mutation that happened before the provenance write
+    // failed is rolled back — not left half-applied.
+    expect(files.get(appPath)).toBe(originalAppContent);
+    // The provenance file is restored to its exact pre-upgrade bytes, not
+    // left at whatever partial/failed write state `writeProvenance` threw at.
+    expect(files.get(provPath)).toBe(originalProvContent);
   });
 });

--- a/packages/cli/src/upgrade/apply.ts
+++ b/packages/cli/src/upgrade/apply.ts
@@ -121,8 +121,8 @@ export async function applyChangeSet(
   // nothing has been written yet, so `{ok:false}` is returned directly, per
   // ApplyResult's contract, with the project untouched — never a thrown
   // error surfacing after entries have already been rewritten on disk with
-  // no way back (`inst-app-restore-on-error`'s snapshot only covers the
-  // for-each-entry loop below, not a failure ahead of it).
+  // no way back (`inst-app-restore-on-error`'s restore only covers the
+  // `try` block below, not a failure ahead of it).
   let existingRecords: ProvenanceRecord[];
   try {
     existingRecords = parseProvenanceRecordSet(provContent, provPath);
@@ -176,6 +176,29 @@ export async function applyChangeSet(
       // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-apply-entry
     }
     // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-for-each-entry
+
+    // @cpt-begin:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-update-prov
+    // Provenance is a SET — one record per applied template (ADR-0019) — never
+    // a single whole-repository record. `existingRecords`/`targetIndex` were
+    // validated above, before any file was written (see the precondition
+    // block for why validation stays outside this `try`). Only the record for
+    // the template this upgrade targets changes; every other applied
+    // template's record is re-serialized untouched (ADR-0021 Confirmation
+    // (d): "the other applied template and its provenance record are
+    // unaffected").
+    //
+    // Invariant: the `writeProvenance` FILESYSTEM WRITE is not pure — it can
+    // fail exactly like any project-file write can (issue #506) — so it MUST
+    // stay inside this `try`, on the same rollback boundary as
+    // `inst-app-for-each-entry`. A failure here lands in the `catch` below,
+    // which restores every snapshotted file — `provPath` included,
+    // snapshotted at the top of this function — so the prior provenance
+    // bytes come back exactly like any rolled-back project file.
+    const updatedRecords = existingRecords.map((record, index) =>
+      index === targetIndex ? { ...record, scaffoldedFromVersion: changeSet.targetVersion } : record,
+    );
+    await deps.writeProvenance(provPath, JSON.stringify(updatedRecords, null, 2));
+    // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-update-prov
   } catch (err) {
     // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-try
     // @cpt-begin:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-catch
@@ -198,21 +221,6 @@ export async function applyChangeSet(
     // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-return-failure
     // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-catch
   }
-
-  // @cpt-begin:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-update-prov
-  // Provenance is a SET — one record per applied template (ADR-0019) — never
-  // a single whole-repository record. `existingRecords`/`targetIndex` were
-  // already validated above, before any file was written, so this step is a
-  // pure substitution into an already-known-good array — it cannot itself
-  // throw. Only the record for the template this upgrade targets changes;
-  // every other applied template's record is re-serialized untouched
-  // (ADR-0021 Confirmation (d): "the other applied template and its
-  // provenance record are unaffected").
-  const updatedRecords = existingRecords.map((record, index) =>
-    index === targetIndex ? { ...record, scaffoldedFromVersion: changeSet.targetVersion } : record,
-  );
-  await deps.writeProvenance(provPath, JSON.stringify(updatedRecords, null, 2));
-  // @cpt-end:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-update-prov
 
   // @cpt-begin:cpt-frontx-algo-upgrade-changeset-apply:p1:inst-app-retain-snapshot
   // Snapshot is returned to the caller for rollback — retained until a new upgrade cycle


### PR DESCRIPTION
Fixes #506.

## Problem

`applyChangeSet` ran the final `deps.writeProvenance(...)` after the try/catch boundary that protects project-file mutations. A filesystem failure there threw past the promised `ApplyResult` failure path after approved project files were already changed, leaving the repository partially upgraded.

## Change

- **`packages/cli/src/upgrade/apply.ts`** — moved the provenance write (`inst-app-update-prov`) inside the existing `try` block. `.frontx/provenance.json` was already snapshotted at the top of the function, so the existing `catch` now restores it along with every mutated project file and returns typed `{ok: false}`. The success path (multi-record provenance array from #500, ADR-0021 semantics) is byte-identical apart from indentation.
- **`packages/cli/src/__tests__/upgrade.test.ts`** — regression test: applies a change set that mutates `src/App.tsx`, then fails `writeProvenance`; asserts the project file and provenance file are restored byte-for-byte and `applyChangeSet` returns `{ok: false}` instead of throwing. The test fails on `develop` and passes here.
- **`packages/cli/architecture/features/upgrade-changeset/FEATURE.md`** — `inst-app-update-prov` renumbered under `inst-app-try`; rollback contract wording, DoD, and acceptance criteria updated to cover the provenance-write failure. `cfs validate`: 0 errors, coverage 171/171.

## Verification

- Upgrade test files: all pass (incl. new regression test); full `packages/cli` suite: 412 passed, with only the pre-existing `@gears-frontx/test-support/path-guard` resolution failures identical on `develop`.
- `tsc --noEmit`: no new errors. `eslint` on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade operations now roll back all modified project files when provenance updates fail.
  * Previous provenance data is restored when an upgrade cannot be completed.
  * Upgrade failures now return a structured error instead of leaving partial changes or unexpectedly throwing.
  * Prevented partially applied upgrades when storage errors occur after files have been modified.

* **Tests**
  * Added coverage for failures occurring after project files have been modified, including restoration of provenance data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->