### PR TITLE
fix(deps): bump smol-toml to 1.8.0 to clear GHSA-7w5x-hrqm-74c2

### DIFF
--- a/.cf-studio/config/core.toml
+++ b/.cf-studio/config/core.toml
@@ -322,7 +322,7 @@ conf_version = "1.0.0"
 format = "CFS"
 path = "../packages/cyber-pilot-kit-frontx"
 install_mode = "register"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 tool_risk_fingerprint = "3bdcd30d3029ad80e74c76eb0b57d80ad617a51191eb9d9307b2921c65f5dc16"
 
 [kits.cyber-pilot-kit-frontx.source_provenance]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7578,7 +7578,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -9205,10 +9207,10 @@
     },
     "packages/cyber-pilot-kit-frontx": {
       "name": "@gears-frontx/cyber-pilot-kit-frontx",
-      "version": "0.3.0-alpha.3",
+      "version": "0.3.0-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "smol-toml": "^1.6.1"
+        "smol-toml": "^1.8.0"
       },
       "devDependencies": {
         "@gears-frontx/test-support": "0.1.0-alpha.0",

--- a/packages/cyber-pilot-kit-frontx/.cf-studio-kit.toml
+++ b/packages/cyber-pilot-kit-frontx/.cf-studio-kit.toml
@@ -12,7 +12,7 @@ manifest_version = "1.0"
 [[kits]]
 slug = "cyber-pilot-kit-frontx"
 name = "FrontX AI Tooling Kit"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 
 [[kits.resources]]
 id = "frontx_skill"

--- a/packages/cyber-pilot-kit-frontx/package.json
+++ b/packages/cyber-pilot-kit-frontx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gears-frontx/cyber-pilot-kit-frontx",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "description": "FrontX AI Tooling Kit — ecosystem-level AI capabilities for AI agents working in FrontX projects",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -47,6 +47,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.8.0"
   }
 }


### PR DESCRIPTION
## Why

GHSA-7w5x-hrqm-74c2 (published 2026-09-09) flags `smol-toml <=1.7.0`. The root lockfile pinned `smol-toml@1.6.1`, pulled in as a production dependency by `packages/cyber-pilot-kit-frontx`. This fails the "Audit dependencies for high severity vulnerabilities" step (`npm audit --audit-level=high --omit=dev`) on `develop` and on every open PR, since that step runs against the shared root lockfile regardless of branch.

## What

- Bump `packages/cyber-pilot-kit-frontx`'s `smol-toml` dependency to `^1.8.0` (patched at 1.7.1, latest is 1.8.0) and refresh `package-lock.json` accordingly (`smol-toml` entries only).
- Bump `@gears-frontx/cyber-pilot-kit-frontx` to `0.3.0-alpha.4` per this repo's version-bump-on-change policy, and update its version in `.cf-studio-kit.toml` and its registration entry in `.cf-studio/config/core.toml` to match (a self-validation test checks these stay in sync with `package.json`). No exact pins of this package exist elsewhere in the repo.

## Verification

- `npm audit --audit-level=high --omit=dev` — exit 0 (GHSA-7w5x-hrqm-74c2 cleared; 4 unrelated moderate advisories remain, none new)
- `npx vitest run` in `packages/cyber-pilot-kit-frontx` — 13 files / 240 tests passed
- `npm run lint` — passed
- `npm run type-check` — passed
- `npm run policy:version-bump-on-change` (base `origin/develop`) — passed
- `npm run policy:version-check` and `npm run policy:template-pin-drift` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Cyber Pilot Kit Frontend package to version 0.3.0-alpha.4.
  - Updated the TOML parsing runtime dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->