### PR TITLE
fix: green develop - lift fast-uri past the audited range and catch the uikit screens up with the 0.4 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5393,9 +5393,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "pg-protocol": "1.10.3",
     "picomatch": "4.0.4",
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "esbuild": "0.25.12",
     "js-yaml": "4.3.0",
     "vitest": "4.1.4",

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/components/ProfileDetailsCard.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/profile/components/ProfileDetailsCard.tsx
@@ -128,23 +128,39 @@ export const ProfileDetailsCard: React.FC<ProfileDetailsCardProps> = ({
        */
       <form onSubmit={handleSubmit} className={styles.form}>
         {/*
-          Field wires the label's `htmlFor`, the control's id and
-          `aria-describedby` itself — the ids these three fields used to carry
-          by hand would now compete with the ones it generates.
+          Field is layout only: it wires no ids and disables no control, so
+          each label points at its input's own id and each input carries its
+          own `disabled`. `data-disabled` on the Field is what dims the label
+          alongside the control the kit's CSS already dims.
         */}
-        <Field name="firstName" disabled={isSaving}>
-          <FieldLabel>{t('first_name_label')}</FieldLabel>
-          <Input value={formValues.firstName} onChange={handleFieldChange('firstName')} />
+        <Field data-disabled={isSaving || undefined}>
+          <FieldLabel htmlFor="profile-first-name">{t('first_name_label')}</FieldLabel>
+          <Input
+            id="profile-first-name"
+            disabled={isSaving}
+            value={formValues.firstName}
+            onChange={handleFieldChange('firstName')}
+          />
         </Field>
 
-        <Field name="lastName" disabled={isSaving}>
-          <FieldLabel>{t('last_name_label')}</FieldLabel>
-          <Input value={formValues.lastName} onChange={handleFieldChange('lastName')} />
+        <Field data-disabled={isSaving || undefined}>
+          <FieldLabel htmlFor="profile-last-name">{t('last_name_label')}</FieldLabel>
+          <Input
+            id="profile-last-name"
+            disabled={isSaving}
+            value={formValues.lastName}
+            onChange={handleFieldChange('lastName')}
+          />
         </Field>
 
-        <Field name="department" disabled={isSaving}>
-          <FieldLabel>{t('department_label')}</FieldLabel>
-          <Input value={formValues.department} onChange={handleFieldChange('department')} />
+        <Field data-disabled={isSaving || undefined}>
+          <FieldLabel htmlFor="profile-department">{t('department_label')}</FieldLabel>
+          <Input
+            id="profile-department"
+            disabled={isSaving}
+            value={formValues.department}
+            onChange={handleFieldChange('department')}
+          />
         </Field>
 
         {/*

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/DataDisplayElements.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/DataDisplayElements.tsx
@@ -120,27 +120,33 @@ export const DataDisplayElements: React.FC<DataDisplayElementsProps> = ({
         description={t('element.badge.description')}
       >
         {/*
-          The kit's badge variants are semantic states, not the visual weights
-          shadcn names — there is no `default`, `outline` or `secondary` here.
+          Badge's variants sit on one paint axis in two groups: the tones
+          below, and the upstream weights (`default`, `secondary`,
+          `destructive`, `outline`, `ghost`, `link`). `secondary` is the
+          tone row's neutral — the kit ships no separate `muted` name for it.
+          A tone paints, it does not announce, so every label spells its
+          state out in words.
         */}
         <div className={styles.row}>
           <Badge variant="success">Running</Badge>
           <Badge variant="warning">Degraded</Badge>
           <Badge variant="info">Queued</Badge>
           <Badge variant="danger">Failed</Badge>
-          <Badge variant="muted">Draft</Badge>
+          <Badge variant="accent">Beta</Badge>
+          <Badge variant="secondary">Draft</Badge>
         </div>
 
         {/*
-          The status dot is its own boolean prop, not a shape: `shape` picks
-          pill vs. plain, and either can carry the dot.
+          Upstream weights, and the one case that needs `render`: a badge that
+          is really a link. Hover feedback and the focus ring only apply once
+          an interactive element is actually underneath.
         */}
         <div className={styles.row}>
-          <Badge variant="success" dot>
-            Online
-          </Badge>
-          <Badge variant="muted" dot>
-            Offline
+          <Badge>default</Badge>
+          <Badge variant="outline">outline</Badge>
+          <Badge variant="destructive">destructive</Badge>
+          <Badge variant="outline" render={<a href="#badge" />}>
+            Pro plan
           </Badge>
         </div>
       </ElementDemo>

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/FormElements.tsx
@@ -54,6 +54,25 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
   const [region, setRegion] = useState('eu-central');
   const [plan, setPlan] = useState('free');
   const [notifications, setNotifications] = useState(true);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  /**
+   * Field derives no validation of its own, so the demo runs the check the
+   * browser already did: `<input type="email" required>` fills in `validity`
+   * either way, and this only picks which message the field shows. Read on
+   * blur rather than on every keystroke so a half-typed address is not
+   * flagged as malformed while it is still being typed.
+   */
+  const validateEmail = (event: React.FocusEvent<HTMLInputElement>) => {
+    const { validity } = event.currentTarget;
+    if (validity.valueMissing) {
+      setEmailError('Email is required.');
+    } else if (validity.typeMismatch) {
+      setEmailError('That does not look like an email.');
+    } else {
+      setEmailError(null);
+    }
+  };
 
   return (
     <section id="category-forms" className={styles.category}>
@@ -66,16 +85,31 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
       >
         <div className={styles.stack}>
           {/*
-            Field is the kit's composition for a labelled control: it wires the
-            label's `htmlFor`, the control's id and `aria-describedby` itself, so
-            nothing below sets them by hand.
+            Field is the kit's layout for a labelled control and nothing more:
+            it wires no ids and derives no validity, so `htmlFor`,
+            `aria-describedby` and the invalid state are all set by hand here.
+            The description stays in `aria-describedby` when the error joins it
+            — replacing it would drop the hint the moment it is most useful.
           */}
-          <Field name="email">
-            <FieldLabel>Email</FieldLabel>
-            <Input type="email" required placeholder="you@company.com" />
-            <FieldDescription>We only use it for the invoice.</FieldDescription>
-            <FieldError match="valueMissing">Email is required.</FieldError>
-            <FieldError match="typeMismatch">That does not look like an email.</FieldError>
+          <Field data-invalid={emailError ? true : undefined}>
+            <FieldLabel htmlFor="form-demo-email">Email</FieldLabel>
+            <Input
+              id="form-demo-email"
+              type="email"
+              required
+              placeholder="you@company.com"
+              aria-invalid={emailError ? true : undefined}
+              aria-describedby={
+                emailError
+                  ? 'form-demo-email-description form-demo-email-error'
+                  : 'form-demo-email-description'
+              }
+              onBlur={validateEmail}
+            />
+            <FieldDescription id="form-demo-email-description">
+              We only use it for the invoice.
+            </FieldDescription>
+            <FieldError id="form-demo-email-error">{emailError}</FieldError>
           </Field>
         </div>
       </ElementDemo>
@@ -133,8 +167,12 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
         description={t('element.select.description')}
       >
         <div className={styles.stack}>
-          <Field name="region">
-            <FieldLabel>Region</FieldLabel>
+          <Field>
+            {/*
+              SelectTrigger renders the button that carries the field's
+              accessible name, so the label points at the trigger's own id.
+            */}
+            <FieldLabel htmlFor="form-demo-region">Region</FieldLabel>
             {/*
               Select reports `null` when a selection is cleared, which this demo
               has no control for; the fallback keeps the trigger showing a region
@@ -145,7 +183,7 @@ export const FormElements: React.FC<FormElementsProps> = ({ t, portalContainer }
               value={region}
               onValueChange={(value) => setRegion(value ?? REGION_ITEMS[0].value)}
             >
-              <SelectTrigger>
+              <SelectTrigger id="form-demo-region">
                 <SelectValue placeholder="Pick a region" />
               </SelectTrigger>
               <SelectContent container={portalContainer}>

--- a/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/OverlayElements.tsx
+++ b/template-mfe/src-app/mfe_packages/demo-mfe/src/screens/uikit/components/OverlayElements.tsx
@@ -57,9 +57,10 @@ export const OverlayElements: React.FC<OverlayElementsProps> = ({ t, portalConta
                 <DialogTitle>New project</DialogTitle>
                 <DialogDescription>Projects group deployments and their settings.</DialogDescription>
               </DialogHeader>
-              <Field name="project">
-                <FieldLabel>Project name</FieldLabel>
-                <Input placeholder="acme-web" />
+              {/* Field wires no ids of its own, so the pair is joined by hand. */}
+              <Field>
+                <FieldLabel htmlFor="overlay-demo-project">Project name</FieldLabel>
+                <Input id="overlay-demo-project" placeholder="acme-web" />
               </Field>
               <DialogFooter>
                 <DialogClose render={<Button variant="outline" />}>


### PR DESCRIPTION
## Description

`develop` is red on two independent gates, and this PR clears both so the branch goes back to green.

The `validate` job's final step, `npm audit --audit-level=high --omit=dev`, fails against the current `develop` lockfile: the transitive `fast-uri` resolves to 3.1.5, which carries GHSA-5jgf-p345-68v8 plus three sibling advisories, all high severity. Nothing in the tree changed to cause this - the advisory was published on 2026-09-02, so an unchanged lockfile flipped from green to red. `develop`'s last CI run (2026-09-01) still shows the audit step passing; running the same command against `develop` today exits 1. Every branch inherits the red gate.

The second red gate is `Template Validate`'s "Validate shell + overlay composition" step, which type-checks demo-mfe's uikit screens against the published ui-kit 0.4. The screens still used props the 0.4 port removed: `Field`'s `name` and `disabled`, `FieldError`'s `match`, and `Badge`'s `dot` and `muted`.

## What changed

- The root `overrides` pin for `fast-uri` moves from `3.1.5` to `3.1.7`, the head of the 3.x line, with the single hoisted lockfile entry moving with it. No new override is introduced, no dependent manifest changes, and the remaining audit findings are moderate and sit below the gate's threshold.
- The four demo screens are migrated to the kit's actual 0.4 API, cherry-picked as-is from #598 (`05b72a3f`); that commit drops out of #598 on its next rebase.

## Verification

- `npm audit --audit-level=high --omit=dev` exits 0 (was exit 1 on `develop`); only 4 moderate findings remain
- `npm ci` exits 0 and is clean; the lock diff is minimal and the Linux-only optional `@emnapi/*` entries stay intact
- The previously failing "Validate shell + overlay composition" step was reproduced locally end to end - composition, build, type-check (demo-mfe passes), `arch:deps`, lint, `test:unit` - all green
- Full local run of `type-check:all`, `lint`, `test:unit`, `arch:*` and the policy gates all pass

All 10 CI checks are green on the current head.
